### PR TITLE
Add Polari project page for DOD member Dausume

### DIFF
--- a/docs/blog/posts/2019-05-15.md
+++ b/docs/blog/posts/2019-05-15.md
@@ -31,7 +31,7 @@ Meetup link: https://www.meetup.com/DesigningOpenDemocracy/events/261014681/
 
 This will be a series of special joint presentations with Melbourne Geek Night and Designing Open Democracy about innovative democratic startups growing in Melbourne.
 
-One of the presentation in this event will be by Danny Johnson on his MYO Democracy platform on how he is developing an open-source platform to assist in supporting community decision making.
+One of the presentations in this event was by Danny Johnson on his [MYO Democracy](../../projects/myo-democracy.md) platform — an open-source platform for collaborative democratic decision making.
 
 The second presentation by Steve Guardiani of Melbourne Business Centre is geared towards anyone interested in starting (or growing) a business and the unexpected challenges that may hit you! Steve will deliver a candid talk about some of his experiences and will include:
 

--- a/docs/blog/posts/2023-09-10.md
+++ b/docs/blog/posts/2023-09-10.md
@@ -16,7 +16,7 @@ title: Dausume introduces his Open Source Research & Democracy Platforms
 
 # Dausume introduces his Open Source Research & Democracy Platforms 
 
-**This was saved from the forum and is posted here to help him get his word out about his effort**
+**This was saved from the forum and is posted here to help him get his word out about his effort. See the [Polari project page](../../projects/polari.md) for a fuller overview.**
 
 Howdy ya’ll, my name is Dustin and I’m from America. I’ve worked for a while on two projects that interrelate.
 

