### PR TITLE
Projects index with status groupings and per-project metadata box

### DIFF
--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -12,6 +12,87 @@
 }
 
 /****************************************/
+/* Project status badges */
+
+.project-status-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.75em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+}
+
+.project-status-badge.status-active     { background: #e6f4ea; color: #2e7d32; }
+.project-status-badge.status-mothballed { background: #fff3e0; color: #e65100; }
+.project-status-badge.status-cancelled  { background: #f5f5f5; color: #757575; }
+
+/* Projects index page */
+
+.projects-index-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.project-index-card {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    text-decoration: none;
+    color: inherit;
+    transition: box-shadow 0.2s;
+}
+
+.project-index-card:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.project-index-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.project-index-card-title {
+    font-weight: 600;
+}
+
+.project-index-card p {
+    margin: 0;
+    font-size: 0.9em;
+    color: #555;
+}
+
+/* Individual project page metadata box */
+
+.project-meta-box {
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    background: rgba(0, 0, 0, 0.02);
+}
+
+.project-meta-box table {
+    margin: 0;
+}
+
+.project-meta-box th {
+    width: 7em;
+    font-weight: 600;
+    color: #555;
+    padding: 0.2rem 0.75rem 0.2rem 0;
+}
+
+/****************************************/
 
 #hero-container {
     min-height:100vh; 

--- a/docs/overrides/project.html
+++ b/docs/overrides/project.html
@@ -1,0 +1,30 @@
+{% extends "main.html" %}
+{% block content %}
+{%- if page.meta.status or page.meta.contributors %}
+<div class="project-meta-box md-typeset">
+  <table>
+    <tbody>
+      {%- if page.meta.status %}
+      <tr>
+        <th>Status</th>
+        <td><span class="project-status-badge status-{{ page.meta.status }}">{{ page.meta.status | capitalize }}</span></td>
+      </tr>
+      {%- endif %}
+      {%- if page.meta.contributors %}
+      <tr>
+        <th>Contributors</th>
+        <td>{{ page.meta.contributors | join(', ') }}</td>
+      </tr>
+      {%- endif %}
+      {%- if page.meta.website %}
+      <tr>
+        <th>Website</th>
+        <td><a href="{{ page.meta.website }}">{{ page.meta.website }}</a></td>
+      </tr>
+      {%- endif %}
+    </tbody>
+  </table>
+</div>
+{%- endif %}
+{{ super() }}
+{% endblock %}

--- a/docs/overrides/projects.html
+++ b/docs/overrides/projects.html
@@ -1,0 +1,40 @@
+{% extends "main.html" %}
+{% block content %}
+{{ super() }}
+<div class="md-typeset">
+{% set status_groups = [
+  ('active',     'Active'),
+  ('mothballed', 'Mothballed'),
+  ('cancelled',  'Cancelled')
+] %}
+{% for status_key, status_label in status_groups %}
+  {%- set ns = namespace(has_items=false) %}
+  {%- for file in pages %}
+    {%- if file.page and file.page.url and file.page.url.startswith('projects/') and file.page.url != page.url and file.page.meta.get('status') == status_key %}
+      {%- set ns.has_items = true %}
+    {%- endif %}
+  {%- endfor %}
+  {%- if ns.has_items %}
+  <h2>{{ status_label }}</h2>
+  <div class="projects-index-grid">
+    {%- for file in pages %}
+      {%- if file.page and file.page.url and file.page.url.startswith('projects/') and file.page.url != page.url and file.page.meta.get('status') == status_key %}
+      <a class="project-index-card" href="{{ file.page.url }}">
+        <div class="project-index-card-header">
+          <span class="project-index-card-title">{{ file.page.title }}</span>
+          <span class="project-status-badge status-{{ status_key }}">{{ status_label }}</span>
+        </div>
+        {%- if file.page.meta.get('summary') %}
+        <p>{{ file.page.meta.summary }}</p>
+        {%- endif %}
+        {%- if file.page.meta.get('contributors') %}
+        <p class="project-card-contributors">{{ file.page.meta.contributors | join(', ') }}</p>
+        {%- endif %}
+      </a>
+      {%- endif %}
+    {%- endfor %}
+  </div>
+  {%- endif %}
+{%- endfor %}
+</div>
+{% endblock %}

--- a/docs/projects/electiondates.org.md
+++ b/docs/projects/electiondates.org.md
@@ -1,5 +1,6 @@
 ---
 title: ElectionDates.org
+template: project.html
 status: mothballed
 summary: "A crowdsourced website to make it easy to find and share the next election date for any country. The project is currently mothballed."
 contributors:

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -1,7 +1,8 @@
+---
+title: Projects
+template: projects.html
+---
+
 # Projects
 
-Within Designing Open Democracy, members may work on various different democracy related projects.
-
-Some of the active projects are shown below in addition to how you can participate in it.
-
-If interested in any of these projects then join our telegram channel shown in our discussion page to learn how you can work on it.
+Members of Designing Open Democracy work on various democracy-related projects. Below is a full record of projects past and present — join our [Telegram channel](https://t.me/joinchat/HNk_UBX8A7jBPJPbAZU5Zg) if you'd like to get involved in any active ones.

--- a/docs/projects/wiki-content-creation-project.md
+++ b/docs/projects/wiki-content-creation-project.md
@@ -1,5 +1,6 @@
 ---
 title: Wiki Content Creation Project
+template: project.html
 status: active
 summary: "Building short, factual articles on core democracy topics so the wiki is accessible to everyone."
 contributors:


### PR DESCRIPTION
## Summary

- **Front page unchanged** — active projects section still shows `status: active` only
- **Projects index page** (`/projects/`) now auto-generates a grouped list (Active / Mothballed / Cancelled) from frontmatter — no manual maintenance needed, changing a project's status updates the page automatically
- **Individual project pages** get a small metadata box at the top showing status badge, contributors, and website
- **Status badges**: green for active, amber for mothballed, grey for cancelled

## How it works

Two new Jinja2 template overrides:
- `projects.html` — used by the projects index, loops over all pages under `projects/` grouped by status
- `project.html` — used by individual project pages, renders the metadata table from frontmatter

To change a project's status, just update `status:` in its frontmatter.

## Test plan

- [ ] CI build passes
- [ ] `/projects/` shows Wiki Content Creation Project under "Active" and ElectionDates.org under "Mothballed"
- [ ] Individual project pages show the metadata box with correct status badge colour
- [ ] Front page still only shows active projects


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_