### PR TITLE
Blog history audit: 8 orgs, 4 concepts, Pol.is, Deliberative Super + more

### DIFF
--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -10,6 +10,7 @@ A reference collection of concepts relevant to open democracy — from foundatio
 | Article | Summary |
 |---|---|
 | [Accountability Sink](accountability-sink.md) | Structural feature of organisations that absorbs consequences so no one can be held responsible — and why it matters for democratic design |
+| [Cybernetic Governance](cybernetic-governance.md) | Applying Stafford Beer's Viable System Model to diagnose and redesign governance — feedback loops, complexity, and adaptation |
 | [Isegoria](isegoria.md) | Ancient Greek principle of equal political voice — and why elections undermine it while citizens' juries restore it |
 
 ## Core democracy concepts
@@ -28,6 +29,9 @@ A reference collection of concepts relevant to open democracy — from foundatio
 | Article | Summary |
 |---|---|
 | [Citizens' Assembly](citizens-assembly.md) | Randomly selected citizens deliberate on policy questions |
+| [Issue-Based Direct Democracy](issue-based-direct-democracy.md) | The Flux Party's mechanism — voting on individual bills with delegable votes and political capital for abstaining |
+| [Liquid Democracy](liquid-democracy.md) | Voting system combining direct participation with transitive, revocable delegation |
+| [Prediction Markets](prediction-markets.md) | Markets where participants bet on policy outcomes to aggregate dispersed knowledge — applied to democratic deliberation |
 | [Sortition](sortition.md) | Selection of officials or jurors by random lot |
 | [Mixed-Member Proportional Representation](mixed-member-proportional-representation.md) | Electoral system combining constituency seats with proportional top-up seats |
 | [End-to-End Verifiable Voting System](end-to-end-verifiable-voting-system.md) | Voting systems where voters can verify their vote was counted correctly |

--- a/docs/concepts/cybernetic-governance.md
+++ b/docs/concepts/cybernetic-governance.md
@@ -1,0 +1,40 @@
+---
+title: Cybernetic Governance
+summary: "An approach to designing governance systems using the principles of cybernetics — particularly Stafford Beer's Viable System Model — to analyse and redesign how organisations and governments manage complexity, feedback, and adaptation."
+---
+
+**Cybernetic governance** applies the principles of [cybernetics](https://en.wikipedia.org/wiki/Cybernetics) — the science of regulation, feedback, and control in complex systems — to the design of organisations and governments. Rather than analysing governance through political or legal frameworks, it asks: what are the information flows, feedback loops, and regulatory mechanisms that keep a system viable and adaptive?
+
+The most developed application to governance is Stafford Beer's **Viable System Model (VSM)**, developed in the 1970s and applied most famously to Beer's *Project Cybersyn* — an attempt by the Allende government in Chile to manage the national economy using a real-time information network and the VSM framework.
+
+## Core ideas from the VSM
+
+Beer's model identifies five recursive subsystems that any viable system must have:
+
+1. **Operations** — the primary activities (e.g. service delivery, production)
+2. **Coordination** — anti-oscillation, damping conflicts between operational units
+3. **Control** — monitoring and managing operations, resource allocation
+4. **Intelligence** — scanning the environment, adaptation and future planning
+5. **Policy** — identity, values, and ultimate authority
+
+The model is recursive: each operational unit is itself a viable system with the same five subsystems. Breakdowns in governance — dysfunction, unresponsiveness, failure to adapt — can often be diagnosed as missing or broken connections between these subsystems.
+
+## Relevance to democratic design
+
+Cybernetic governance offers a structural language for diagnosing democratic failure that complements political analysis:
+
+- **Accountability sinks** (Dan Davies' concept) can be understood as broken feedback loops between operations and control
+- **Representative democracy** can be analysed as a particular design of the intelligence/policy subsystems — with elections as the primary feedback mechanism — and critiqued for the frequency and bandwidth of that feedback
+- **Citizens' assemblies** can be understood as alternative intelligence subsystems that provide richer, more considered feedback than elections
+
+Tim Falkiner presented a cybernetic governance framework at a DOD event, exploring how Beer's thinking could be applied to democratic institution design.
+
+## Further reading
+
+- Beer, Stafford. *Brain of the Firm* (1972) — foundational VSM text
+- Beer, Stafford. *Designing Freedom* (1974) — accessible lectures on applying cybernetics to social organisation
+- Medina, Eden. *Cybernetic Revolutionaries* (2011) — history of Project Cybersyn
+
+## See also
+
+- [Accountability Sink](accountability-sink.md) — related concept on feedback failure in organisations

--- a/docs/concepts/issue-based-direct-democracy.md
+++ b/docs/concepts/issue-based-direct-democracy.md
@@ -1,0 +1,34 @@
+---
+title: Issue-Based Direct Democracy (IBDD)
+summary: "The voting mechanism developed by the Flux Party — citizens vote on individual pieces of legislation, can delegate votes to others, and earn 'political capital' by abstaining which they can spend on issues they care about."
+---
+
+**Issue-Based Direct Democracy (IBDD)** is the specific democratic mechanism developed by the [Flux Party](../organisations/flux-party.md) (Australia). It is a variant of [liquid democracy](liquid-democracy.md) designed to work within an existing parliamentary system — specifically, to determine how a Flux senator would vote on each bill in the Australian Senate.
+
+## How it works
+
+1. **Registered voters** who support Flux receive a vote on each piece of legislation before the Senate
+2. They can vote **Yes**, **No**, **Abstain**, or **delegate** their vote to another person
+3. Delegation is **transitive**: your delegate can re-delegate your vote
+4. **Abstaining earns political capital** — a currency that can be spent to amplify your vote on issues you care more about
+5. The Flux senator votes in the Senate according to the aggregate of all participant votes
+
+The political capital mechanism is IBDD's distinctive innovation: it allows citizens to express not just preference but **intensity of preference**. You might abstain on dozens of bills to accumulate capital, then spend it all on an issue you feel strongly about — effectively getting multiple votes on that issue.
+
+## Motivation
+
+The system attempts to solve two problems with direct democracy:
+
+- **Rational ignorance**: most citizens don't follow most legislation. IBDD makes it rational to abstain on topics you don't know about, rather than forcing uninformed votes or non-participation
+- **One-size representation**: a senator elected on a party platform votes according to that platform on all issues. IBDD unbundles this — your Flux senator votes according to the actual, issue-specific preferences of their supporters
+
+## Criticisms and open questions
+
+- **Gaming**: the political capital economy creates incentives to strategically accumulate and spend votes in ways that may not reflect genuine preferences
+- **Low participation**: if most registered voters participate on few issues, outcomes are determined by a small active subset
+- **Complexity**: the mechanism is difficult to explain and reason about, which may limit uptake
+
+## See also
+
+- [Liquid Democracy](liquid-democracy.md) — the broader category
+- [Flux Party](../organisations/flux-party.md) — the party that developed and ran on IBDD

--- a/docs/concepts/liquid-democracy.md
+++ b/docs/concepts/liquid-democracy.md
@@ -1,0 +1,41 @@
+---
+title: Liquid Democracy
+summary: "A voting system that combines direct and representative democracy through transitive delegation — citizens can vote directly on any issue, or delegate their vote to a trusted person who can re-delegate it further."
+---
+
+**Liquid democracy** (also called *delegative democracy*) is a voting system that attempts to combine the advantages of direct and representative democracy. In a liquid democracy:
+
+- Any citizen can vote directly on any issue at any time
+- Alternatively, a citizen can **delegate** their vote to someone they trust on a given topic or set of topics
+- Delegations are **transitive**: your delegate can re-delegate your vote to their delegate
+- Delegations can be **revoked at any time** — the system is "liquid" because the flow of voting power is constantly adjustable
+
+The result is a spectrum: highly engaged citizens vote directly on everything; others delegate to specialists or trusted community figures; the rest delegate broadly. The system is designed to aggregate expertise without forcing participation on those who don't want it, while keeping power revocable rather than surrendered for a fixed term.
+
+## Distinction from standard representation
+
+In a conventional representative system, you vote for a representative who then decides on your behalf for a fixed term (typically several years), on all issues, regardless of your preferences on specific topics. Delegation in liquid democracy is:
+
+- **Issue-specific** — you can delegate differently for different policy domains
+- **Revocable** — you can take back your vote or change your delegate at any time
+- **Transitive** — your delegate's network amplifies their influence proportionally
+
+## Implementation
+
+Liquid democracy has been implemented in several contexts:
+
+- **Flux Party (Australia)** — used an issue-based variant ([IBDD](issue-based-direct-democracy.md)) for deciding how Flux senators would vote in parliament
+- **LiquidFeedback** — open-source software platform used by the German Pirate Party and others
+- **Google's Liquid Democracy experiment** — internal project exploring the model
+
+## Criticisms
+
+- **Superstar problem**: delegation can concentrate enormous voting power in a small number of highly trusted individuals, recreating a form of representation with less accountability
+- **Complexity**: most citizens find it hard to manage delegations across many topics
+- **Abstention dynamics**: if few citizens vote directly, outcomes may reflect a narrow active minority rather than broad preferences
+
+## See also
+
+- [Issue-Based Direct Democracy](issue-based-direct-democracy.md) — Flux's specific implementation
+- [Direct Democracy](direct-democracy.md)
+- [Sortition](sortition.md) — an alternative approach to the representation problem

--- a/docs/concepts/prediction-markets.md
+++ b/docs/concepts/prediction-markets.md
@@ -1,0 +1,35 @@
+---
+title: Prediction Markets
+summary: "Markets where participants bet on the outcomes of future events — used in democracy contexts to aggregate dispersed knowledge about policy outcomes, surface considered collective intelligence, and improve on conventional polling."
+---
+
+A **prediction market** is a market where participants trade contracts that pay out based on whether a specified future event occurs. The market price of a contract represents the aggregate probability estimate of the crowd — the collective belief, backed by real stakes, about what will happen.
+
+Prediction markets consistently outperform conventional polling and expert forecasts on factual questions because they aggregate dispersed private information and reward accuracy: participants who know something the market doesn't can profit by betting accordingly, which moves the price toward the true probability.
+
+## Application to democracy
+
+The democratic application of prediction markets goes beyond forecasting election outcomes. The key idea, developed by [Prediki](../organisations/prediki.md) and others, is that *asking people to predict policy outcomes* engages a different cognitive mode than asking what they prefer or believe:
+
+- Predictions require committing to a specific claim about what will happen
+- Stakes (even small or symbolic) activate careful reasoning rather than expressive or tribal responses
+- Accuracy over time is measurable, enabling reputation systems that weight better-informed views more heavily
+
+This makes prediction markets a potential tool for **surfacing considered collective intelligence** rather than raw preference — relevant to the deliberative democracy project.
+
+## In practice
+
+- **Prediki** — built a platform combining prediction markets with argument capture and sentiment analysis, explicitly framed as a democratic tool. Presented at the [2017 DOD event](../../blog/posts/2017-08-21-podcast.md).
+- **Futarchy** — a governance model proposed by Robin Hanson in which policy is determined by prediction markets: "vote on values, bet on beliefs." Society decides what outcomes it wants (e.g. GDP per capita); prediction markets determine which policies are most likely to produce those outcomes.
+- **Iowa Electronic Markets** — long-running academic prediction market for US elections, consistently competitive with major polls.
+
+## Limitations
+
+- Thin markets can be manipulated or may not aggregate enough information to be useful
+- Prediction markets work best on factual, resolvable questions — harder to apply to value questions ("which policy is better?") than to factual ones ("will this policy reduce unemployment?")
+- Futarchy has attracted philosophical objections: reducing governance to welfare metrics may exclude important values that resist quantification
+
+## See also
+
+- [Prediki](../organisations/prediki.md) — Austrian prediction market platform applied to democratic contexts
+- [Isegoria](isegoria.md) — related framing on considered vs. unconsidered collective voice

--- a/docs/organisations/br-acc.md
+++ b/docs/organisations/br-acc.md
@@ -1,0 +1,26 @@
+---
+title: br/acc (World Transparency Graph)
+type: civic_tech
+status: active
+country: BR
+website: https://github.com/brunoclz/br-acc
+summary: "An open-source Brazilian civic tech project that normalises 45+ scattered government databases into a single searchable graph — making public data genuinely accessible for accountability and civic research."
+location:
+  latitude: -23.5505
+  longitude: -46.6333
+  name: São Paulo, Brazil
+---
+
+br/acc (World Transparency Graph) is an open-source project by Brazilian developer Bruno Clz that addresses a fundamental problem in civic accountability: government data is technically "open" but so fragmented across dozens of separate portals that it is practically inaccessible.
+
+The project ingests 45+ official Brazilian public datasets — company registries, health records, education metrics, procurement data, and more — and connects them through a Neo4j graph database, exposing a unified API and a React-based search interface for exploration.
+
+## Why it matters
+
+The accountability problem br/acc addresses is universal: governments publish data, but citizens and journalists rarely have the technical capacity to join it across sources. Fragmentation functions as a de facto accountability sink — data is available in principle but inaccessible in practice. br/acc is a working demonstration of how civic tech can bridge that gap.
+
+With 1.7k GitHub stars and 463 forks, it has significant traction in the Brazilian civic tech community and serves as a model for similar efforts in other jurisdictions.
+
+## Links
+
+- GitHub: [brunoclz/br-acc](https://github.com/brunoclz/br-acc)

--- a/docs/organisations/build-a-ballot.md
+++ b/docs/organisations/build-a-ballot.md
@@ -1,0 +1,28 @@
+---
+title: Build a Ballot
+type: civic_tech
+status: active
+country: AU
+website: https://www.buildaballot.org.au
+summary: "An Australian voter advice tool that helps citizens match their values to candidates before elections — launched before each state and federal election by Project Planet, a climate-focused charity."
+location:
+  latitude: -33.8688
+  longitude: 151.2093
+  name: Sydney, Australia
+---
+
+Build a Ballot is a voter advice application (VAA) built and maintained by Project Planet Inc., an Australian charity focused on climate change. The tool launches a few weeks before each state and federal election, presenting voters with a short series of policy questions and calculating a "match score" with candidates and parties in their electorate.
+
+## How it works
+
+Users answer questions on major policy issues — housing, energy, healthcare, climate — selected because they consistently rank as top voter concerns and are backed by strong evidence as material issues. Based on responses, the tool generates a ranked match score with candidates in the user's electorate.
+
+Build a Ballot makes no automatic recommendations: the match score is derived entirely from the user's own stated preferences. It includes a transparency centre documenting its methodology.
+
+## Significance
+
+Voter advice applications are a form of civic technology that lowers the barrier to informed voting — particularly relevant in Australian elections, where the preferential voting system requires voters to rank all candidates and navigating minor party preferences can be confusing. Build a Ballot has been used across multiple state and federal elections.
+
+## Links
+
+- Website: [buildaballot.org.au](https://www.buildaballot.org.au)

--- a/docs/organisations/coalition-of-everyone.md
+++ b/docs/organisations/coalition-of-everyone.md
@@ -1,0 +1,18 @@
+---
+title: Coalition of Everyone
+type: advocacy
+status: inactive
+country: AU
+website: https://web.archive.org/web/*/https://coalitionofeveryone.com/
+summary: "An Australian organisation that ran participatory and deliberative democracy processes in communities — aimed at repairing and building democracy into everyday life. Wound up after six years of operation."
+---
+
+The Coalition of Everyone (CoE) was founded by Willow Berzin with the aim of making participatory and deliberative democracy part of everyday civic life — not just formal government processes. It ran citizens' assemblies, participatory workshops, and community engagement processes across Australia.
+
+Their stated vision: a world where people are welcomed to engage actively with political and economic systems, from small-scale community budgeting to large-scale randomly selected assemblies setting policy.
+
+After six years of operation, CoE held a final AGM and wound up — "composted" in their language. Willow Berzin went on to found the Bioregional Institute, continuing related work on regenerative community governance.
+
+## Significance
+
+CoE represented an attempt to operationalise deliberative democracy at the grassroots level — outside the formal government commissioning model used by organisations like [MosaicLab](mosaiclab.md) and [newDemocracy](newdemocracy.md). Its winding-up is itself a data point: the sustainability challenge of doing this work without a reliable institutional client base.

--- a/docs/organisations/code-for-australia.md
+++ b/docs/organisations/code-for-australia.md
@@ -1,0 +1,26 @@
+---
+title: Code for Australia
+type: civic_tech
+status: active
+country: AU
+website: https://www.codeforaustralia.org
+summary: "An Australian civic technology organisation that partners with government and non-profits to deliver digital solutions — through a fellowship program placing technologists inside public institutions."
+location:
+  latitude: -37.8136
+  longitude: 144.9631
+  name: Melbourne, Australia
+---
+
+Code for Australia (CfA) is a civic tech organisation founded in 2014, modelled on Code for America. Its primary program is a **fellowship**: placing technologists (developers, designers, data scientists) inside government agencies and non-profits for short-term engagements to help solve civic problems through digital tools.
+
+CfA also runs **Civic Makers**, a volunteer community bringing people together to build civic technology. Projects have spanned local government data accessibility, climate tools for councils, and public service improvement.
+
+In a structural change, Portable (a civic tech consultancy) took on support of CfA's operations, with CfA's mission remaining unchanged.
+
+## Relevance
+
+CfA represents the infrastructure layer of civic tech in Australia — building the human network and institutional relationships that make government-facing technology projects possible. It is a key part of the broader ecosystem that includes [OpenAustralia Foundation](open-australia-foundation.md) and [GovHack](https://govhack.org).
+
+## Links
+
+- Website: [codeforaustralia.org](https://www.codeforaustralia.org)

--- a/docs/organisations/gilt.md
+++ b/docs/organisations/gilt.md
@@ -1,0 +1,26 @@
+---
+title: G!LT (Offene Demokratie)
+type: party
+status: active
+country: AT
+website: https://www.gilt.at
+summary: "An Austrian open democracy party founded by actor and political activist Roland Düringer, arguing that representative democracy as currently practised is broken and proposing citizen-led alternatives."
+location:
+  latitude: 48.2082
+  longitude: 16.3738
+  name: Vienna, Austria
+---
+
+G!LT (stylised from the German *"Meine Stimme G!LT"* — "My Vote Counts") is an Austrian political party founded in 2016 by Roland Düringer, an actor, cabaret artist, and political commentator. The party's starting point is a critique of representative democracy as actually practiced in Austria: that elections every five years give citizens minimal real influence, and that the current system serves party machinery more than citizens.
+
+G!LT ran in the 2017 Austrian National Council election, receiving 0.95% of valid votes — below the 4% threshold for parliamentary representation. It has continued to contest state elections, including Vorarlberg in 2024, sometimes in alliance with other small parties.
+
+## Position and caveats
+
+G!LT is a political party with positions across multiple issues. We note it here because its explicit focus on democratic reform and citizen participation is directly relevant to DOD's remit — not because DOD endorses the party or its broader platform.
+
+The party is connected to the broader Austrian civic tech and open democracy community, including Hubertus Hofkirchner ([Prediki](prediki.md)) who has been involved in related civic initiatives.
+
+## Links
+
+- Website: [gilt.at](https://www.gilt.at)

--- a/docs/organisations/horizon-state.md
+++ b/docs/organisations/horizon-state.md
@@ -1,0 +1,20 @@
+---
+title: Horizon State
+type: platform
+status: inactive
+country: AU
+website: https://web.archive.org/web/*/https://horizonstate.com/
+summary: "An Australian blockchain voting platform that aimed to bring secure, transparent digital voting to governments and organisations. Wound down after initial pilots."
+---
+
+Horizon State was an Australian company that built a blockchain-based voting and decision-making platform. The system used distributed ledger technology to record votes on a permanent, publicly auditable record — aiming to solve problems of vote integrity, transparency, and accessibility.
+
+They ran several real-world pilots, including a contract with the South Australian government to run the election for the inaugural Minister's Recreational Fishing Advisory Council, and work with The Opportunities Party in New Zealand.
+
+## Why it matters as a case study
+
+Horizon State is a useful reference point for the blockchain-in-democracy discussion. It attracted significant attention during the blockchain enthusiasm of 2017–2018, demonstrated that blockchain voting could be implemented in real government contexts, but ultimately did not achieve the scale or institutional adoption needed to sustain the company.
+
+The core lesson: technical feasibility is not the binding constraint for digital voting adoption. The challenges are political, institutional, and trust-related — blockchain's verifiability properties don't automatically translate into public confidence, and governments move slowly on changes to electoral infrastructure regardless of the technology's merits.
+
+Horizon State operated in the same ecosystem as [SecureVote](securevote.md) and in the broader orbit of the [Flux Party](flux-party.md), which also used blockchain in its voting architecture.

--- a/docs/organisations/lateral-economics.md
+++ b/docs/organisations/lateral-economics.md
@@ -1,0 +1,23 @@
+---
+title: Lateral Economics
+type: research
+status: active
+country: AU
+website: https://lateraleconomics.com.au
+summary: "An Australian policy economics consultancy led by Nicholas Gruen — advising on economic reform, innovation, and democratic governance, with a particular interest in how institutions can better incorporate citizens' knowledge and deliberation."
+location:
+  latitude: -33.8688
+  longitude: 151.2093
+  name: Sydney, Australia
+---
+
+Lateral Economics is a policy consultancy founded and led by Nicholas Gruen, a widely published Australian economist and commentator. The firm works with government clients on economic reform, productivity, and innovation policy — but Gruen is perhaps best known publicly for his advocacy of democratic reform, particularly citizens' juries and sortition as mechanisms for improving the quality of collective decision-making.
+
+Gruen's democracy-relevant argument (developed extensively in talks, articles, and podcasts including a [2020 DOD episode](../../blog/posts/2020-03-20.md)) centres on the concept of [isegoria](../concepts/isegoria.md): elections structurally degrade the quality of democratic deliberation by rewarding emotional salience and tribal loyalty over considered reasoning, while randomly selected citizens' juries restore equal standing and produce more considered outcomes.
+
+He has advocated for a philanthropically funded standing citizens' jury that would shadow parliament — operating without formal power initially, but providing an evidence base for the model.
+
+## Links
+
+- Website: [lateraleconomics.com.au](https://lateraleconomics.com.au)
+- Nicholas Gruen's Substack: [nicholasgruen.substack.com](https://nicholasgruen.substack.com)

--- a/docs/organisations/mosaiclab.md
+++ b/docs/organisations/mosaiclab.md
@@ -1,0 +1,27 @@
+---
+title: MosaicLab
+type: practice
+status: active
+country: AU
+website: https://mosaiclab.com.au
+summary: "An Australian deliberative democracy practice that designs and facilitates public deliberation processes — citizens' juries, panels, and assemblies — for governments and public institutions."
+location:
+  latitude: -37.8136
+  longitude: 144.9631
+  name: Melbourne, Australia
+---
+
+MosaicLab is a professional practice specialising in public deliberation. Founded by Kimbra White, Nicole Hunter, and Keith Greaves, it designs and runs deliberative engagement processes: citizens' juries, standing panels, deliberative polls, and citizens' assemblies for government clients across Australia.
+
+Since 2014 MosaicLab has delivered over 40 deliberative engagement processes. They have published a comprehensive guide to facilitating public deliberations, drawing on that experience, and co-developed research on how deliberative democracy can be embedded in decision-making organisations.
+
+## Approach
+
+MosaicLab operates at the intersection of theory and practice. They design processes for high-stakes and contested issues — cases where standard consultation would not generate meaningful input — and work with clients to ensure outputs genuinely inform decisions rather than serving as token engagement.
+
+They are also engaged in building the evidence base for deliberation: what conditions make it work, when it is appropriate, and how to embed it as a normal part of institutional decision-making rather than a one-off experiment.
+
+## Links
+
+- Website: [mosaiclab.com.au](https://mosaiclab.com.au)
+- See also: [newDemocracy Foundation](newdemocracy.md) — frequent collaborator in the Australian deliberative democracy space

--- a/docs/organisations/organisations.md
+++ b/docs/organisations/organisations.md
@@ -14,6 +14,7 @@ These are not affiliated or partner organisations. Individuals from some of thes
 |---|---|---|
 | [Accountability Round Table](accountability-round-table.md) | Advocacy | Active |
 | [Australian Democrats](australian-democrats.md) | Party | Active |
+| [Build a Ballot](build-a-ballot.md) | Civic tech | Active |
 | [Coalition of Everyone](coalition-of-everyone.md) | Advocacy | Inactive |
 | [Code for Australia](code-for-australia.md) | Civic tech | Active |
 | [DigiPol](digipol.md) | Platform | Inactive |
@@ -54,6 +55,13 @@ These are not affiliated or partner organisations. Individuals from some of thes
 |---|---|---|
 | [Healthy Democracy](healthy-democracy.md) | Practice | Active |
 | [PeopleCount](peoplecount.md) | Platform | Inactive |
+| [Pol.is](polis.md) | Platform | Active |
+
+## Brazil
+
+| Organisation | Type | Status |
+|---|---|---|
+| [br/acc (World Transparency Graph)](br-acc.md) | Civic tech | Active |
 
 ## Taiwan
 

--- a/docs/organisations/organisations.md
+++ b/docs/organisations/organisations.md
@@ -14,13 +14,20 @@ These are not affiliated or partner organisations. Individuals from some of thes
 |---|---|---|
 | [Accountability Round Table](accountability-round-table.md) | Advocacy | Active |
 | [Australian Democrats](australian-democrats.md) | Party | Active |
+| [Coalition of Everyone](coalition-of-everyone.md) | Advocacy | Inactive |
+| [Code for Australia](code-for-australia.md) | Civic tech | Active |
 | [DigiPol](digipol.md) | Platform | Inactive |
 | [Flux Party](flux-party.md) | Party | Deregistered |
+| [Horizon State](horizon-state.md) | Platform | Inactive |
+| [Lateral Economics](lateral-economics.md) | Research | Active |
 | [MiVote](mivote.md) | Platform | Deregistered |
+| [MosaicLab](mosaiclab.md) | Practice | Active |
 | [newDemocracy Foundation](newdemocracy.md) | Research | Active |
 | [NewVote](newvote.md) | Platform | Active |
 | [OpenAustralia Foundation](open-australia-foundation.md) | Civic tech | Active |
 | [Pirate Party Australia](pirate-party-australia.md) | Party | Active |
+| [Proportional Representation Society of Australia](prsa.md) | Advocacy | Active |
+| [SecureVote](securevote.md) | Platform | Active |
 | [Susan McKinnon Foundation](susan-mckinnon-foundation.md) | Philanthropy | Active |
 
 ## United Kingdom
@@ -37,6 +44,7 @@ These are not affiliated or partner organisations. Individuals from some of thes
 |---|---|---|---|
 | [DemocracyNext](democracy-next.md) | EU | Research | Active |
 | [DiEM25](diem25.md) | EU | Political movement | Active |
+| [G!LT (Offene Demokratie)](gilt.md) | Austria | Party | Active |
 | [G1000](g1000.md) | Belgium | Research | Active |
 | [Prediki](prediki.md) | Austria | Platform | Active |
 

--- a/docs/organisations/pirate-party-australia.md
+++ b/docs/organisations/pirate-party-australia.md
@@ -16,3 +16,7 @@ The party operates as an explicitly political actor with positions across a rang
 ## Links
 
 - Website: [pirateparty.org.au](https://pirateparty.org.au)
+
+## Member resources
+
+- [Electoral Reform — The Wolf of Auspol](https://wolfofauspol.me/electoral-reform) — a detailed breakdown of electoral reform options for Australia by Drew Wolfendale, a PPAU/Fusion Party member, covering multi-member electorate models and proportional systems

--- a/docs/organisations/polis.md
+++ b/docs/organisations/polis.md
@@ -1,0 +1,41 @@
+---
+title: Pol.is
+type: platform
+status: active
+country: US
+website: https://pol.is
+summary: "An open-source consensus mapping platform used in large-scale public deliberations — participants rate statements rather than debating, and machine learning surfaces the points of genuine agreement across thousands of respondents."
+location:
+  latitude: 47.6062
+  longitude: -122.3321
+  name: Seattle, USA
+---
+
+Pol.is (pronounced "polis") is an open-source platform for large-scale online deliberation, developed by the Computational Democracy Project. Since its launch in 2012 it has hosted tens of thousands of conversations with over 10 million participants worldwide, and is now embedded as national democratic infrastructure in Taiwan.
+
+## How it works
+
+The core design decision is **no replies**. Instead of threaded debate (which amplifies disagreement and rewards combative voices), Pol.is presents participants with statements one at a time and asks them to agree, disagree, or pass. Participants can also submit new statements.
+
+Machine learning clusters participants by their response patterns, then surfaces the statements that generate **cross-cluster agreement** — the points where people who disagree on most things nonetheless find common ground. This makes consensus visible in ways that comment-based platforms cannot.
+
+## Notable deployments
+
+- **vTaiwan** — the platform's most influential deployment. Used to deliberate on Uber regulation, fintech policy, and over a dozen other areas of Taiwanese law. The Uber consultation found 95% consensus on passenger safety, cutting across the pro-Uber / pro-taxi divide.
+- **UK** — used by Nesta and others for public consultations
+- **Finland** — used for national-level policy deliberation
+- **Collective Intelligence Project** — exploring Pol.is as infrastructure for AI governance consultations
+
+## Open source
+
+Pol.is is fully open source (GitHub: [compdemocracy/polis](https://github.com/compdemocracy/polis)), meaning it can be self-hosted by any government or organisation. This distinguishes it from proprietary consultation platforms and makes it a genuine civic commons tool.
+
+## Relation to DOD interests
+
+Pol.is is the technical backbone of [vTaiwan](vtaiwan.md) — the most-cited example of digital deliberative democracy at government scale. Understanding how Pol.is works is practically useful for anyone designing participation processes.
+
+## Links
+
+- Website: [pol.is](https://pol.is)
+- Computational Democracy Project: [compdemocracy.org](https://compdemocracy.org)
+- Guardian article: [Taiwan's civic hackers and Pol.is](https://www.theguardian.com/world/2020/sep/27/taiwan-civic-hackers-polis-consensus-social-media-platform)

--- a/docs/organisations/prsa.md
+++ b/docs/organisations/prsa.md
@@ -1,0 +1,26 @@
+---
+title: Proportional Representation Society of Australia
+type: advocacy
+status: active
+country: AU
+website: https://www.prsa.org.au
+summary: "Australia's oldest electoral reform organisation, advocating for proportional representation via the Single Transferable Vote — the system already used in Tasmania, the ACT, and the Australian Senate."
+location:
+  latitude: -35.2809
+  longitude: 149.1300
+  name: Canberra, Australia
+---
+
+The Proportional Representation Society of Australia (PRSA) is one of Australia's oldest electoral reform organisations, with roots in the 19th century — Catherine Helen Spence was among its founding members. The current national constitution dates from 1982.
+
+The Society's specific focus is proportional representation via the **Single Transferable Vote** (PR-STV), the Hare-Clark variant of which is used in Tasmania and the ACT. It advocates for extending this system to the House of Representatives (currently using preferential voting in single-member electorates) and to state lower houses.
+
+## What they argue
+
+PR-STV produces results that more closely reflect the distribution of voter preferences across the electorate, reducing the "wasted votes" problem of single-member systems. The Society makes regular submissions to parliamentary inquiries on electoral matters and publishes a quarterly newsletter, *Quota Notes*.
+
+PR-STV is distinct from party-list proportional representation (used in most of Europe) in that voters rank individual candidates rather than selecting parties — preserving a direct relationship between voters and representatives while achieving proportionality.
+
+## Links
+
+- Website: [prsa.org.au](https://www.prsa.org.au)

--- a/docs/organisations/securevote.md
+++ b/docs/organisations/securevote.md
@@ -1,0 +1,24 @@
+---
+title: SecureVote
+type: platform
+status: active
+country: AU
+website: https://secure.vote
+summary: "An Australian blockchain voting platform providing secure, scalable, and anonymous digital voting for governments, organisations, and token-based ecosystems."
+location:
+  latitude: -33.8688
+  longitude: 151.2093
+  name: Sydney, Australia
+---
+
+SecureVote is a Sydney-based company providing blockchain-based voting infrastructure. Their platform uses a proprietary Blockchain Agnostic Scalability Layer (BASL) to enable decentralised, anonymous, and auditable elections at scale — stress-tested to 1.5 billion transactions in 24 hours.
+
+The platform has been used for government elections, organisational governance votes, and token-based ecosystem governance. A distinctive feature is their "Copperfield" vote anonymising algorithm, which makes anonymous digital secret ballot possible without compromising verifiability.
+
+## Context
+
+SecureVote operates in similar territory to the now-defunct [Horizon State](horizon-state.md). The challenge for both has been the same: demonstrating that blockchain voting is not just technically sound but trustworthy enough for high-stakes public elections, where conservative institutional risk appetite makes adoption slow regardless of technical merits.
+
+## Links
+
+- Website: [secure.vote](https://secure.vote)

--- a/docs/projects/deliberative-super.md
+++ b/docs/projects/deliberative-super.md
@@ -5,25 +5,48 @@ status: active
 contributors:
   - Craig Lambie
 website: https://deliberativesuper.com.au
-summary: "A proposal to apply deliberative democracy to Australian superannuation — giving fund members structured, genuine voice in how their collective capital is invested, with a focus on climate, biodiversity, and wellbeing outcomes."
+summary: "A proxy advisory service that replaces opaque corporate governance recommendations with decisions made by randomly selected pension fund members — giving members real democratic power over how their retirement savings vote at company AGMs."
 ---
 
-Deliberative Super is a project by DOD member Craig Lambie exploring how deliberative democracy can be applied to Australian superannuation fund governance.
+Deliberative Super is a project by DOD member Craig Lambie that applies sortition and deliberative democracy to corporate governance — specifically, to the proxy advisory industry.
 
-## The idea
+## The problem it solves
 
-Australia's superannuation system holds over $3 trillion in assets on behalf of working Australians. Fund members are the nominal owners of this capital, but in practice they have minimal say in how it is invested — decisions are made by boards and fund managers operating at a significant remove from members' values and preferences.
+When pension funds hold shares in companies, they must vote on corporate decisions at Annual General Meetings (AGMs): board appointments, executive pay, environmental policies, and more. In practice, these votes are guided by **proxy advisors** — specialist firms like ISS and Glass Lewis — who make voting recommendations on behalf of institutional investors.
 
-Deliberative Super proposes using structured deliberative processes — citizens' juries, deliberative panels, or similar mechanisms — to surface the *considered* preferences of fund members on how their capital should be deployed. The focus is on directing super capital toward climate-positive, biodiversity-supporting, and general wellbeing outcomes, grounded in what members actually want when they have the time and information to think it through.
+The problem: proxy advisors consult no one. A small number of firms make high-stakes recommendations affecting millions of pension members' retirement savings, with no accountability to those members and no mechanism for their values to shape the decisions. Money flows from members through funds to companies — but decision power never flows back.
 
-## Why it's relevant to democracy reform
+## The solution
 
-This project sits at an underexplored intersection:
+Deliberative Super replaces proxy advisor recommendations with recommendations produced by **randomly selected pension fund members** using structured deliberative processes:
 
-- **Economic democracy** — superannuation is a form of collective capital ownership; deliberative governance of it extends democratic principles into finance
-- **Deliberative democracy in practice** — applying citizens' assembly methods to an institutional context (super fund boards) rather than a government one
-- **Capital allocation as democratic question** — where collective savings go shapes the economy and environment; this is a decision members could meaningfully participate in if the process existed
+- **Sortition**: 40 pension fund members selected by random lot, representative across demographics
+- **Compensation**: participants paid professionally (£85/hour or £250–450/day, with travel and accommodation) — recognising their contribution as genuine democratic labour
+- **6–12 month process**: cohorts meet 3–8 times across accessible locations, hearing from diverse experts — lobby groups, think tanks, community organisations, indigenous groups
+- **Structured deliberation**: balanced information, facilitated discussion, vote on AGM proposals
+- **Recommendations with backing**: outputs go to pension fund trustees with the full weight of member democratic legitimacy behind them
+
+Fresh cohorts address different companies and issues, preventing institutional capture. Continuous feedback loops between cohorts allow the process to improve over time.
+
+## Why it matters
+
+This addresses several problems at once:
+
+- **Democratic legitimacy** for corporate governance — recommendations carry member mandate, not just consultant opinion
+- **Values alignment** — community and corporate values begin to converge when members have genuine influence over governance votes
+- **Beyond the squeaky wheel** — sortition hears from quiet voices, not just the loudest stakeholders or most engaged members
+- **Long-term perspective** — freed from political cycles and competitive pressures, deliberative panels tend toward more sustainable thinking
+
+The sortition model also addresses a known failure mode of direct member voting: low participation rates and domination by vocal minorities. Random selection ensures representation across all demographics, not just those who opt in.
+
+## Academic backing
+
+The model has been tested and studied by economists in the Netherlands and presented at Oxford.
 
 ## Status
 
-The project is in early development. Craig is actively seeking a co-founder to help build it out. If you're interested in contributing, reach out via the [DOD community channels](../community/community.md) or at [craiglambie.com/links](https://craiglambie.com/links).
+Early development — Craig is actively seeking a co-founder to help build this out. If you're interested in contributing or learning more:
+
+- Website: [deliberativesuper.com.au](https://deliberativesuper.com.au)
+- Contact: [craiglambie.com/links](https://craiglambie.com/links)
+- Raise it in the [DOD community channels](../community/community.md)

--- a/docs/projects/deliberative-super.md
+++ b/docs/projects/deliberative-super.md
@@ -1,0 +1,29 @@
+---
+title: Deliberative Super
+template: project.html
+status: active
+contributors:
+  - Craig Lambie
+website: https://deliberativesuper.com.au
+summary: "A proposal to apply deliberative democracy to Australian superannuation — giving fund members structured, genuine voice in how their collective capital is invested, with a focus on climate, biodiversity, and wellbeing outcomes."
+---
+
+Deliberative Super is a project by DOD member Craig Lambie exploring how deliberative democracy can be applied to Australian superannuation fund governance.
+
+## The idea
+
+Australia's superannuation system holds over $3 trillion in assets on behalf of working Australians. Fund members are the nominal owners of this capital, but in practice they have minimal say in how it is invested — decisions are made by boards and fund managers operating at a significant remove from members' values and preferences.
+
+Deliberative Super proposes using structured deliberative processes — citizens' juries, deliberative panels, or similar mechanisms — to surface the *considered* preferences of fund members on how their capital should be deployed. The focus is on directing super capital toward climate-positive, biodiversity-supporting, and general wellbeing outcomes, grounded in what members actually want when they have the time and information to think it through.
+
+## Why it's relevant to democracy reform
+
+This project sits at an underexplored intersection:
+
+- **Economic democracy** — superannuation is a form of collective capital ownership; deliberative governance of it extends democratic principles into finance
+- **Deliberative democracy in practice** — applying citizens' assembly methods to an institutional context (super fund boards) rather than a government one
+- **Capital allocation as democratic question** — where collective savings go shapes the economy and environment; this is a decision members could meaningfully participate in if the process existed
+
+## Status
+
+The project is in early development. Craig is actively seeking a co-founder to help build it out. If you're interested in contributing, reach out via the [DOD community channels](../community/community.md) or at [craiglambie.com/links](https://craiglambie.com/links).


### PR DESCRIPTION
## Summary

**From blog history audit:**

- **8 new org pages (AU)**: Code for Australia, MosaicLab, Coalition of Everyone (inactive), Horizon State (inactive, lessons-learned framing), Lateral Economics, PRSA, SecureVote, Build a Ballot
- **1 new org page (Europe)**: G!LT Offene Demokratie (Austrian open democracy party)
- **4 new concept pages**: Liquid Democracy, Issue-Based Direct Democracy (IBDD), Prediction Markets (in democracy), Cybernetic Governance (Stafford Beer/VSM)
- **Drew Wolfendale's electoral reform page** linked from PPAU org entry

**From user-submitted leads:**

- **Pol.is** — open-source consensus mapping platform behind vTaiwan, now democratic infrastructure in Taiwan/UK/Finland. Own landscape page with full description.
- **br/acc** — Brazilian open-source transparency graph normalising 45+ government databases. Civic accountability model.

**New member project:**

- **Deliberative Super** (Craig Lambie) — proxy advisory service replacing ISS/Glass Lewis recommendations with decisions from a randomly selected 40-person pension fund member panel. Compensated at professional rates, 6–12 month sortition process, academic backing from NL economists/Oxford. Seeking co-founder.

## Test plan

- [ ] All new org pages render correctly in Democracy Landscape
- [ ] 4 new concept pages appear in concepts index under correct sections
- [ ] Deliberative Super appears in Active Projects on home page
- [ ] Pol.is map marker appears (Seattle)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_