### PR TITLE
Fix map marker separation: blog pins vs org 🏛️ markers

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -91,7 +91,7 @@ document.addEventListener("DOMContentLoaded", function() {
   var myFGMarker = new L.FeatureGroup();
 
   {%- for file in pages %}
-    {%- if file.page.meta.location and file.page.meta.location.latitude and file.page.meta.location.longitude %}
+    {%- if file.page and file.page.url.startswith('blog/') and file.page.meta.location and file.page.meta.location.latitude and file.page.meta.location.longitude %}
       {
         var marker = L.marker([{{ file.page.meta.location.latitude }}, {{ file.page.meta.location.longitude }}], {
             opacity: 1.0 - getFadeRatioBasedOnTime('{{ file.page.meta.date }}') / 2


### PR DESCRIPTION
## Summary

- **Blog marker loop** now filters to `blog/` paths only, so org pages with `location:` frontmatter don't appear as duplicate blue pins alongside their 🏛️ markers
- **Path-based page type detection** throughout the home page template — `projects/` for the Active Projects grid, `organisations/` for org markers, `blog/` for meetup markers — no reliance on frontmatter fields

## Test plan

- [ ] Map shows blue pins for meetup/blog posts only
- [ ] Map shows 🏛️ markers for active orgs only (13 expected)
- [ ] No org appears as both a blue pin and a 🏛️
- [ ] Active Projects grid shows only project pages


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_