--- a/docs/projects/myo-democracy.md
+++ b/docs/projects/myo-democracy.md
@@ -1,0 +1,42 @@
+---
+title: MYO Democracy (Make Your Own Democracy)
+template: project.html
+status: mothballed
+contributors:
+  - Danny Johnson
+website: https://web.archive.org/web/*/https://myodemocracy.org/
+summary: "A Melbourne-based platform for collaborative democratic decision-making — citizens raise issues, propose options, review research, vote on solutions, and track outcomes. Non-partisan and designed to complement rather than replace existing government."
+---
+
+MYO Democracy (Make Your Own Democracy) was a project by Melbourne-based civic technologist Danny Johnson, presented at a [joint Designing Open Democracy / Melbourne Geek Night event in May 2019](../blog/posts/2019-05-15.md).
+
+## What it aimed to do
+
+MYO Democracy sought to give citizens a direct, structured say in the laws that affect them. The platform supported a full democratic workflow:
+
+1. Citizens **raise issues and concerns**
+2. **Propose and prioritise options** for addressing them
+3. **Review relevant research** to inform decisions
+4. **Define expectations** — what success looks like
+5. **Vote** for solutions most likely to succeed
+6. **Track outcomes** and measure whether promised benefits materialised
+
+The platform was explicitly non-partisan. Its stated mission was to "support, promote, drive, petition, monitor and generally pester the existing incumbent government to actually listen to what citizens have said they really need, regardless of whether the solution is left, right or somewhere in between." The goal was to complement and pressure incumbent government — not replace it.
+
+## Context
+
+Danny described the project as free-to-use and open-source, intended for everyday citizens rather than specialists. It was positioned as infrastructure for local centres and online communities to run collaborative democratic processes together.
+
+## Later development
+
+A 2021 Medium article by Danny ("Open and United") showed the thinking evolving toward a broader vision: global democratic self-governance with collaborative decision-making, modular design, distributed implementation, and an economy tied to physical resource usage — bringing open communities together under a collaborative framework.
+
+## Status
+
+The project appears to have gone quiet after 2021. The website (`myodemocracy.org`) is no longer reachable and no public code repository has been found. The Meetup group, Facebook page, and LinkedIn company page remain but are dormant.
+
+## Links
+
+- [Original 2019 DOD presentation](../blog/posts/2019-05-15.md) (includes YouTube recording)
+- [Danny Johnson on Medium](https://medium.com/@danny.johnson)
+- [MYO Democracy Meetup group](https://www.meetup.com/MYODemocracy/)

--- a/docs/projects/polari.md
+++ b/docs/projects/polari.md
@@ -1,0 +1,55 @@
+---
+title: Polari — Open Source Research & Democracy Platform
+template: project.html
+status: active
+contributors:
+  - Dausume
+website: https://github.com/dausume/Polari-Framework
+summary: "A self-hosted, modular research framework with a built-in policy scoring system — allowing communities to directly rate and analyse policies, politicians, and special interest groups using a participatory democratic methodology."
+---
+
+Polari is a project by DOD member Dustin ("Dausume"), a Full Stack Engineer based in the US. It consists of two interconnected open-source platforms: a general-purpose research framework and a democracy/policy scoring application built on top of it.
+
+## The two platforms
+
+### Polari Research Framework
+
+Polari is a backend infrastructure tool that solves a common problem in open-source research: integrating multiple Python libraries into a coherent, persistent system. You define your data objects in Python; Polari automatically generates:
+
+- A **SQLite database** for persistence
+- A **Falcon REST API** for all configured objects
+- A modular node/tree architecture that lets multiple research systems interconnect
+
+An Angular frontend (`polari-platform-angular`) provides a UI layer with table and graph configuration, mapping (GeoJSON/map tiles), light/dark mode, and a no-code interface for basic workflows. The whole stack deploys via Docker Compose with official images (`dausume/polari:python`, `dausume/polari:angular`).
+
+The design is deliberately modular — domain-specific modules (geocoding, geospatial, materials science) plug into the same backbone. The democracy platform is one such module.
+
+### Democracy Platform / Policy Scorecard
+
+Built on the Polari backbone, the Democracy Platform is a direct scoring and analysis system for policies and the actors involved in them. The intent:
+
+- Citizens can **directly rate policies** across configurable dimensions
+- The same scoring applies to **politicians and special interest groups** based on their involvement in policy development
+- The system is designed as an alternative route to **participatory policy design** — not just voting on existing proposals, but enabling communities to draft and evaluate policies themselves
+
+The scoring methodology and database design are described in a pitch deck (available on request); the frontend prototype (`American-Scorecard-Frontend`) demonstrates the interface approach.
+
+## Current status
+
+Actively developed — Dustin commits regularly, with work through May 2026 on:
+
+- Mapping and graphing capabilities
+- No-code/flow-design UI (backend substantially complete)
+- Docker deployment improvements (`polari-node`, `polari-suite`)
+- Angular version updates and dependency maintenance
+
+The platform is at an early version (0.0.1) and primarily seeking contributors and early adopters willing to help mature the no-code interface and policy scoring modules.
+
+## Get involved
+
+- **Backend:** [github.com/dausume/Polari-Framework](https://github.com/dausume/Polari-Framework) (Python, GPL-3.0)
+- **Frontend:** [github.com/dausume/polari-platform-angular](https://github.com/dausume/polari-platform-angular) (TypeScript/Angular)
+- **Deployment:** [github.com/dausume/polari-node](https://github.com/dausume/polari-node) (Docker Compose)
+- Raise it in the [DOD community channels](../community/community.md)
+
+See also the [original introduction post from September 2023](../blog/posts/2023-09-10.md).


### PR DESCRIPTION
## Summary

- Adds `docs/projects/polari.md` — a substantive project page for DOD member Dustin ("Dausume") covering his two interconnected platforms:
  - **Polari Framework** — modular Python backend that auto-generates REST APIs and SQLite databases from object definitions; Docker-first deployment; actively developed (commits as of May 2026)
  - **Democracy/Policy Scorecard** — civic application built on Polari for direct citizen scoring of policies, politicians, and special interest groups; designed for participatory policy design
- Updates the 2023 blog post to link through to the new project page

## Test plan

- [ ] Polari appears in the Active Projects section on the home page
- [ ] Polari appears on the `/projects/` index page with correct status badge
- [ ] Blog post 2023-09-10 links to the project page correctly
- [ ] GitHub repo links are correct

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_