### PR TITLE
Org markers on activity map + home page filtering fix

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -22,7 +22,7 @@
     <p id="projects-subtitle">What our members are building</p>
     <div id="projects-grid">
       {%- for file in pages %}
-        {%- if file.page and file.page.meta.status == 'active' %}
+        {%- if file.page and file.page.meta.status == 'active' and file.page.meta.template == 'project.html' %}
         <a class="project-card" href="{{ file.page.url }}">
           <h3>{{ file.page.title }}</h3>
           {%- if file.page.meta.summary %}

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -22,7 +22,7 @@
     <p id="projects-subtitle">What our members are building</p>
     <div id="projects-grid">
       {%- for file in pages %}
-        {%- if file.page and file.page.meta.status == 'active' and file.page.meta.template == 'project.html' %}
+        {%- if file.page and file.page.meta.status == 'active' and file.page.url.startswith('projects/') %}
         <a class="project-card" href="{{ file.page.url }}">
           <h3>{{ file.page.title }}</h3>
           {%- if file.page.meta.summary %}
@@ -125,7 +125,7 @@ document.addEventListener("DOMContentLoaded", function() {
   var orgMarkers = new L.FeatureGroup();
 
   {%- for file in pages %}
-    {%- if file.page and file.page.meta.location and file.page.meta.location.latitude and file.page.meta.location.longitude and file.page.meta.type and file.page.meta.status == 'active' %}
+    {%- if file.page and file.page.meta.location and file.page.meta.location.latitude and file.page.meta.location.longitude and file.page.url.startswith('organisations/') and file.page.meta.status == 'active' %}
       {
         var marker = L.marker(
           [{{ file.page.meta.location.latitude }}, {{ file.page.meta.location.longitude }}],


### PR DESCRIPTION
## Summary

- **Org markers on map**: 13 active organisations in the Democracy Landscape now appear on the home page activity map as 🏛️ markers, distinct from the blue meetup/event markers. Clicking shows org name, type, city, and website link. fitBounds updated to include both layers.
- **Orgs geolocated**: accountability-round-table (Melbourne), newDemocracy (Sydney), NewVote (Brisbane), OpenAustralia (Sydney), Susan McKinnon (Melbourne), Citizens Parliament (London), Involve (London), Sortition Foundation (Edinburgh), DemocracyNext (Copenhagen), DiEM25 (Brussels), G1000 (Brussels), Healthy Democracy (Portland), Participedia (Vancouver)
- **Home page filtering**: Active Projects section was incorrectly showing org pages alongside projects. Fixed by filtering on `file.page.url.startswith('projects/')` and `organisations/` for org markers — folder path as the source of truth rather than frontmatter fields.

## Test plan

- [ ] Home page Active Projects shows only project pages (not orgs)
- [ ] Map shows 🏛️ markers for active orgs and blue pins for meetups
- [ ] Clicking an org marker shows correct popup with website link
- [ ] Map auto-fits to include all markers globally


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_