### PR TITLE
Improve activity map: responsive sizing, nav fix, expand toggle

### DIFF
--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -61,17 +61,58 @@
     color: #000000b0;
 }
 
-.leaflet-container {
-    height: min(600px, 60vh);
+#map-wrapper {
+    position: relative;
     width: min(900px, 100%);
     margin: 0 auto;
 }
 
+.leaflet-container {
+    height: min(600px, 60vh);
+    width: 100%;
+}
+
+#map-expand-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 500;
+    background: white;
+    border: 2px solid rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#map-wrapper.is-expanded {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 9000;
+    margin: 0;
+    background: #fff;
+}
+
+#map-wrapper.is-expanded .leaflet-container {
+    height: 100vh;
+    width: 100vw;
+}
+
 @media (min-width: 1400px) {
-    .leaflet-container {
-        height: min(750px, 70vh);
+    #map-wrapper {
         width: 100%;
         max-width: 1400px;
+    }
+    .leaflet-container {
+        height: min(750px, 70vh);
     }
 }
 

--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -39,15 +39,17 @@
 }
 
 #activity-map-container {
-    min-height:100vh; 
     background-color: rgba(255, 255, 255, 0.646);
     display: flex;
     justify-content: center;
     align-items: center;
+    padding: 3rem 1rem;
+    isolation: isolate; /* scope Leaflet z-indices so they don't bleed above the nav bar */
 }
 
 #activity-map-card {
     text-align: center;
+    width: 100%;
 }
 
 #activity-map-title {
@@ -60,7 +62,17 @@
 }
 
 .leaflet-container {
-	height: min(700px, 70vh);
-	width: min(900px, 100%);
+    height: min(600px, 60vh);
+    width: min(900px, 100%);
+    margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+    #activity-map-container {
+        padding: 1.5rem 0.5rem;
+    }
+    .leaflet-container {
+        height: 320px;
+    }
 }
 

--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -67,6 +67,14 @@
     margin: 0 auto;
 }
 
+@media (min-width: 1400px) {
+    .leaflet-container {
+        height: min(750px, 70vh);
+        width: 100%;
+        max-width: 1400px;
+    }
+}
+
 @media (max-width: 768px) {
     #activity-map-container {
         padding: 1.5rem 0.5rem;

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -20,12 +20,38 @@
   <div id="activity-map-card" class="mdx-hero md-typeset">
     <h1 id="activity-map-title">Activity Map</h1>
     <p id="activity-map-subtitle">Map of recent activities</p>
-    <div class="leaflet-container" id="map"></div>
+    <div id="map-wrapper">
+      <div class="leaflet-container" id="map"></div>
+      <button id="map-expand-btn" aria-label="Expand map">⛶</button>
+    </div>
   </div>
 </section>
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   const map = L.map('map', { scrollWheelZoom: false }).setView([-27.41, 134.77], 3);
+
+  const mapWrapper = document.getElementById('map-wrapper');
+  const mapSection = document.getElementById('activity-map-container');
+  const expandBtn = document.getElementById('map-expand-btn');
+
+  function setExpanded(expand) {
+    mapWrapper.classList.toggle('is-expanded', expand);
+    // Release the isolation stacking context so the fixed overlay clears the nav bar
+    mapSection.style.isolation = expand ? 'auto' : '';
+    expandBtn.textContent = expand ? '✕' : '⛶';
+    expandBtn.setAttribute('aria-label', expand ? 'Collapse map' : 'Expand map');
+    setTimeout(() => map.invalidateSize(), 50);
+  }
+
+  expandBtn.addEventListener('click', function() {
+    setExpanded(!mapWrapper.classList.contains('is-expanded'));
+  });
+
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && mapWrapper.classList.contains('is-expanded')) {
+      setExpanded(false);
+    }
+  });
   const tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -25,7 +25,7 @@
 </section>
 <script>
 document.addEventListener("DOMContentLoaded", function() {
-  const map = L.map('map').setView([-27.41, 134.77], 3);
+  const map = L.map('map', { scrollWheelZoom: false }).setView([-27.41, 134.77], 3);
   const tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'


### PR DESCRIPTION
## Summary

- **Nav bar overlap fixed** — `isolation: isolate` on the map section scopes Leaflet's internal z-indices (1000+) so they no longer bleed above the Material nav bar
- **Mobile** — removed `min-height: 100vh` that was trapping finger-scroll; map is 320px tall on screens ≤ 768px; `scrollWheelZoom: false` prevents accidental zoom on desktop
- **Widescreen** — media query at ≥ 1400px expands map to full container width (capped at 1400px) and `min(750px, 70vh)` tall
- **Expand toggle** — ⛶ button in the top-right corner expands the map to fill the full viewport; ✕ or Escape collapses it back; `map.invalidateSize()` called after each transition so tiles render correctly

## Test plan

- [ ] CI build passes
- [ ] Map does not overlap the nav bar when scrolling
- [ ] On mobile: map fits without trapping scroll; expand button works
- [ ] On desktop: expand fills viewport, Escape closes it
- [ ] On widescreen (≥ 1400px): map is wider and taller in default state


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_