### PR TITLE
Accountability sink concept + charter neutrality fixes

### DIFF
--- a/docs/concepts/accountability-sink.md
+++ b/docs/concepts/accountability-sink.md
@@ -1,0 +1,30 @@
+---
+title: Accountability Sink
+summary: "A structural feature of organisations in which the consequences of a decision are absorbed or obscured so that no individual can be held responsible for the outcome."
+---
+
+An **accountability sink** is a structural feature of organisations — and especially of large bureaucracies — in which the chain between a decision and its consequences is broken in a way that makes it impossible for anyone to be held responsible. The concept was developed by Dan Davies in *The Unaccountability Machine* (2024).
+
+## The mechanism
+
+The classic pattern: a senior executive makes a decision that optimises a metric visible to them (cost per room, throughput, margin). The decision propagates through layers of management and process until it manifests as a degraded experience for a customer, citizen, or employee. The person at the point of impact — a clerk, a call-centre agent, a front-line worker — has no authority to fix the underlying problem and no channel to communicate the consequence back to whoever caused it. The decision-maker never sees the outcome. The accountability is, in Davies' term, *sunk*.
+
+The voucher is the canonical symbol of an accountability sink: a token gesture offered in place of the thing you actually need, by someone who cannot give you what you need, on behalf of someone who will never know you needed it.
+
+## Why it matters for democratic design
+
+Accountability sinks are not just a corporate phenomenon. They are endemic to large public institutions:
+
+- A policy is set centrally; frontline workers implement it; citizens experience the consequences; the consequences are never aggregated back to the policymakers who set the policy.
+- A regulatory agency is created to hold industry accountable; the agency's own accountability mechanisms are weak; the regulator becomes an accountability sink for public frustration with the industry.
+- An elected representative votes on legislation drafted by staff, advised by consultants, lobbied by industry — the accountability chain is long enough that no clear responsibility attaches to any link.
+
+This is one reason why structural reforms to democracy — citizens' assemblies, participatory budgeting, deliberative panels — often focus on *shortening the chain* between decision and consequence: putting the people who will live with an outcome closer to the decision itself.
+
+## Relation to transparency and oversight
+
+Accountability sinks persist partly because they are invisible. Transparency mechanisms (open data, freedom of information, published rationale for decisions) make the chain visible. Integrity commissions and parliamentary oversight committees exist to force consequences back up the chain. Citizens' assemblies and sortition-based panels can be understood partly as anti-sink mechanisms: they place ordinary people — who will experience consequences — inside the decision-making process rather than outside it.
+
+## Source
+
+- Davies, Dan. *The Unaccountability Machine: Why Big Systems Make Such a Mess of Everything*. Profile Books, 2024.

--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -5,6 +5,12 @@ title: Concepts
 
 A reference collection of concepts relevant to open democracy — from foundational ideas to specific mechanisms and organisational forms.
 
+## Democratic theory and critique
+
+| Article | Summary |
+|---|---|
+| [Accountability Sink](accountability-sink.md) | Structural feature of organisations that absorbs consequences so no one can be held responsible — and why it matters for democratic design |
+
 ## Core democracy concepts
 
 | Article | Summary |

--- a/docs/organisations/democracy-next.md
+++ b/docs/organisations/democracy-next.md
@@ -11,11 +11,11 @@ location:
   name: Copenhagen, Denmark
 ---
 
-DemocracyNext (demnext.org) is a research institute that takes a more radical position than most deliberative democracy organisations: it argues not just that citizens' assemblies are a useful complement to elected government, but that sortition should *replace* elections as the central mechanism of democratic governance.
+DemocracyNext (demnext.org) is a research institute whose position is that sortition should *replace* elections as the central mechanism of democratic governance — not merely complement them. This distinguishes it from organisations that treat citizens' assemblies as an add-on to existing representative systems.
 
-The institute publishes research, convenes practitioners and theorists, and develops the intellectual case for sortition-based democracy — drawing on ancient Athenian practice, modern complexity theory, and the accumulated evidence from contemporary citizens' assemblies. It engages seriously with both the theory (why sortition would be more legitimate and effective than elections) and the design questions (how you actually build stable institutions around random selection).
+The institute publishes research, convenes practitioners and theorists, and develops the intellectual case for sortition-based democracy — drawing on ancient Athenian practice, modern complexity theory, and the accumulated evidence from contemporary citizens' assemblies. It engages with both the theoretical questions (legitimacy, representation, deliberation quality) and the design questions (how to build stable institutions around random selection).
 
-For anyone thinking seriously about structural democratic alternatives rather than just incremental reform, DemocracyNext is a key reference.
+DemocracyNext is a useful reference for understanding the strongest case for sortition as a primary governance mechanism, as distinct from its use as a supplementary or advisory tool.
 
 ## Links
 

--- a/docs/organisations/sortition-foundation.md
+++ b/docs/organisations/sortition-foundation.md
@@ -13,7 +13,7 @@ location:
 
 The Sortition Foundation is the UK's leading organisation specifically dedicated to sortition — the selection of decision-makers by random lot rather than election. Their flagship campaign is the **House of Citizens**: replacing the appointed House of Lords with a chamber of randomly selected citizens who serve fixed, non-renewable terms.
 
-Beyond the Lords campaign, the foundation promotes sortition more broadly: in local government, planning processes, and deliberative policy forums. They argue that random selection produces more representative, less partisan, and more considered decision-making than competitive elections, and they support this argument with reference to the growing body of evidence from citizens' assemblies worldwide.
+Beyond the Lords campaign, the foundation promotes sortition more broadly: in local government, planning processes, and deliberative policy forums. Their case is that random selection produces more representative, less partisan, and more considered decision-making than competitive elections — a position they support with reference to the growing body of evidence from citizens' assemblies worldwide.
 
 The foundation has become a key reference point for anyone working on democratic innovation in the UK and internationally.
 


### PR DESCRIPTION
## Summary

- **New concept page**: [Accountability Sink](docs/concepts/accountability-sink.md) — Dan Davies' concept from *The Unaccountability Machine*, covering the mechanism, why it's endemic to public institutions, and how democratic design features (citizens' assemblies, transparency, oversight) function as counter-measures. Added to concepts index under a new "Democratic theory and critique" section.
- **Charter neutrality fixes** (from a review of the wiki against DOD's nonpartisan charter):
  - `democracy-next.md` — removed "more radical" framing and "anyone thinking seriously" line that implicitly ranked wholesale sortition replacement as more legitimate than incremental reform. Now describes their position factually.
  - `sortition-foundation.md` — attributed sortition's claimed advantages to the organisation ("their case is that…") rather than presenting them as established facts.

## Test plan

- [ ] Accountability sink page renders correctly and appears in concepts index
- [ ] DemocracyNext and Sortition Foundation pages read as neutral descriptions, not advocacy


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_