### PR TITLE
Remove contributors from front page project cards

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -28,11 +28,6 @@
           {%- if file.page.meta.summary %}
           <p>{{ file.page.meta.summary }}</p>
           {%- endif %}
-          {%- if file.page.meta.contributors %}
-          <p class="project-card-contributors">
-            {%- for c in file.page.meta.contributors %}{{ c }}{% if not loop.last %}, {% endif %}{%- endfor %}
-          </p>
-          {%- endif %}
         </a>
         {%- endif %}
       {%- endfor %}


### PR DESCRIPTION
Front page project cards now show title and summary only. Contributors are still visible on individual project pages via the metadata box.

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_