### PR TITLE
Fix CI deploy and add CLAUDE.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,30 +28,24 @@ jobs:
       - name: Build docs
         run: mkdocs build
 
+      - name: Upload pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site/
+
   deploy:
     name: deploy
     needs: build
     if: github.ref == 'refs/heads/main'
     permissions:
-      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+env:
+  DISABLE_MKDOCS_2_WARNING: true
+
 jobs:
   build:
     name: build
@@ -29,9 +32,13 @@ jobs:
     name: deploy
     needs: build
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -41,7 +48,10 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# Claude Code Notes
+
+## Tech Stack
+
+This is a MkDocs + Material for MkDocs static site deployed to GitHub Pages.
+
+- Build: `mkdocs build` (or `make build`)
+- Local dev: `make serve`
+- Deploy: CI pushes to `gh-pages` branch via `mkdocs gh-deploy --force`
+- Python deps: `requirements.txt` (site build), `util/requirements.txt` (utility scripts only)
+
+## Known Watch Items
+
+### MkDocs ecosystem fragmentation (as of May 2026)
+
+The MkDocs ecosystem is in flux. The original maintainer went inactive and planned a v2 that would break all existing plugins and themes. This caused a community split:
+
+- **ProperDocs** (`pip install properdocs`) — continuation of MkDocs 1.x, drop-in replacement
+- **MaterialX** — continuation of mkdocs-material as a separate package
+
+Current status: we are still on `mkdocs + mkdocs-material` and it works fine. `DISABLE_MKDOCS_2_WARNING=true` is set in CI to suppress advertising injected by `mkdocs-rss-plugin` (which added `properdocs` as a hard dependency).
+
+**When to act:** If `mkdocs-material` stops releasing updates or moves to `materialx`, migrate by swapping package names in `requirements.txt` and replacing `mkdocs` commands with `properdocs`. It is designed to be a drop-in replacement.
+
+Reference: https://fpgmaas.com/blog/collapse-of-mkdocs/
+
+## Conventions
+
+### Project pages (`docs/projects/`)
+
+- Use `template: project.html` in frontmatter — renders a metadata box (status, contributors, website)
+- `status` values: `active` | `mothballed` | `cancelled`
+- `status: active` pages appear in the front page projects section automatically
+- All projects (any status) appear grouped on the `/projects/` index page
+
+### Organisation pages (`docs/organisations/`)
+
+- The section is framed as a **Democracy Landscape reference** — organisations we monitor, not formal affiliates
+- Use `type`, `status`, `country`, `website`, `summary` in frontmatter
+- `status` values: `active` | `inactive` | `deregistered`
+- For defunct orgs, point `website` to the Wayback Machine calendar URL: `https://web.archive.org/web/*/https://originalurl.com/`
+
+### Utility scripts (`util/`)
+
+- `createPost.py` — interactive CLI to create a new blog post with frontmatter
+- `frontmatter_updator.py` — uses OpenAI API to auto-fill frontmatter; requires `util/requirements.txt`


### PR DESCRIPTION
## Summary

- **Fix CI deploy**: Pages source is set to "GitHub Actions" in repo settings, so `mkdocs gh-deploy` (which pushes to gh-pages branch) was never being served. Switched to `upload-pages-artifact` + `deploy-pages` which is what the GitHub Actions source expects.
- **Suppress properdocs warning**: `DISABLE_MKDOCS_2_WARNING=true` set as a workflow env var. The warning is injected by `mkdocs-rss-plugin 1.19.0` which added `properdocs` as a hard dependency for advertising purposes.
- **CLAUDE.md**: Documents the MkDocs ecosystem fragmentation situation, when/how to migrate, and conventions for project/org pages so future sessions have context automatically.

## Test plan

- [ ] CI build passes
- [ ] Deploy job succeeds and site updates on merge
- [ ] No properdocs warning in build output


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_