### PR TITLE
Democracy Landscape expansion + member orientation improvements

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,59 +1,25 @@
 ---
-title: Designing Open Democracy
+title: About
 contributors:
   - Charlie
 ---
 
-## About Designing Open Democracy
+Designing Open Democracy is an Australian-operated forum of process engineers, social architects, and philosophers exploring how technology, engineering, and the design of social systems can be applied to democracy at every level of society.
 
-[Designing Open Democracy](https://www.designingopendemocracy.com) is an
-Australian operated forum of process engineers, social architects and
-philosophers aiming to explore the ways that technology, engineering and
-design of social systems can be applied to every levels of society.
+We are **nonpartisan and agnostic** to any particular democratic approach. Our aim is to foster tighter consensus and collaboration between political parties, organisations, and individuals working toward a stronger, healthier democracy — without presuming any one system to be superior.
 
-We are nonpartisan and also agnostic to any particular democratic
-innovative approach, aiming to help foster tighter consensus and
-collaboration between all political parties and organisation towards a
-stronger and healthier democracy.
+→ *To get involved, see the [Community](community/community.md) page.*
 
-Designing Open Democracy will not presume any form of democratic system
-to be superior, but is a forum for discussion and practical planning on
-how such system may be implemented. In addition, this meetup will not be
-exclusive to any political party, but be a forum for members of various
-parties, groups and individuals to come together to trade ideas related
-to open democracy and evaluate their strengths and weaknesses.
+## Podcast
 
-### Podcast
+In-depth discussions on opportunities for reforming democratic institutions — from local organisations to national governments — through technology and other practices.
 
-In our podcast you will find detailed discussions in potential
-opportunities for reforming of existing democratic institutions; from
-local organisations to national governments around the world through
-technology or other practices. Our aim is to improve democracy: we think
-this can best be done by providing a forum for discussing democracy
-proposals, ideas, and to foster collaboration between people who would
-like to participate in democracy reform.
+Subscribe in your podcast app or find us on:
 
-You can subscribe to the podcast in your podcast app of choice, or on
-[Anchor.fm](https://anchor.fm/designingopendemocracy),
-[Spotify](https://open.spotify.com/show/4aOBVMKFEfgf03P6mNNZdw) or
-[Apple
-Podcasts](https://podcasts.apple.com/au/podcast/designing-open-democracy/id1492656241).
+- [Apple Podcasts](https://podcasts.apple.com/au/podcast/designing-open-democracy/id1492656241)
+- [Spotify](https://open.spotify.com/show/4aOBVMKFEfgf03P6mNNZdw)
+- [Anchor.fm](https://anchor.fm/designingopendemocracy)
 
-### Youtube Channel
+## YouTube
 
-We have a youtube channel where we post any videos recordings of meetings and events [Click here to browse our video list at YouTube](https://www.youtube.com/channel/UCqIo0VC_zHyPjzNKIafGJpg/featured)
-
-
-### Join the Discussion
-
-#### Meetup
-
-Check out our [Meetup page](https://www.designingopendemocracy.com) for
-events taking place online and in person in Melbourne, Australia.
-
-#### Telegram
-
-If you have the messaging app Telegram you can join our instant
-messaging chatroom. Click
-[here](https://t.me/joinchat/HNk_UBX8A7jBPJPbAZU5Zg) for an invite to
-our Telegram channel.
+Recorded meetups, talks, and events: [Designing Open Democracy on YouTube](https://www.youtube.com/channel/UCqIo0VC_zHyPjzNKIafGJpg/featured)

--- a/docs/community/community.md
+++ b/docs/community/community.md
@@ -1,1 +1,41 @@
-This will contain various information on events and ways to contribute and follow activities within this group
+---
+title: Community
+---
+
+Designing Open Democracy is a community of process engineers, social architects, technologists, and engaged citizens working on how democracy can be better designed. We are based in Melbourne but operate globally online.
+
+We are nonpartisan and agnostic to any particular democratic approach — the goal is to understand, build, and improve democratic systems, not to advocate for any party or ideology.
+
+## Join the conversation
+
+| Channel | What it's for |
+|---|---|
+| [Telegram](https://t.me/joinchat/HNk_UBX8A7jBPJPbAZU5Zg) | Day-to-day discussion, announcements, coordination |
+| [Meetup](https://www.meetup.com/DesigningOpenDemocracy/) | Melbourne in-person events |
+| [Humanitix](https://events.humanitix.com/host/designing-open-democracy) | Melbourne in-person events (ticketed) |
+| [YouTube](https://www.youtube.com/channel/UCqIo0VC_zHyPjzNKIafGJpg/featured) | Recorded meetups and talks |
+| [Podcast](https://podcasts.apple.com/au/podcast/designing-open-democracy/id1492656241) | Audio discussions on democracy reform |
+
+## Active projects
+
+These are things members are currently building. If one interests you, reach out via Telegram or contact the contributor listed on the project page.
+
+### [Civics Ecosystem Toolkit](../projects/civics-ecosystem-toolkit.md)
+*Brian Khuu* — A practical reference for building participatory civic structures in Australia: cooperative governance models, the Civics Ecosystem Cooperative, and the Party Members Fund concept. v1.2 published May 2026. Feedback and collaboration welcome.
+
+### [Write in Stone](../projects/write-in-stone.md)
+*Austin* — A Windows desktop app that creates a verifiable research record for journalists and investigators. If you work in journalism, OSINT, or research and want to trial it, get in touch with Austin.
+
+### [Wiki Content Creation](../projects/wiki-content-creation-project.md)
+*Usmaan, Aya* — Writing short, accessible articles on core democracy topics for this wiki. If you want to contribute an article, [open a pull request](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io) or ask in Telegram for guidance on what's needed.
+
+## Contribute to this wiki
+
+The wiki is a [public GitHub repository](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io). Anyone can contribute:
+
+- **Edit or add a page** — fork the repo, make changes in Markdown, open a pull request
+- **Add a blog post** — document a meetup, event, or piece of relevant news
+- **Add an organisation** — if you know of a democracy-related org worth tracking, add it to the [Democracy Landscape](../organisations/organisations.md)
+- **Flag an issue** — open a GitHub issue if something is wrong or missing
+
+If you're not comfortable with Git, post in Telegram and someone can help or do it for you.

--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -1,6 +1,41 @@
 ---
-summary: This page contains various concepts you can learn about.
-title: Various Concepts to Learn About
+summary: A reference index of democracy-related concepts.
+title: Concepts
 ---
 
-This contains various concepts you can learn about
+A reference collection of concepts relevant to open democracy — from foundational ideas to specific mechanisms and organisational forms.
+
+## Core democracy concepts
+
+| Article | Summary |
+|---|---|
+| [What is Democracy?](what-is-democracy.md) | An overview of democracy as a concept and system |
+| [Democracy](democracy.md) | Definition, types, and principles |
+| [Direct Democracy](direct-democracy.md) | Citizens vote directly on laws and policies |
+| [Representative Democracy](representative-democracy.md) | Citizens elect representatives to decide on their behalf |
+| [Liberal Democracy](liberal-democracy.md) | Representative democracy with protected civil liberties |
+| [Constitutional Democracy](constitutional-democracy.md) | Democracy governed by a constitution limiting state power |
+
+## Democratic mechanisms
+
+| Article | Summary |
+|---|---|
+| [Citizens' Assembly](citizens-assembly.md) | Randomly selected citizens deliberate on policy questions |
+| [Sortition](sortition.md) | Selection of officials or jurors by random lot |
+| [Mixed-Member Proportional Representation](mixed-member-proportional-representation.md) | Electoral system combining constituency seats with proportional top-up seats |
+| [End-to-End Verifiable Voting System](end-to-end-verifiable-voting-system.md) | Voting systems where voters can verify their vote was counted correctly |
+| [E-Government](e-government.md) | Digital delivery of government services and participation |
+| [Organisations of World Citizens](organizations-of-world-citizens.md) | Global civic organisations and world citizenship concepts |
+
+## Workplace and economic democracy
+
+| Article | Summary |
+|---|---|
+| [Workplace Democracy](workplace-democracy.md) | Democratic decision-making structures within organisations |
+| [Worker Cooperatives](worker-cooperatives.md) | Businesses owned and governed by their workers |
+| [Community Business](community-business.md) | Enterprises owned and run by local communities |
+| [Cooperative](cooperative.md) | Member-owned organisations governed on a one-member-one-vote basis |
+| [Decentralized Autonomous Organization](decentralized-autonomous-organization.md) | Blockchain-based organisations governed by smart contracts |
+| [Employee Ownership Trusts](employee-ownership-trusts.md) | Trust structures enabling employee ownership of businesses |
+| [Employee Stock Ownership Plans](employee-stock-ownership-plans.md) | Plans giving employees ownership stakes in their employer |
+| [Equity Compensation Plans](equity-compensation-plans.md) | Structures for sharing company equity with employees |

--- a/docs/organisations/accountability-round-table.md
+++ b/docs/organisations/accountability-round-table.md
@@ -1,0 +1,16 @@
+---
+title: Accountability Round Table
+type: advocacy
+status: active
+country: AU
+website: http://accountabilityrt.org
+summary: "A non-partisan Australian group of citizens — academics, lawyers, politicians, journalists — working to improve standards of accountability, transparency, and democratic integrity in Australian governments."
+---
+
+The Accountability Round Table is a non-partisan coalition of professionals with backgrounds across academia, law, politics, and journalism. Its focus is on the structural conditions that allow democratic accountability to function: transparency laws, integrity commissions, ministerial conduct standards, and parliamentary oversight.
+
+The group makes submissions to public inquiries and publishes analysis on accountability-related reform. It grew out of concerns in the mid-2000s about erosion of standards in federal and state governance.
+
+## Links
+
+- Website: [accountabilityrt.org](http://accountabilityrt.org)

--- a/docs/organisations/australian-democrats.md
+++ b/docs/organisations/australian-democrats.md
@@ -1,0 +1,29 @@
+---
+title: Australian Democrats
+type: party
+status: active
+country: AU
+website: https://democrats.org.au
+summary: "A re-established Australian centrist political party with a strong focus on democratic reform, electoral integrity, and evidence-based policy — including explicit support for citizens' assemblies and proportional representation."
+---
+
+The Australian Democrats were originally founded in 1977 by Don Chipp with the stated aim to "keep the bastards honest" — a positioning as a principled centrist force holding the major parties accountable. The party held the balance of power in the Senate for many years before collapsing around 2008. It has since been re-established and is rebuilding a presence at state and federal levels.
+
+## Relevance to democracy reform
+
+The Democrats are notable in the current landscape for making democratic reform a substantive part of their platform rather than a peripheral concern. Their Victorian branch in particular has published detailed policy positions on:
+
+- **Citizens' assemblies** — supporting the use of a randomly selected citizens' assembly to decide how Victoria's Upper House electoral system should be reformed before putting the outcome to a referendum
+- **Proportional representation** — advocating for statewide PR for the Victorian Legislative Council, which would lower the election quota from 16.7% to ~2.4% and enable more diverse representation
+- **Evidence-based framing** — their policy positions cite the 2025 Australian Election Study (48% support for citizens' assemblies, 32% trust in government) and the Victorian parliamentary inquiry findings
+
+See the [blog post on the Victorian Upper House inquiry](../../blog/2026/05/24/victoria-s-upper-house-inquiry-the-case-for-a-citizens-assembly/) for context on the specific proposal.
+
+## Position and caveats
+
+The Democrats are a political party with a full platform across many issues. We track them here because their democracy reform positions are substantive and evidence-grounded — not because DOD endorses the party or its broader platform.
+
+## Links
+
+- Website: [democrats.org.au](https://democrats.org.au)
+- Victorian branch: [vic.democrats.org.au](https://vic.democrats.org.au)

--- a/docs/organisations/citizens-parliament-uk.md
+++ b/docs/organisations/citizens-parliament-uk.md
@@ -1,0 +1,16 @@
+---
+title: Citizens Parliament (UK)
+type: advocacy
+status: active
+country: UK
+website: https://www.citizensparliament.uk
+summary: "A UK campaign to replace the House of Lords with a randomly selected citizens' chamber — a permanent sortition-based upper house."
+---
+
+Citizens Parliament is a UK advocacy organisation with a specific and concrete goal: abolish the appointed House of Lords and replace it with a representative chamber selected by sortition — a random sample of everyday people, similar to a jury, serving as a permanent upper house of review.
+
+The proposal is notable for its institutional specificity. Rather than calling for a citizens' assembly to advise government (a common ask), Citizens Parliament argues for sortition as a permanent, structural feature of the constitution — replacing patronage and party appointment entirely.
+
+## Links
+
+- Website: [citizensparliament.uk](https://www.citizensparliament.uk)

--- a/docs/organisations/democracy-next.md
+++ b/docs/organisations/democracy-next.md
@@ -1,0 +1,18 @@
+---
+title: DemocracyNext
+type: research
+status: active
+country: EU
+website: https://www.demnext.org
+summary: "An international research institute focused on the theory and practice of sortition-based democracy — replacing elections with randomly selected assemblies as the primary decision-making mechanism."
+---
+
+DemocracyNext (demnext.org) is a research institute that takes a more radical position than most deliberative democracy organisations: it argues not just that citizens' assemblies are a useful complement to elected government, but that sortition should *replace* elections as the central mechanism of democratic governance.
+
+The institute publishes research, convenes practitioners and theorists, and develops the intellectual case for sortition-based democracy — drawing on ancient Athenian practice, modern complexity theory, and the accumulated evidence from contemporary citizens' assemblies. It engages seriously with both the theory (why sortition would be more legitimate and effective than elections) and the design questions (how you actually build stable institutions around random selection).
+
+For anyone thinking seriously about structural democratic alternatives rather than just incremental reform, DemocracyNext is a key reference.
+
+## Links
+
+- Website: [demnext.org](https://www.demnext.org)

--- a/docs/organisations/diem25.md
+++ b/docs/organisations/diem25.md
@@ -1,0 +1,24 @@
+---
+title: DiEM25
+type: political_movement
+status: active
+country: EU
+website: https://diem25.org
+summary: "A pan-European political movement founded by Yanis Varoufakis in 2016, calling for radical democratisation of EU institutions through transparency, a transnational constitutional assembly, and coordinated progressive politics across member states."
+---
+
+DiEM25 (Democracy in Europe Movement 2025) was founded by economist and former Greek Finance Minister Yanis Varoufakis in 2016, with the stated goal of democratising the European Union before it disintegrated — the "2025" being an original deadline, since passed. The movement has since evolved into a sustained transnational political organisation with chapters across Europe and affiliated national parties (MERA25 in Greece, and others).
+
+## Why it's notable for democracy watchers
+
+DiEM25 is one of the few serious attempts to build a *transnational* democratic movement that addresses the legitimacy problem of supranational institutions. Most democracy reform work operates within national borders; DiEM25 grapples directly with the harder question: how do you democratise institutions like the European Central Bank, the Eurogroup, or the IMF that are structurally insulated from electoral accountability?
+
+Their proposals include radical transparency for EU institutions, a pan-European constituent assembly, and coordinated cross-border political action — acknowledging that national-level democratic reform is insufficient when key decisions are made at a level that no national electorate can reach.
+
+## Position and caveats
+
+DiEM25 has explicit left-progressive political positions — anti-austerity, pro-redistribution, sceptical of establishment liberalism. It is a political movement with a platform, not a nonpartisan research organisation. We monitor it here because the structural questions it raises about transnational democratic legitimacy are genuinely important regardless of one's views on its specific policy positions.
+
+## Links
+
+- Website: [diem25.org](https://diem25.org)

--- a/docs/organisations/g1000.md
+++ b/docs/organisations/g1000.md
@@ -1,0 +1,18 @@
+---
+title: G1000
+type: research
+status: active
+country: BE
+website: https://www.g1000.org
+summary: "A Belgian civic innovation initiative that pioneered large-scale citizens' assemblies, bringing together randomly selected citizens to deliberate on complex public issues."
+---
+
+G1000 emerged from a 2011 experiment in Belgium: assembling 1,000 randomly selected citizens to deliberate on major policy questions at a time when Belgian politics was in prolonged deadlock (the country had gone without a federal government for over a year). The experiment demonstrated that ordinary citizens, given structured time and balanced information, could reach substantive and considered conclusions on hard political questions.
+
+The original G1000 has since become a model and a reference point for citizens' assembly design internationally. The Belgian experience — particularly the contrast between what the citizens produced and what the professional political class couldn't agree on — became one of the most cited early examples in the deliberative democracy literature.
+
+The organisation continues to work on participatory processes and to document and share what was learned from the original experiment.
+
+## Links
+
+- Website: [g1000.org](https://www.g1000.org)

--- a/docs/organisations/healthy-democracy.md
+++ b/docs/organisations/healthy-democracy.md
@@ -1,0 +1,18 @@
+---
+title: Healthy Democracy
+type: practice
+status: active
+country: US
+website: https://healthydemocracy.org
+summary: "A US non-profit that designs and runs Citizens' Initiative Reviews — structured deliberative processes where randomly selected citizens evaluate ballot measures and publish findings for the wider electorate."
+---
+
+Healthy Democracy developed and institutionalised the **Citizens' Initiative Review** (CIR) — a process in which a randomly selected, representative panel of citizens spends several days intensively studying a ballot measure: hearing from proponents and opponents, questioning experts, and deliberating together. The panel's findings — a balanced statement of key arguments and evidence — are then published in the official voter's guide sent to all voters before the election.
+
+The CIR has been used in Oregon since 2011 and has since been piloted in other US states. It addresses a specific problem: direct democracy (ballot initiatives) gives citizens power to make law, but most voters have neither the time nor the information to evaluate complex measures carefully. The CIR creates a small group that *does* do that work, and makes their findings available to everyone.
+
+This is a practically important design: it shows how deliberative democracy methods can be integrated into existing electoral infrastructure rather than requiring wholesale institutional redesign.
+
+## Links
+
+- Website: [healthydemocracy.org](https://healthydemocracy.org)

--- a/docs/organisations/involve.md
+++ b/docs/organisations/involve.md
@@ -1,0 +1,18 @@
+---
+title: Involve
+type: research
+status: active
+country: UK
+website: https://www.involve.org.uk
+summary: "A UK charity that develops and promotes public participation and deliberative democracy, advising governments on how to design and run genuine engagement processes."
+---
+
+Involve is a UK charity at the intersection of research and practice in public participation. They work with governments, public institutions, and communities to design participation processes that actually influence decisions — as opposed to the tokenistic consultation that often passes for engagement.
+
+Their work spans deliberative mini-publics (citizens' assemblies, juries), participatory budgeting, digital participation tools, and the policy frameworks needed to make participation systemic rather than ad hoc. They publish guides, case studies, and critical analysis that are useful both for practitioners running processes and for advocates making the case for better participation.
+
+Involve occupies a thoughtful position in the field: supportive of participatory innovation but rigorous about the conditions under which it works and the ways it can be co-opted or superficialised.
+
+## Links
+
+- Website: [involve.org.uk](https://www.involve.org.uk)

--- a/docs/organisations/newdemocracy.md
+++ b/docs/organisations/newdemocracy.md
@@ -1,0 +1,20 @@
+---
+title: newDemocracy Foundation
+type: research
+status: active
+country: AU
+website: https://www.newdemocracy.com.au
+summary: "An independent, non-partisan Australian research and development organisation that designs and runs real-world deliberative democracy trials using randomly selected citizens."
+---
+
+newDemocracy is one of Australia's most active organisations in the deliberative democracy space. It conducts real-world trials using random selection and deliberation — the jury model — to show that citizens, given good information and time to deliberate, can reach considered decisions on complex public issues.
+
+The foundation is non-partisan and works across government, community, and institutional settings. It publishes research on what works, what doesn't, and why — with the explicit goal of making deliberative methods a normal part of democratic governance rather than an experimental curiosity.
+
+## Approach
+
+newDemocracy's core argument is that the adversarial, partisan nature of representative democracy produces poor decisions on long-term or complex issues, and that randomly selected citizens' assemblies and juries consistently outperform what elected bodies produce when given the same brief. Their work is empirical — they run trials, document outcomes, and publish findings.
+
+## Links
+
+- Website: [newdemocracy.com.au](https://www.newdemocracy.com.au)

--- a/docs/organisations/newvote.md
+++ b/docs/organisations/newvote.md
@@ -1,0 +1,20 @@
+---
+title: NewVote
+type: platform
+status: active
+country: AU
+website: https://newvote.org
+summary: "An Australian civic technology institute combining direct, deliberative, and representative democracy — empowering people on specific issues and surfacing the informed 'will of the people' to elected governments."
+---
+
+NewVote is built on a simple philosophy: the world is better when everyone is empowered. The institute uses technology to operate across three democratic modes simultaneously:
+
+- **Direct democracy** — empowering citizens to engage directly on specific issues rather than waiting for elections
+- **Deliberative democracy** — uncovering the *informed* will of the people, not just raw opinion
+- **Representative democracy** — presenting those informed perspectives to elected governments as a structured input
+
+Rather than replacing existing democratic institutions, NewVote positions itself as a nudge — a layer of structured civic engagement that connects ordinary people to the decisions that affect them, and makes those preferences visible to the people making the decisions.
+
+## Links
+
+- Website: [newvote.org](https://newvote.org)

--- a/docs/organisations/open-australia-foundation.md
+++ b/docs/organisations/open-australia-foundation.md
@@ -1,0 +1,21 @@
+---
+title: OpenAustralia Foundation
+type: civic_tech
+status: active
+country: AU
+website: https://www.openaustraliafoundation.org.au
+summary: "An Australian civic technology charity building tools that help citizens understand and engage with their parliament and government."
+---
+
+The OpenAustralia Foundation is a non-partisan charity whose work centres on making Australian parliamentary and government information accessible and usable. They build and maintain several well-known tools:
+
+- **[They Vote For You](https://theyvoteforyou.org.au)** — tracks how every MP and Senator votes on legislation
+- **[OpenAustralia](https://www.openaustralia.org.au)** — makes parliamentary debates searchable and followable
+- **[Right To Know](https://www.righttoknow.org.au)** — a platform for making and tracking Freedom of Information requests
+- **[Planning Alerts](https://www.planningalerts.org.au)** — notifies citizens of development applications near them
+
+The foundation's model is to take government data that is technically public but practically inaccessible and present it in a form ordinary people can actually use. This kind of infrastructure work is foundational to an informed democratic public.
+
+## Links
+
+- Website: [openaustraliafoundation.org.au](https://www.openaustraliafoundation.org.au)

--- a/docs/organisations/organisations.md
+++ b/docs/organisations/organisations.md
@@ -2,12 +2,56 @@
 title: Democracy Landscape
 ---
 
-# Democracy Landscape
+A reference directory of organisations active in the democracy, civic technology, and democratic reform space. Maintained by DOD members as a monitoring resource — to keep track of what different groups are doing and how the broader landscape is evolving.
 
-This section is a reference list of organisations active in the democracy and civic technology space. It is maintained by Designing Open Democracy members as a monitoring resource — to keep track of what different groups are doing and how the broader landscape is evolving.
+These are not affiliated or partner organisations. Individuals from some of these groups participate in our discussions, but there is no formal association. Entries aim to be neutral and factual.
 
-These are not affiliated or partner organisations. Individuals from some of these groups participate in our discussions, but there is no formal association.
+---
 
-Entries aim to be neutral and factual. If you notice outdated information or missing organisations worth tracking, contributions are welcome via pull request.
+## Australia
 
-![Democracy organisations being monitored](orgswemonitor.png)
+| Organisation | Type | Status |
+|---|---|---|
+| [Accountability Round Table](accountability-round-table.md) | Advocacy | Active |
+| [Australian Democrats](australian-democrats.md) | Party | Active |
+| [DigiPol](digipol.md) | Platform | Inactive |
+| [Flux Party](flux-party.md) | Party | Deregistered |
+| [MiVote](mivote.md) | Platform | Deregistered |
+| [newDemocracy Foundation](newdemocracy.md) | Research | Active |
+| [NewVote](newvote.md) | Platform | Active |
+| [OpenAustralia Foundation](open-australia-foundation.md) | Civic tech | Active |
+| [Pirate Party Australia](pirate-party-australia.md) | Party | Active |
+| [Susan McKinnon Foundation](susan-mckinnon-foundation.md) | Philanthropy | Active |
+
+## United Kingdom
+
+| Organisation | Type | Status |
+|---|---|---|
+| [Citizens Parliament](citizens-parliament-uk.md) | Advocacy | Active |
+| [Involve](involve.md) | Research | Active |
+| [Sortition Foundation](sortition-foundation.md) | Advocacy | Active |
+
+## Europe
+
+| Organisation | Country | Type | Status |
+|---|---|---|---|
+| [DemocracyNext](democracy-next.md) | EU | Research | Active |
+| [DiEM25](diem25.md) | EU | Political movement | Active |
+| [G1000](g1000.md) | Belgium | Research | Active |
+
+## United States
+
+| Organisation | Type | Status |
+|---|---|---|
+| [Healthy Democracy](healthy-democracy.md) | Practice | Active |
+| [PeopleCount](peoplecount.md) | Platform | Inactive |
+
+## Global
+
+| Organisation | Type | Status |
+|---|---|---|
+| [Participedia](participedia.md) | Research | Active |
+
+---
+
+*To add an organisation, [open a pull request](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io) or raise it in the [Telegram channel](https://t.me/joinchat/HNk_UBX8A7jBPJPbAZU5Zg).*

--- a/docs/organisations/participedia.md
+++ b/docs/organisations/participedia.md
@@ -1,0 +1,18 @@
+---
+title: Participedia
+type: research
+status: active
+country: CA
+website: https://participedia.net
+summary: "A global open-access database and research platform cataloguing thousands of participatory democracy cases, methods, and organisations from around the world."
+---
+
+Participedia is a collaborative academic platform hosted by the University of British Columbia and Harvard University. It functions as a living encyclopaedia of participatory democracy — cataloguing case studies, methods, and organisations from across the world with structured, comparable data.
+
+For anyone researching what democratic innovations have actually been tried, where, and with what results, Participedia is one of the most comprehensive starting points available. The database covers citizens' assemblies, participatory budgeting, deliberative polls, community consultations, digital democracy experiments, and much more — with enough detail to understand both design and outcome.
+
+The platform is open-access and contributions are welcome, making it a useful place to document new cases as well as research existing ones.
+
+## Links
+
+- Website: [participedia.net](https://participedia.net)

--- a/docs/organisations/pirate-party-australia.md
+++ b/docs/organisations/pirate-party-australia.md
@@ -1,0 +1,18 @@
+---
+title: Pirate Party Australia
+type: party
+status: active
+country: AU
+website: https://pirateparty.org.au
+summary: "An Australian political party focused on digital rights, civil liberties, and democratic reform, including initiating the Electoral Royal Commission campaign to investigate Australian voting reform."
+---
+
+Pirate Party Australia is the Australian branch of the international Pirate Party movement, which originated in Sweden in 2006 around issues of copyright reform and internet freedom. The Australian chapter has broadened its platform to include democratic reform, government transparency, and civil liberties.
+
+Of particular note to the democracy reform field: PPAU initiated the **Electoral Royal Commission** campaign, advocating for a formal commission of inquiry into Australian voting systems and electoral reform options. The campaign reflects a view that the mechanisms by which Australians elect their representatives deserve serious, structured scrutiny — not just ad hoc party-political debate.
+
+The party operates as an explicitly political actor with positions across a range of issues, though its structural focus on how democratic processes work (rather than purely what policies they should produce) gives it some overlap with the nonpartisan democracy reform community.
+
+## Links
+
+- Website: [pirateparty.org.au](https://pirateparty.org.au)

--- a/docs/organisations/sortition-foundation.md
+++ b/docs/organisations/sortition-foundation.md
@@ -1,0 +1,18 @@
+---
+title: Sortition Foundation
+type: advocacy
+status: active
+country: UK
+website: https://www.sortitionfoundation.org
+summary: "A UK-based organisation advocating for the use of random selection (sortition) in democratic institutions, most prominently campaigning to replace the House of Lords with a randomly selected citizens' chamber."
+---
+
+The Sortition Foundation is the UK's leading organisation specifically dedicated to sortition — the selection of decision-makers by random lot rather than election. Their flagship campaign is the **House of Citizens**: replacing the appointed House of Lords with a chamber of randomly selected citizens who serve fixed, non-renewable terms.
+
+Beyond the Lords campaign, the foundation promotes sortition more broadly: in local government, planning processes, and deliberative policy forums. They argue that random selection produces more representative, less partisan, and more considered decision-making than competitive elections, and they support this argument with reference to the growing body of evidence from citizens' assemblies worldwide.
+
+The foundation has become a key reference point for anyone working on democratic innovation in the UK and internationally.
+
+## Links
+
+- Website: [sortitionfoundation.org](https://www.sortitionfoundation.org)

--- a/docs/organisations/susan-mckinnon-foundation.md
+++ b/docs/organisations/susan-mckinnon-foundation.md
@@ -1,0 +1,16 @@
+---
+title: Susan McKinnon Foundation
+type: philanthropy
+status: active
+country: AU
+website: https://www.susanmckinnon.org.au
+summary: "A non-partisan Australian foundation working across all sides of politics to find common ground and practical pathways on major national challenges, with a focus on democratic and public sector reform."
+---
+
+The Susan McKinnon Foundation is a private philanthropic foundation focused on strengthening Australian democracy and governance. It funds and supports work on electoral reform, parliamentary integrity, public sector capability, and cross-party collaboration.
+
+Its explicitly non-partisan stance — working with all sides of politics rather than advocating for any particular party or ideology — makes it distinctive in the Australian policy landscape. The foundation tends to focus on institutional reform (how decisions get made) rather than policy outcomes.
+
+## Links
+
+- Website: [susanmckinnon.org.au](https://www.susanmckinnon.org.au)

--- a/docs/projects/civics-ecosystem-toolkit.md
+++ b/docs/projects/civics-ecosystem-toolkit.md
@@ -23,3 +23,7 @@ It is intended to evolve over time as the ideas are tested and refined.
 **v1.2** — May 2026
 
 See the [full toolkit](https://www.designingopendemocracy.com/Civics-Ecosystem-Toolkit/01-civics-ecosystem-toolkit-index.html) for the complete set of documents.
+
+## Get involved
+
+Read the toolkit and share feedback — the ideas here are meant to be stress-tested. Reach out to Brian via the [DOD Telegram](https://t.me/joinchat/HNk_UBX8A7jBPJPbAZU5Zg) if you want to discuss or collaborate.

--- a/docs/projects/wiki-content-creation-project.md
+++ b/docs/projects/wiki-content-creation-project.md
@@ -8,13 +8,16 @@ contributors:
   - Aya.elfadil
 ---
 
-The goal of the Content Creation Project is to have short/summarized
-articles on important/core topics. Articles should be factual in nature
-and provide references when possible. Where possible, a section telling
-people how they can get involved should be present. Any website can be
-used to get information (doesn't have to be just Wikipedia)'
+The goal is to build short, factual articles on core democracy topics — accessible to anyone, not just specialists. Articles should provide references where possible.
 
-Charlie's Trello: <https://trello.com/b/P5xdCf43/open-democracy-wiki>
+## Get involved
+
+Pick a topic below that interests you and write a short article (a few paragraphs with references is enough to start). Then either:
+
+- [Open a pull request](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io) directly on the wiki, or
+- Post a draft in the [DOD Telegram](https://t.me/joinchat/HNk_UBX8A7jBPJPbAZU5Zg) and someone can help you publish it
+
+Topic tracking: <https://trello.com/b/P5xdCf43/open-democracy-wiki>
 
 Here are some initial ideas for content (open to suggestions):
 

--- a/docs/projects/write-in-stone.md
+++ b/docs/projects/write-in-stone.md
@@ -23,6 +23,10 @@ Trustworthy public information is a precondition for informed democratic partici
 - Open source investigators (OSINT)
 - Computer programmers documenting technical decisions
 
+## Get involved
+
+If you're a journalist, researcher, or investigator and want to trial Stone, reach out to Austin via the [DOD Telegram](https://t.me/joinchat/HNk_UBX8A7jBPJPbAZU5Zg) or via Instagram below.
+
 ## Links
 
 - Website: [writeinstone.com](https://www.writeinstone.com)

--- a/docs/research/research.md
+++ b/docs/research/research.md
@@ -5,18 +5,27 @@ contributors:
   - BrianKhuu
 ---
 
-This section contains various research efforts. This might be eventally moved to a proper place later.
+Working research notes and reference material compiled by DOD members.
 
-Plus is useful for others doing extra research as well.
+**Note:** Organisation listings that originated here have been migrated to the [Democracy Landscape](../organisations/organisations.md), which is the maintained reference for orgs we monitor. The files below are retained as raw working notes.
 
-## Links Of Interest
+## Files in this section
 
-- [Simulating alternate voting
-  systems](https://www.youtube.com/watch?v=yhO6jfHPFQU)
+| File | Contents |
+|---|---|
+| [Australian orgs list](current-known-efforts-in-australia-regarding-democracy-related-organisations.md) | Original link-list — see Landscape for current entries |
+| [Worldwide orgs list](current-known-efforts-world-wide-regarding-democracy-related-organisations.md) | Original link-list — see Landscape for current entries |
+| [Democracy approaches](democracy-approaches.md) | Overview of different democratic approaches and models |
+| [Methods and infrastructure](methods-and-infrastructure-of-democratic-governance.md) | Notes on democratic governance methods and infrastructure |
+| [Software related to government](software-related-to-government.md) | Catalogue of civic technology and government software |
+| [Sources of funding and grants](sources-of-funding-and-grants.md) | Funding sources relevant to democracy projects |
+| [Discussion topics](discussion-topics.md) | Topics raised for discussion at DOD meetups |
+| [Democracy Analysis Project](democracy-analysis-project.md) | Member project to classify and analyse democracy approaches |
+| [Democracy Analysis — Links](democracy-analysis-project---links.md) | Reference links for the analysis project |
+| [Democracy Analysis — Classification](democracy-analysis-project---classification-task.md) | Classification framework for democracy approaches |
 
-- Extra Credits Youtube Channel
-  - [The Rules of Society - Rules, Part 1 - Extra Politics -
-    \#4](https://www.youtube.com/watch?v=gK1dZ67MLjY) : Youtube Series
-    on political design
-  - [Fixing Broken Politics - You Think It's Bad Now... - Extra Politics
-    (American Context)](https://www.youtube.com/watch?v=8TRyN0mpczQ)
+## Quick links
+
+- [Simulating alternate voting systems](https://www.youtube.com/watch?v=yhO6jfHPFQU) — YouTube
+- [Extra Credits: The Rules of Society](https://www.youtube.com/watch?v=gK1dZ67MLjY) — YouTube series on political design
+- [Extra Credits: Fixing Broken Politics](https://www.youtube.com/watch?v=8TRyN0mpczQ) — YouTube


### PR DESCRIPTION
## Summary

### Democracy Landscape — 16 new org pages

**Australia:** Accountability Round Table, Australian Democrats, newDemocracy Foundation, NewVote, OpenAustralia Foundation, Pirate Party Australia, Susan McKinnon Foundation

**UK:** Citizens Parliament, Involve, Sortition Foundation

**Europe:** DemocracyNext (EU), DiEM25 (EU), G1000 (Belgium)

**USA:** Healthy Democracy, PeopleCount (already existed, kept)

**Global:** Participedia

### Member orientation
- `community.md` rewritten from empty placeholder to a proper getting-started page: channels table, active projects summary with leads, wiki contribution guide
- Active project pages (Civics Ecosystem Toolkit, Write in Stone, Wiki Content Creation) each have a "Get involved" section

### Index page tidying
- `organisations.md`: country-grouped table of all 20 orgs replacing an outdated PNG
- `about.md`: trimmed to mission + podcast + YouTube; "how to join" now lives in community page only
- `concepts.md`: two-table index of all concept pages replacing a one-liner placeholder
- `research.md`: notes org lists have migrated to Democracy Landscape; adds a file inventory

## Test plan

- [ ] Democracy Landscape shows all orgs grouped by country
- [ ] Community page has channel links, active projects, contribution guide
- [ ] Concepts page indexes all concept articles
- [ ] About page no longer duplicates community page content
- [ ] All new org pages render with status/type/country metadata

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy