### PR TITLE
Add Victorian Democrats citizens' assembly post + Write in Stone project

### DIFF
--- a/docs/blog/posts/2026-05-24-vic-upper-house-citizens-assembly.md
+++ b/docs/blog/posts/2026-05-24-vic-upper-house-citizens-assembly.md
@@ -1,0 +1,28 @@
+---
+authors:
+  - Brian Khuu
+categories:
+  - Policy
+  - Resources
+date: 2026-05-24 00:00:00
+tags:
+  - Citizens Assembly
+  - Electoral Reform
+  - Victoria
+  - Australia
+  - Proportional Representation
+title: "Victorian Democrats propose a citizens' assembly to reform the Upper House"
+summary: "The AES 2025 found only 32% of Australians trust government — and 48% now support a citizens' assembly. A new Victorian Democrats policy takes that seriously."
+---
+
+The 2025 Australian Election Study found that only 32% of Australians trust government. When asked about reform options, the most popular was a **citizens' assembly** — a body of randomly selected citizens who deliberate on important policy issues. 48% of respondents supported the idea, with only 20% opposed.
+
+<!-- more -->
+
+The Victorian Democrats have put forward a policy that takes this seriously: use a citizens' assembly of 50–100 Victorians to decide how the state's Upper House should be reformed, before putting the outcome to a referendum.
+
+The Victorian parliament recently completed an inquiry into Upper House electoral reform. The most supported option among inquiry respondents was moving to statewide proportional representation (rather than the current eight regional seats), which would lower the election quota from 16.7% to around 2.4% — making it easier for minor parties and independents to win seats.
+
+The proposal is notable not just for what it advocates (PR), but for *how* it proposes to get there — using a citizens' assembly as the decision-making process itself.
+
+Full policy: [Make Victoria's Upper House the Citizens' House of Review](https://vic.democrats.org.au/manifesto/1sVFDKLAfCkso1djRdablw/make-victoria-s-upper-house-the-citizens-house-of-review)

--- a/docs/projects/write-in-stone.md
+++ b/docs/projects/write-in-stone.md
@@ -1,0 +1,29 @@
+---
+title: Write in Stone
+template: project.html
+status: active
+summary: "A Windows desktop app that creates a verifiable, auditable record of research and reporting — like a journalist's bodycam for their computer."
+contributors:
+  - Austin
+website: https://www.writeinstone.com
+---
+
+Write in Stone (Stone) is a Windows 10/11 desktop application built by DOD member Austin. It captures and preserves a verifiable record of research work — sources consulted, evidence gathered, editorial decisions made — so that the provenance of any piece of reporting or analysis can be traced and trusted.
+
+The core idea is that trust in published work should come from *demonstrated process*, not just reputation. Journalists and investigators who use Stone make a commitment to greater transparency, surfacing the research trail behind their conclusions.
+
+## Relevance to open democracy
+
+Trustworthy public information is a precondition for informed democratic participation. When research records are opaque, misinformation and manufactured doubt thrive. Tools that make the evidence behind reporting auditable address one of the more structural problems in the modern information environment.
+
+## Who it is for
+
+- Journalists
+- Academics
+- Open source investigators (OSINT)
+- Computer programmers documenting technical decisions
+
+## Links
+
+- Website: [writeinstone.com](https://www.writeinstone.com)
+- Austin on Instagram: [@daym0on_music](https://www.instagram.com/daym0on_music/)


### PR DESCRIPTION
## Summary

- **Blog post** — Short link-post on the Victorian Democrats proposal to use a citizens' assembly to decide Upper House electoral reform, anchored by the AES 2025 finding that 48% of Australians now support citizens' assemblies.
- **Write in Stone project page** — Project page for Austin's (DOD member) Windows research-provenance app. Framed as an information integrity tool supporting democratic discourse rather than a direct reform project.

## Test plan

- [ ] Blog post dated 2026-05-24 appears in blog index
- [ ] Write in Stone appears in Active Projects on home page and in Projects index
- [ ] Project page shows Austin as contributor and links to writeinstone.com

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_