### PR TITLE
Add active projects section to home page

### DIFF
--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -38,6 +38,69 @@
     color: #000000b0;
 }
 
+#projects-container {
+    background-color: rgba(245, 245, 255, 0.95);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 3rem 1rem;
+}
+
+#projects-card {
+    text-align: center;
+    width: 100%;
+    max-width: 1100px;
+}
+
+#projects-title {
+    color: #3949ab;
+    font-size: 46px;
+}
+
+#projects-subtitle {
+    color: #000000b0;
+}
+
+#projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    text-align: left;
+}
+
+.project-card {
+    background: white;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
+    padding: 1.5rem;
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    flex-direction: column;
+    transition: box-shadow 0.2s, transform 0.2s;
+}
+
+.project-card:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    transform: translateY(-2px);
+}
+
+.project-card h3 {
+    color: #3949ab;
+    margin-top: 0;
+}
+
+.project-card p {
+    flex: 1;
+}
+
+.project-card-contributors {
+    margin-top: 1rem;
+    font-size: 0.8em;
+    color: #888;
+}
+
 #activity-map-container {
     background-color: rgba(255, 255, 255, 0.646);
     display: flex;

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -15,6 +15,30 @@
       </div>
   </div>
 </section>
+<!-- Active Projects -->
+<section id="projects-container" class="mdx-container">
+  <div id="projects-card" class="mdx-hero md-typeset">
+    <h1 id="projects-title">Active Projects</h1>
+    <p id="projects-subtitle">What our members are building</p>
+    <div id="projects-grid">
+      {%- for file in pages %}
+        {%- if file.page and file.page.meta.status == 'active' %}
+        <a class="project-card" href="{{ file.page.url }}">
+          <h3>{{ file.page.title }}</h3>
+          {%- if file.page.meta.summary %}
+          <p>{{ file.page.meta.summary }}</p>
+          {%- endif %}
+          {%- if file.page.meta.contributors %}
+          <p class="project-card-contributors">
+            {%- for c in file.page.meta.contributors %}{{ c }}{% if not loop.last %}, {% endif %}{%- endfor %}
+          </p>
+          {%- endif %}
+        </a>
+        {%- endif %}
+      {%- endfor %}
+    </div>
+  </div>
+</section>
 <!-- Activity Map (The idea is we cover the last few years of activities) (And potentially the future?) -->
 <section id="activity-map-container" class="mdx-container">
   <div id="activity-map-card" class="mdx-hero md-typeset">

--- a/docs/projects/electiondates.org.md
+++ b/docs/projects/electiondates.org.md
@@ -1,5 +1,7 @@
 ---
 title: ElectionDates.org
+status: active
+summary: "A crowdsourced website to make it easy to find and share the next election date for any country."
 contributors:
   - BrianKhuu
   - Usmaan

--- a/docs/projects/wiki-content-creation-project.md
+++ b/docs/projects/wiki-content-creation-project.md
@@ -1,5 +1,7 @@
 ---
 title: Wiki Content Creation Project
+status: active
+summary: "Building short, factual articles on core democracy topics so the wiki is accessible to everyone."
 contributors:
   - Usmaan
   - Aya.elfadil


### PR DESCRIPTION
## Summary

Adds a new full-width "Active Projects" section to the home page, sitting between the hero and the activity map:

> **hero** (who we are) → **projects** (what we're building) → **map** (where we've been)

The section is **frontmatter-driven** — to feature a project, just add two fields to its `.md` file:

```yaml
status: active
summary: "One sentence describing the project."
```

No template changes needed when adding or retiring projects.

## What's included

- New `#projects-container` section in `home.html` — loops over all pages with `status: active`, renders a responsive card grid
- Card grid CSS with hover lift effect and indigo accent colour to distinguish it from the blue hero and red-orange map sections
- `electiondates.org.md` and `wiki-content-creation-project.md` updated with `status: active` and a `summary`

## Test plan

- [ ] CI build passes
- [ ] Home page shows the two existing projects as cards between the hero and map
- [ ] Cards link correctly to their project pages
- [ ] Grid reflows to a single column on mobile
- [ ] Adding `status: active` to any other page's frontmatter adds it to the grid automatically


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_