### PR TITLE
Fix desktop navigation layout

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,4 +1,5 @@
 {% extends "main.html" %}
+{% block site_nav %}{% endblock %}
 {% block tabs %}
 {{ super() }}
 <section id="hero-container" class="mdx-container">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,15 +6,14 @@ theme:
   custom_dir: docs/overrides
   features:
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
-    - toc.integrate
     - navigation.top
     - search.suggest
     - search.highlight
     - content.tabs.link
     - content.code.annotation
     - content.code.copy
-    - header.autohide
   language: en
   palette:
     scheme: slate


### PR DESCRIPTION
## What was wrong

- `header.autohide` was causing the nav bar to slide in/out on scroll — the main source of the "slide in/slide out interface" feeling
- No `navigation.tabs.sticky` meant the tab bar also scrolled away
- `toc.integrate` merged the table of contents into the left sidebar, crowding it and pushing layout into drawer mode on mid-width screens

## Changes

- Remove `header.autohide` — nav bar is now always visible
- Add `navigation.tabs.sticky` — tab bar stays pinned while scrolling
- Remove `toc.integrate` — TOC returns to its own right column
- Hide sidebar on homepage (`{% block site_nav %}{% endblock %}` in `home.html`) — the full-screen hero/projects/map sections don't need it

## Test plan

- [ ] CI passes
- [ ] Desktop: nav bar stays visible while scrolling
- [ ] Desktop: sidebar visible on content pages (concepts, blog, orgs, etc.)
- [ ] Desktop: TOC appears on right side of content pages
- [ ] Homepage: no sidebar shown


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_