### PR TITLE
Add organisations index page with status-grouped cards

### DIFF
--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -25,9 +25,17 @@
     white-space: nowrap;
 }
 
-.project-status-badge.status-active     { background: #e6f4ea; color: #2e7d32; }
-.project-status-badge.status-mothballed { background: #fff3e0; color: #e65100; }
-.project-status-badge.status-cancelled  { background: #f5f5f5; color: #757575; }
+.project-status-badge.status-active       { background: #e6f4ea; color: #2e7d32; }
+.project-status-badge.status-mothballed   { background: #fff3e0; color: #e65100; }
+.project-status-badge.status-cancelled    { background: #f5f5f5; color: #757575; }
+.project-status-badge.status-inactive     { background: #fff3e0; color: #e65100; }
+.project-status-badge.status-deregistered { background: #f5f5f5; color: #757575; }
+
+.org-index-card-meta {
+    font-size: 0.8em;
+    color: #888;
+    margin-bottom: 0.4em;
+}
 
 /* Projects index page */
 

--- a/docs/organisations/organisations.md
+++ b/docs/organisations/organisations.md
@@ -1,80 +1,11 @@
 ---
 title: Democracy Landscape
+template: organisations.html
 ---
 
 A reference directory of organisations active in the democracy, civic technology, and democratic reform space. Maintained by DOD members as a monitoring resource — to keep track of what different groups are doing and how the broader landscape is evolving.
 
 These are not affiliated or partner organisations. Individuals from some of these groups participate in our discussions, but there is no formal association. Entries aim to be neutral and factual.
-
----
-
-## Australia
-
-| Organisation | Type | Status |
-|---|---|---|
-| [Accountability Round Table](accountability-round-table.md) | Advocacy | Active |
-| [Australian Democrats](australian-democrats.md) | Party | Active |
-| [Build a Ballot](build-a-ballot.md) | Civic tech | Active |
-| [Coalition of Everyone](coalition-of-everyone.md) | Advocacy | Inactive |
-| [Code for Australia](code-for-australia.md) | Civic tech | Active |
-| [DigiPol](digipol.md) | Platform | Inactive |
-| [Flux Party](flux-party.md) | Party | Deregistered |
-| [Horizon State](horizon-state.md) | Platform | Inactive |
-| [Lateral Economics](lateral-economics.md) | Research | Active |
-| [MiVote](mivote.md) | Platform | Deregistered |
-| [MosaicLab](mosaiclab.md) | Practice | Active |
-| [newDemocracy Foundation](newdemocracy.md) | Research | Active |
-| [NewVote](newvote.md) | Platform | Active |
-| [OpenAustralia Foundation](open-australia-foundation.md) | Civic tech | Active |
-| [Pirate Party Australia](pirate-party-australia.md) | Party | Active |
-| [Proportional Representation Society of Australia](prsa.md) | Advocacy | Active |
-| [SecureVote](securevote.md) | Platform | Active |
-| [Susan McKinnon Foundation](susan-mckinnon-foundation.md) | Philanthropy | Active |
-
-## United Kingdom
-
-| Organisation | Type | Status |
-|---|---|---|
-| [Citizens Parliament](citizens-parliament-uk.md) | Advocacy | Active |
-| [Involve](involve.md) | Research | Active |
-| [Sortition Foundation](sortition-foundation.md) | Advocacy | Active |
-
-## Europe
-
-| Organisation | Country | Type | Status |
-|---|---|---|---|
-| [DemocracyNext](democracy-next.md) | EU | Research | Active |
-| [DiEM25](diem25.md) | EU | Political movement | Active |
-| [G!LT (Offene Demokratie)](gilt.md) | Austria | Party | Active |
-| [G1000](g1000.md) | Belgium | Research | Active |
-| [Prediki](prediki.md) | Austria | Platform | Active |
-
-## United States
-
-| Organisation | Type | Status |
-|---|---|---|
-| [Healthy Democracy](healthy-democracy.md) | Practice | Active |
-| [PeopleCount](peoplecount.md) | Platform | Inactive |
-| [Pol.is](polis.md) | Platform | Active |
-
-## Brazil
-
-| Organisation | Type | Status |
-|---|---|---|
-| [br/acc (World Transparency Graph)](br-acc.md) | Civic tech | Active |
-
-## Taiwan
-
-| Organisation | Type | Status |
-|---|---|---|
-| [g0v (gov zero)](g0v.md) | Civic tech | Active |
-| [vTaiwan](vtaiwan.md) | Platform | Active |
-
-## Global
-
-| Organisation | Type | Status |
-|---|---|---|
-| [Participedia](participedia.md) | Research | Active |
 
 ---
 

--- a/docs/overrides/organisations.html
+++ b/docs/overrides/organisations.html
@@ -1,0 +1,44 @@
+{% extends "main.html" %}
+{% block content %}
+{{ super() }}
+<div class="md-typeset">
+{% set status_groups = [
+  ('active',       'Active'),
+  ('inactive',     'Inactive'),
+  ('deregistered', 'Deregistered')
+] %}
+{% for status_key, status_label in status_groups %}
+  {%- set ns = namespace(has_items=false) %}
+  {%- for file in pages %}
+    {%- if file.page and file.page.url and file.page.url.startswith('organisations/') and file.page.url != page.url and file.page.meta.get('status') == status_key %}
+      {%- set ns.has_items = true %}
+    {%- endif %}
+  {%- endfor %}
+  {%- if ns.has_items %}
+  <h2>{{ status_label }}</h2>
+  <div class="projects-index-grid">
+    {%- for file in pages %}
+      {%- if file.page and file.page.url and file.page.url.startswith('organisations/') and file.page.url != page.url and file.page.meta.get('status') == status_key %}
+      <a class="project-index-card" href="{{ file.page.url }}">
+        <div class="project-index-card-header">
+          <span class="project-index-card-title">{{ file.page.title }}</span>
+          <span class="project-status-badge status-{{ status_key }}">{{ status_label }}</span>
+        </div>
+        {%- if file.page.meta.get('type') or file.page.meta.get('country') %}
+        <p class="org-index-card-meta">
+          {%- if file.page.meta.get('type') %}{{ file.page.meta.type }}{%- endif %}
+          {%- if file.page.meta.get('type') and file.page.meta.get('country') %} · {%- endif %}
+          {%- if file.page.meta.get('country') %}{{ file.page.meta.country }}{%- endif %}
+        </p>
+        {%- endif %}
+        {%- if file.page.meta.get('summary') %}
+        <p>{{ file.page.meta.summary }}</p>
+        {%- endif %}
+      </a>
+      {%- endif %}
+    {%- endfor %}
+  </div>
+  {%- endif %}
+{%- endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Replaces the manual markdown country/table layout on the Democracy Landscape page with a Jinja2 template (`organisations.html`) that auto-generates cards grouped by status (Active / Inactive / Deregistered)
- Each card shows the org name, a coloured status badge, type · country meta line, and summary text
- Mirrors the existing projects index pattern exactly
- Adds CSS for `status-inactive` (orange) and `status-deregistered` (grey) badges, plus `.org-index-card-meta` for the small meta line

## Test plan

- [ ] Democracy Landscape page renders cards grouped under Active / Inactive / Deregistered headings
- [ ] Status badges are correctly coloured (green / orange / grey)
- [ ] Type and country appear as small grey meta text on each card
- [ ] Defunct orgs (Flux Party, MiVote, DigiPol, Horizon State, Coalition of Everyone, PeopleCount) appear under Inactive or Deregistered, not Active
- [ ] Cards link through to individual org pages

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_