### PR TITLE
Tighten concept pages: remove unsourced claims, add disclaimer, trim to pointer format

### DIFF
--- a/docs/concepts/cognitive-division-of-labour.md
+++ b/docs/concepts/cognitive-division-of-labour.md
@@ -2,44 +2,18 @@
 title: Cognitive Division of Labour
 ---
 
-Cognitive division of labour is the idea that, in any complex society, it is impossible for all people to have well-formed views on all questions — and that democratic systems therefore need mechanisms for navigating *who decides what, and how*.
+The idea, from economist Joseph Schumpeter, that in a complex society not everyone can have well-formed views on all questions — and that democratic systems therefore need mechanisms for navigating who decides what.
 
-The concept was articulated by the Austrian economist Joseph Schumpeter in *Capitalism, Socialism and Democracy* (1943) and developed in the Australian democracy reform context by economist Nicolas Gruen, who presented it at a [2017 Designing Open Democracy event](../blog/posts/2017-08-21-podcast.md).
-
-## Schumpeter's framing
-
-Schumpeter observed that most citizens, most of the time, simply do not have detailed knowledge of most policy questions. This is not a failure of intelligence or civic virtue — it is an unavoidable consequence of complexity. Just as an economy requires specialisation (not everyone can be expert in everything), democratic governance requires some form of cognitive specialisation.
-
-The problem is that electoral democracy, as it evolved, did not design a good answer to this challenge. Instead it produced what Gruen called **"vox pop democracy"** — finding out what people think *before* they think, in the sense that mass media and electoral campaigns capture reactive public emotion rather than considered public judgement.
-
-## The electoral shortcut and its costs
-
-Elections, Gruen argued, are a competitive and aristocratic mechanism — they tend to select people who are good at winning elections, a distinct skill from governing or deliberating. Because voting is individually irrational (the chance of casting the decisive vote is infinitesimal), political engagement is driven almost entirely by emotion: solidarity, identity, outrage, aspiration.
-
-In Gruen's framing, politics is run by *emotive force* rather than considered judgement — soundbites get through, complex arguments don't, and cultural conflict strengthens because it reliably activates the emotions that drive political engagement.
-
-As he put it at the [2017 DOD event](../blog/posts/2017-08-21-podcast.md): "The magic trick is that the reason for current troubles is because the pollies are the bad guys. But we are getting exactly what we're asking for."
-
-## Citizen juries as a response
-
-Gruen's proposed response was to supplement elected chambers with bodies selected by [sortition](sortition.md) — randomly selected citizen juries operating like judicial juries:
-
-- A jury's job is not to *beat* anyone but to *reach a conclusion*
-- Jury deliberation is "democratic in the sense of equality of speech, not freedom of speech" — everyone has an equal voice in the room, not just the loudest
-- Jurors are not performing for an audience or an election; they are working toward a shared answer
-
-Schumpeter's insight, applied this way, suggests that the appropriate division of cognitive labour in a democracy involves *some* decisions being made by competitive election (legitimacy, representation, accountability) and *some* by deliberative lottery (quality, considered judgement, public values).
-
-The division is not about expertise vs. the public — it is about which *institutional form* is likely to produce which kind of reasoning.
-
-## Relationship to other concepts
-
-- [Sortition](sortition.md) — the mechanism Gruen proposed for addressing cognitive division of labour
-- [Citizens' Assembly](citizens-assembly.md) — the applied form of deliberative sortition
-- [Isegoria](isegoria.md) — Nicolas Gruen's related concept: equal voice as a democratic value
-- [Vox pop democracy](../blog/posts/2017-08-21-podcast.md) — the failure mode this concept diagnoses
+Developed in the Australian context by economist Nicolas Gruen at the [2017 Designing Open Democracy event](../blog/posts/2017-08-21-podcast.md). Gruen argued that elections are a competitive mechanism that rewards emotional mobilisation over considered judgement, and proposed supplementing elected chambers with citizen juries selected by sortition as a way of addressing this. As he put it: *"The magic trick is that the reason for current troubles is because the pollies are the bad guys. But we are getting exactly what we're asking for."*
 
 ## Further reading
 
-- Nicolas Gruen's 2017 DOD presentation: [recording and notes](../blog/posts/2017-08-21-podcast.md)
+- [Nicolas Gruen's 2017 DOD presentation](../blog/posts/2017-08-21-podcast.md) — recording and full notes
 - Joseph Schumpeter, *Capitalism, Socialism and Democracy* (1943)
+- [Nicolas Gruen — Wikipedia](https://en.wikipedia.org/wiki/Nicholas_Gruen)
+
+## See also
+
+- [Sortition](sortition.md)
+- [Citizens' Assembly](citizens-assembly.md)
+- [Isegoria](isegoria.md)

--- a/docs/concepts/cognitive-division-of-labour.md
+++ b/docs/concepts/cognitive-division-of-labour.md
@@ -42,4 +42,4 @@ The division is not about expertise vs. the public — it is about which *instit
 ## Further reading
 
 - Nicolas Gruen's 2017 DOD presentation: [recording and notes](../blog/posts/2017-08-21-podcast.md)
-- Joseph Schumpeter, *Capitalism, Socialism and Democracy* (1943), Part IV
+- Joseph Schumpeter, *Capitalism, Socialism and Democracy* (1943)

--- a/docs/concepts/cognitive-division-of-labour.md
+++ b/docs/concepts/cognitive-division-of-labour.md
@@ -14,11 +14,11 @@ The problem is that electoral democracy, as it evolved, did not design a good an
 
 ## The electoral shortcut and its costs
 
-Elections, Gruen argued, are a competitive and aristocratic mechanism — they select people who are good at winning elections, which is a distinct skill from being good at governing or deliberating. Because voting is individually irrational (the chance of casting the decisive vote is infinitesimal), political engagement is driven almost entirely by emotion: solidarity, identity, outrage, aspiration.
+Elections, Gruen argued, are a competitive and aristocratic mechanism — they tend to select people who are good at winning elections, a distinct skill from governing or deliberating. Because voting is individually irrational (the chance of casting the decisive vote is infinitesimal), political engagement is driven almost entirely by emotion: solidarity, identity, outrage, aspiration.
 
-The result: politics is run by *emotive force*, and the cognitive content of democratic deliberation is low. Soundbites get through; complex arguments don't. Cultural war strengthens because it plays on emotions that politics can reliably activate.
+In Gruen's framing, politics is run by *emotive force* rather than considered judgement — soundbites get through, complex arguments don't, and cultural conflict strengthens because it reliably activates the emotions that drive political engagement.
 
-This is not because politicians are villains — it is because the system optimises for emotional mobilisation rather than considered judgement. "The magic trick," Gruen observed, "is that the reason for current troubles is because the pollies are the bad guys. But we are getting exactly what we're asking for."
+As he put it at the [2017 DOD event](../blog/posts/2017-08-21-podcast.md): "The magic trick is that the reason for current troubles is because the pollies are the bad guys. But we are getting exactly what we're asking for."
 
 ## Citizen juries as a response
 

--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -5,13 +5,17 @@ title: Concepts
 
 A reference collection of concepts relevant to open democracy — from foundational ideas to specific mechanisms and organisational forms.
 
+These pages aim to describe and explain concepts discussed in the democracy reform space. They do not represent DOD endorsement of any particular approach. DOD is nonpartisan and agnostic to any specific democratic model. Some pages draw on secondary sources beyond DOD's own discussions; in those cases, content reflects editorial summaries rather than DOD positions.
+
 ## Democratic theory and critique
 
 | Article | Summary |
 |---|---|
 | [Accountability Sink](accountability-sink.md) | Structural feature of organisations that absorbs consequences so no one can be held responsible — and why it matters for democratic design |
+| [Cognitive Division of Labour](cognitive-division-of-labour.md) | Schumpeter and Gruen's concept: not everyone can have views on everything — democratic systems need mechanisms for navigating who decides what |
 | [Cybernetic Governance](cybernetic-governance.md) | Applying Stafford Beer's Viable System Model to diagnose and redesign governance — feedback loops, complexity, and adaptation |
 | [Isegoria](isegoria.md) | Ancient Greek principle of equal political voice — and why elections undermine it while citizens' juries restore it |
+| [Tribal Epistemology](tribal-epistemology.md) | When group identity determines what people believe rather than evidence — and the implications for democratic deliberation |
 
 ## Core democracy concepts
 
@@ -29,7 +33,9 @@ A reference collection of concepts relevant to open democracy — from foundatio
 | Article | Summary |
 |---|---|
 | [Citizens' Assembly](citizens-assembly.md) | Randomly selected citizens deliberate on policy questions |
+| [Consensus Mapping](consensus-mapping.md) | Surfacing areas of public agreement at scale rather than amplifying disagreement — used in Taiwan's vTaiwan process |
 | [Issue-Based Direct Democracy](issue-based-direct-democracy.md) | The Flux Party's mechanism — voting on individual bills with delegable votes and political capital for abstaining |
+| [Radical Transparency](radical-transparency.md) | Governance practice of making all processes and decisions public by default and in real time |
 | [Liquid Democracy](liquid-democracy.md) | Voting system combining direct participation with transitive, revocable delegation |
 | [Prediction Markets](prediction-markets.md) | Markets where participants bet on policy outcomes to aggregate dispersed knowledge — applied to democratic deliberation |
 | [Sortition](sortition.md) | Selection of officials or jurors by random lot |
@@ -42,6 +48,7 @@ A reference collection of concepts relevant to open democracy — from foundatio
 
 | Article | Summary |
 |---|---|
+| [Economic Democracy](economic-democracy.md) | Extending democratic principles into economic institutions — cooperative and mutual forms vs. shareholder-primacy structures |
 | [Workplace Democracy](workplace-democracy.md) | Democratic decision-making structures within organisations |
 | [Worker Cooperatives](worker-cooperatives.md) | Businesses owned and governed by their workers |
 | [Community Business](community-business.md) | Enterprises owned and run by local communities |

--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -5,7 +5,7 @@ title: Concepts
 
 A reference collection of concepts relevant to open democracy — from foundational ideas to specific mechanisms and organisational forms.
 
-These pages aim to describe and explain concepts discussed in the democracy reform space. They do not represent DOD endorsement of any particular approach. DOD is nonpartisan and agnostic to any specific democratic model. Some pages draw on secondary sources beyond DOD's own discussions; in those cases, content reflects editorial summaries rather than DOD positions.
+These pages are discovery aids — brief orientations to help you find better sources, not authoritative explanations. Content comes from DOD member discussions and events where noted, and points outward to external sources for depth. DOD is nonpartisan and agnostic to any specific democratic model; inclusion of a concept here is not an endorsement.
 
 ## Democratic theory and critique
 

--- a/docs/concepts/consensus-mapping.md
+++ b/docs/concepts/consensus-mapping.md
@@ -14,7 +14,7 @@ The result is that decision-makers receive a distorted picture of public opinion
 
 The most widely used implementation is **[Pol.is](../organisations/polis.md)**, an open-source opinion-mapping tool developed in the US and used extensively in Taiwan's [vTaiwan](../organisations/vtaiwan.md) process.
 
-Rather than open-ended comment threads, Pol.is shows participants a series of statements and asks them to agree, disagree, or pass. As responses accumulate, a dimensionality-reduction algorithm (PCA) clusters participants into groups with similar response patterns. The visualisation reveals:
+Rather than open-ended comment threads, Pol.is shows participants a series of statements and asks them to agree, disagree, or pass. As responses accumulate, a clustering algorithm groups participants with similar response patterns. The visualisation reveals:
 
 - Which positions command broad agreement across all clusters
 - Which positions are contested between clusters

--- a/docs/concepts/consensus-mapping.md
+++ b/docs/concepts/consensus-mapping.md
@@ -2,43 +2,18 @@
 title: Consensus Mapping
 ---
 
-Consensus mapping is an approach to large-scale public deliberation that surfaces areas of agreement across a population rather than amplifying disagreement. It is distinct from polling (which measures the distribution of views) and from open comment threads (which tend to be dominated by the most vocal and polarised participants).
+An approach to large-scale public deliberation that surfaces areas of agreement across a population rather than amplifying disagreement — distinct from polling and from open comment threads, which tend to amplify the most vocal and polarised voices.
 
-## The problem it addresses
+The main implementation is **[Pol.is](../organisations/polis.md)**, used extensively in Taiwan's [vTaiwan](../organisations/vtaiwan.md) process. The [Taiwan digital democracy post](../blog/posts/2026-05-25-taiwan-digital-democracy.md) covers how it worked in practice, including the Uber regulation case.
 
-Standard online public consultation produces noise. Comment fields fill with repetitive arguments; extreme positions attract disproportionate attention; genuine points of consensus are invisible within the volume. Worse, platforms optimised for engagement (social media, open forums) actively reward conflict — disagreement generates more interaction than agreement.
+## Further reading
 
-The result is that decision-makers receive a distorted picture of public opinion: they see what people fight about, not what they agree on. And what people agree on is often the more useful input for policy.
-
-## How it works
-
-The most widely used implementation is **[Pol.is](../organisations/polis.md)**, an open-source opinion-mapping tool developed in the US and used extensively in Taiwan's [vTaiwan](../organisations/vtaiwan.md) process.
-
-Rather than open-ended comment threads, Pol.is shows participants a series of statements and asks them to agree, disagree, or pass. As responses accumulate, a clustering algorithm groups participants with similar response patterns. The visualisation reveals:
-
-- Which positions command broad agreement across all clusters
-- Which positions are contested between clusters
-- Where unexpected cross-partisan consensus exists
-
-The key design insight: participants can only respond to existing statements, not generate new ones freely. This removes the amplification dynamic. A statement with one loud proponent shows up as one data point; a statement that 70% of participants agree with across all clusters is immediately visible.
-
-## In practice: vTaiwan and the Uber case
-
-Taiwan's [vTaiwan](../organisations/vtaiwan.md) process used Pol.is for public consultations on contested policy questions including ride-sharing regulation, online alcohol sales, and fintech.
-
-In the Uber consultation, Pol.is results showed that most participants — across pro-Uber and pro-taxi clusters — agreed on safety requirements, insurance obligations, and worker protections. The areas of genuine disagreement were narrower than the noise suggested. The regulation that followed drew on those consensus points.
-
-The process also surfaced positions that cut across conventional political lines — agreements that would never have appeared in a partisan framing of the debate.
-
-## Relationship to other deliberative approaches
-
-Consensus mapping scales differently from [citizens' assemblies](citizens-assembly.md): it can involve thousands of participants rather than dozens, and at much lower cost. But it produces a different kind of output — a map of opinion structure rather than a deliberated recommendation.
-
-The two approaches complement each other: consensus mapping can identify the shape of the landscape; a citizens' assembly can then deliberate on the contested terrain.
+- [Pol.is documentation](https://pol.is/home)
+- [vTaiwan case studies](https://info.vtaiwan.tw/)
 
 ## See also
 
-- [Pol.is](../organisations/polis.md) — the main open-source implementation
-- [vTaiwan](../organisations/vtaiwan.md) — the most documented application
-- [Citizens' Assembly](citizens-assembly.md) — complementary deliberative approach
-- [Radical Transparency](radical-transparency.md) — related concept from Taiwan's digital democracy practice
+- [Pol.is](../organisations/polis.md)
+- [vTaiwan](../organisations/vtaiwan.md)
+- [Citizens' Assembly](citizens-assembly.md)
+- [Radical Transparency](radical-transparency.md)

--- a/docs/concepts/economic-democracy.md
+++ b/docs/concepts/economic-democracy.md
@@ -28,7 +28,7 @@ Related forms include **mutuals** (member-owned financial institutions), **emplo
 
 Melbourne-based cooperative entrepreneur Antony McMullen presented this framing at a [2020 Designing Open Democracy podcast](../blog/posts/2020-06-20-podcast.md), in the context of the Australian banking royal commission — which had exposed misconduct at major banks driven by the shareholder-primacy model.
 
-McMullen's argument: the failure was structural, not just behavioural. Customer-owned banks (mutuals) and cooperatives did not exhibit the same misconduct because their governance structure aligned decision-making authority with member interests rather than investor returns.
+McMullen's argument was that the failure was structural, not just behavioural — that governance structures aligned to investor returns create different incentives than member-owned structures.
 
 McMullen co-founded **Co-operative Bonds** (a cooperative development consultancy), **888 Co-operative Causeway** (a Melbourne cooperative network), and the **Co-op Incubator**.
 

--- a/docs/concepts/economic-democracy.md
+++ b/docs/concepts/economic-democracy.md
@@ -2,39 +2,23 @@
 title: Economic Democracy
 ---
 
-Economic democracy is the extension of democratic principles into economic institutions — ownership structures, corporate governance, and the distribution of economic power — rather than limiting democracy to political institutions alone.
+The extension of democratic principles into economic institutions — ownership structures, corporate governance, and the distribution of economic power — rather than limiting democracy to political institutions alone.
 
-The term distinguishes a structural approach from Corporate Social Responsibility (CSR): CSR asks corporations to behave well within their existing ownership and governance structure; economic democracy asks whether that structure itself is democratic.
+Distinct from Corporate Social Responsibility (CSR): CSR asks corporations to behave well within their existing governance structure; economic democracy asks whether that structure itself should be democratic.
 
-## The core distinction
+The main forms in practice are cooperatives (worker-owned, consumer-owned, or multi-stakeholder), mutuals, and employee ownership trusts.
 
-In a standard corporation, decision-making power flows from capital ownership. Shareholders elect directors; directors appoint management; management directs labour. Workers, customers, and communities affected by corporate decisions have no formal role in governance — their interests are considered only insofar as management chooses to consider them, or insofar as regulation compels it.
+Presented at a [2020 Designing Open Democracy podcast](../blog/posts/2020-06-20-podcast.md) by Antony McMullen of [Co-operative Bonds](../organisations/cooperative-bonds.md), in the context of the Australian banking royal commission.
 
-CSR and ESG frameworks operate within this structure: they ask managers to voluntarily weigh non-shareholder interests, or require disclosure. But the governance structure itself — capital in command — remains unchanged.
+## Further reading
 
-Economic democracy asks a different question: what would it look like to design economic institutions where those affected by decisions have a formal, structural role in making them?
-
-## Forms in practice
-
-The most developed form is the **cooperative**, in which the enterprise is owned and governed by its members — workers, customers, or both:
-
-- **Worker cooperatives** — employees own and govern the firm collectively; decisions about wages, investment, and direction are made by the workforce
-- **Consumer cooperatives** — members are customers; governance reflects member interests rather than investor interests
-- **Multi-stakeholder cooperatives** — governance is shared across workers, customers, and community representatives
-
-Related forms include **mutuals** (member-owned financial institutions), **employee ownership trusts**, and **community benefit societies**.
-
-## The Australian context
-
-Melbourne-based cooperative entrepreneur Antony McMullen presented this framing at a [2020 Designing Open Democracy podcast](../blog/posts/2020-06-20-podcast.md), in the context of the Australian banking royal commission — which had exposed misconduct at major banks driven by the shareholder-primacy model.
-
-McMullen's argument was that the failure was structural, not just behavioural — that governance structures aligned to investor returns create different incentives than member-owned structures.
-
-McMullen co-founded **Co-operative Bonds** (a cooperative development consultancy), **888 Co-operative Causeway** (a Melbourne cooperative network), and the **Co-op Incubator**.
+- [Co-operative Bonds](https://bonds.coop) — Antony McMullen's consultancy
+- [Business Council of Co-operatives and Mutuals](https://bccm.coop/)
+- [Economic democracy — Wikipedia](https://en.wikipedia.org/wiki/Economic_democracy)
 
 ## See also
 
 - [Worker Cooperatives](worker-cooperatives.md)
-- [Workplace Democracy](workplace-democracy.md)
-- [Community Business](community-business.md)
 - [Cooperative](cooperative.md)
+- [Workplace Democracy](workplace-democracy.md)
+- [888 Co-operative Causeway](../organisations/888-cooperative-causeway.md)

--- a/docs/concepts/economic-democracy.md
+++ b/docs/concepts/economic-democracy.md
@@ -32,12 +32,6 @@ McMullen's argument: the failure was structural, not just behavioural. Customer-
 
 McMullen co-founded **Co-operative Bonds** (a cooperative development consultancy), **888 Co-operative Causeway** (a Melbourne cooperative network), and the **Co-op Incubator**.
 
-## Connection to political democracy
-
-Economic democracy and political democracy are not separate domains. Economic inequality affects political participation: those with greater economic resources have greater capacity to influence political processes, fund campaigns, and shape public discourse. Concentrated corporate power creates interests capable of dominating regulatory agencies, lobbying legislatures, and setting the terms of policy debate.
-
-From this perspective, extending democratic governance into economic institutions is not a separate project from democratic reform — it is part of the same project. Cooperatives and mutuals are, among other things, institutions that distribute economic power more widely, which tends to distribute political power more widely too.
-
 ## See also
 
 - [Worker Cooperatives](worker-cooperatives.md)

--- a/docs/concepts/radical-transparency.md
+++ b/docs/concepts/radical-transparency.md
@@ -8,7 +8,7 @@ The term distinguishes this approach from ordinary transparency (publishing docu
 
 ## The Taiwan example
 
-The clearest contemporary example is Taiwan under digital minister Audrey Tang (2016–2024). Key practices:
+The clearest contemporary example is Taiwan under former digital minister Audrey Tang. Key practices:
 
 - **Cabinet meetings live-streamed** in full, available to anyone in real time
 - **Verbatim transcripts published** — not edited summaries but the actual words spoken
@@ -17,7 +17,7 @@ The clearest contemporary example is Taiwan under digital minister Audrey Tang (
 
 The effect is to change what participants are willing to say and do. When every word of a meeting is published verbatim, officials cannot later misrepresent what was decided or why. Stakeholders who participate in consultation processes cannot claim privately to government that they hold different positions than they stated publicly.
 
-Tang described this as "sunlight as disinfectant" — the exposure itself changes behaviour, not just the availability of information after the fact.
+The exposure itself changes behaviour, not just the availability of information after the fact.
 
 ## Why it matters
 

--- a/docs/concepts/radical-transparency.md
+++ b/docs/concepts/radical-transparency.md
@@ -2,43 +2,17 @@
 title: Radical Transparency
 ---
 
-Radical transparency is a governance practice in which government processes, meetings, and decisions are made fully and immediately public — not through selective disclosure or after-the-fact summaries, but by default and in real time.
+A governance practice in which government processes, meetings, and decisions are made fully and immediately public by default — not through selective disclosure or after-the-fact summaries.
 
-The term distinguishes this approach from ordinary transparency (publishing documents, FOI requests, annual reports) by its scope and proactivity. Ordinary transparency makes information *available*; radical transparency makes it *inescapable*.
+The most cited example is Taiwan under former digital minister Audrey Tang: cabinet meetings live-streamed, verbatim transcripts published, and vTaiwan consultation data made openly available. Covered in the [Taiwan digital democracy post](../blog/posts/2026-05-25-taiwan-digital-democracy.md).
 
-## The Taiwan example
+## Further reading
 
-The clearest contemporary example is Taiwan under former digital minister Audrey Tang. Key practices:
-
-- **Cabinet meetings live-streamed** in full, available to anyone in real time
-- **Verbatim transcripts published** — not edited summaries but the actual words spoken
-- **vTaiwan consultations published openly** — all Pol.is data, participant clusters, and reasoning made public, not just the conclusions
-- **Government responses to civic proposals** published with the same visibility as the proposals themselves
-
-The effect is to change what participants are willing to say and do. When every word of a meeting is published verbatim, officials cannot later misrepresent what was decided or why. Stakeholders who participate in consultation processes cannot claim privately to government that they hold different positions than they stated publicly.
-
-The exposure itself changes behaviour, not just the availability of information after the fact.
-
-## Why it matters
-
-Standard transparency operates through accountability after the fact: documents can be requested, decisions can be reviewed, officials can be questioned in retrospect. This creates incentives to be careful about what is written down while allowing what is *said* in meetings to remain opaque.
-
-Radical transparency removes that gap. If meetings are published verbatim, the informal conversation *is* the record. This shifts the incentive structure for everyone in the room.
-
-It also changes the relationship between government and civic society: when the process is genuinely open, civic tech communities like [g0v](../organisations/g0v.md) can meaningfully audit, extend, and participate in it — rather than working from after-the-fact summaries that may be incomplete or selective.
-
-## Tensions and limits
-
-Radical transparency is not without costs:
-
-- **Candour in deliberation.** Decision-makers may speak differently when they know every word is public. Some argue this reduces honest deliberation; others argue it reduces strategic dishonesty.
-- **Information overload.** Publishing everything makes selection and interpretation more important, not less — someone still decides what to highlight.
-- **Participant safety.** Not all participants in public consultations want their views publicly attached to their identity, particularly on contested issues.
-
-Taiwan's approach addressed some of these by publishing *aggregate* Pol.is data (clusters, not individual responses) while keeping individual votes private — combining openness about the process with privacy for participants.
+- [Audrey Tang on radical transparency](https://en.wikipedia.org/wiki/Audrey_Tang)
+- [vTaiwan process documentation](https://info.vtaiwan.tw/)
 
 ## See also
 
-- [vTaiwan](../organisations/vtaiwan.md) — consultation platform using radical transparency principles
-- [g0v](../organisations/g0v.md) — civic tech community that helped develop and audit Taiwan's open government tools
-- [Consensus Mapping](consensus-mapping.md) — related approach for surfacing public opinion openly
+- [vTaiwan](../organisations/vtaiwan.md)
+- [g0v](../organisations/g0v.md)
+- [Consensus Mapping](consensus-mapping.md)

--- a/docs/concepts/tribal-epistemology.md
+++ b/docs/concepts/tribal-epistemology.md
@@ -2,40 +2,17 @@
 title: Tribal Epistemology
 ---
 
-Tribal epistemology is the condition in which group membership determines what people believe — where the truth of a claim is assessed not by evidence or reasoning but by whether it is endorsed by one's political or social tribe.
+The condition in which group membership determines what people believe — where truth is assessed by whether a claim is endorsed by one's political tribe rather than by evidence or reasoning.
 
-The term describes a situation where the normal epistemic tools — evidence, argument, expert consensus — are effectively bypassed by identity. What "we" believe is true; what "they" believe is false; and any evidence that contradicts tribal belief is suspect by definition.
+Discussed at the [2019 DOD session on trust](../blog/posts/2019-12-11-podcast.md) in the context of how factual fragmentation undermines democratic deliberation.
 
-## How it develops
+## Further reading
 
-Tribal epistemology is not simply tribalism or partisanship. People have always held group loyalties that affect their views. The specific condition of tribal epistemology develops when:
-
-1. **Information is sorted by tribe.** Different communities receive different factual accounts of the same events, from sources that cater to their prior beliefs. The result is not disagreement about values — it is disagreement about facts.
-
-2. **Trust is intra-tribal.** People trust sources endorsed by their tribe and distrust sources endorsed by the opposing tribe. Expert consensus from institutions perceived as belonging to the other tribe carries negative weight — it is evidence *against* a claim, not for it.
-
-3. **Correction is impossible.** Because corrections come from sources that are inherently distrusted, they cannot update beliefs. The correction itself becomes further evidence of conspiracy or bias.
-
-Discussed at a [2019 Designing Open Democracy session on trust](../blog/posts/2019-12-11-podcast.md), tribal epistemology was connected to broader questions about how democratic deliberation can function when citizens' factual premises are systematically divergent.
-
-## Relationship to democratic governance
-
-Democratic deliberation presupposes some shared epistemic ground — some common set of facts that participants can reason from together. Tribal epistemology erodes this ground. When large portions of the population hold incompatible factual beliefs — not just incompatible values — the mechanisms of democratic persuasion (debate, evidence, argument) break down.
-
-This connects to the [cognitive division of labour](cognitive-division-of-labour.md) problem: electoral democracy is driven by emotive force rather than considered judgement, and tribal epistemology is partly a consequence of that dynamic. When political identity is the dominant lens through which all information is filtered, the emotion of tribal solidarity overwhelms the truth-seeking that deliberation requires.
-
-## Possible responses
-
-Responses to tribal epistemology generally fall into two categories:
-
-**Structural:** Create deliberative institutions that remove participants from their tribal context — [citizens' assemblies](citizens-assembly.md) and juries work partly because participants are taken out of the normal media and social environment, given shared information, and required to reason together toward a conclusion. The shared deliberative context partially substitutes for the shared epistemic context that tribal epistemology has eroded.
-
-**Epistemic:** Improve media literacy, support trusted civic institutions, create shared spaces for cross-partisan dialogue. These are slower and harder — tribal epistemology tends to be self-reinforcing — but may address root causes rather than symptoms.
-
-Neither approach fully resolves the problem; it is ongoing terrain in democratic theory and practice.
+- [Tribal epistemology — Vox](https://www.vox.com/2017/3/22/14762030/tribal-epistemology-explained)
+- [Epistemology — Stanford Encyclopedia of Philosophy](https://plato.stanford.edu/entries/epistemology/)
 
 ## See also
 
-- [Cognitive Division of Labour](cognitive-division-of-labour.md) — the broader context for why democratic deliberation defaults to emotion
-- [Citizens' Assembly](citizens-assembly.md) — a structural response to epistemically fragmented publics
-- [Consensus Mapping](consensus-mapping.md) — finding shared ground across polarised positions at scale
+- [Cognitive Division of Labour](cognitive-division-of-labour.md)
+- [Citizens' Assembly](citizens-assembly.md)
+- [Consensus Mapping](consensus-mapping.md)

--- a/docs/concepts/tribal-epistemology.md
+++ b/docs/concepts/tribal-epistemology.md
@@ -4,7 +4,7 @@ title: Tribal Epistemology
 
 Tribal epistemology is the condition in which group membership determines what people believe — where the truth of a claim is assessed not by evidence or reasoning but by whether it is endorsed by one's political or social tribe.
 
-The term, popularised in US political commentary (particularly by journalist David Roberts), describes a situation where the normal epistemic tools — evidence, argument, expert consensus — are effectively bypassed by identity. What "we" believe is true; what "they" believe is false; and any evidence that contradicts tribal belief is suspect by definition.
+The term describes a situation where the normal epistemic tools — evidence, argument, expert consensus — are effectively bypassed by identity. What "we" believe is true; what "they" believe is false; and any evidence that contradicts tribal belief is suspect by definition.
 
 ## How it develops
 

--- a/docs/organisations/your-party.md
+++ b/docs/organisations/your-party.md
@@ -7,7 +7,7 @@ website: https://www.yourparty.uk
 summary: "A UK political party founded in 2025, notable for using sortition (via the Sortition Foundation) to select delegates to its founding conference — producing a statistically representative membership sample balanced by gender, region, age, ethnicity, and other characteristics."
 ---
 
-Your Party is a UK political party registered with the Electoral Commission in September 2025. It was announced by Jeremy Corbyn and Zarah Sultana following their departures from Labour, reaching 55,000 members by December 2025.
+Your Party is a UK political party ([Wikipedia](https://en.wikipedia.org/wiki/Your_Party_(UK))) registered with the Electoral Commission in September 2025. It was announced by Jeremy Corbyn and Zarah Sultana following their departures from Labour, reaching 55,000 members by December 2025.
 
 Of particular interest to the democracy reform community is the party's use of **sortition** to select conference delegates — a novel application of the principle to internal party governance rather than government institutions.
 


### PR DESCRIPTION
## Summary

Follow-up to #24 — tightens the new concept pages to match DOD's purpose as a discovery/pointer resource rather than an authoritative reference.

- **Remove unsourced claims**: David Roberts attribution, Schumpeter part number, Audrey Tang tenure dates, unverified quote, PCA algorithm detail, unreferenced editorial section on economic democracy
- **Add Wikipedia link** to Your Party org page for factual claims
- **Fix charter-sensitive framing**: McMullen's structural argument attributed to him not stated as fact; Gruen's electoral critique framed as his argument not editorial assertion
- **Concepts index disclaimer**: "These pages are discovery aids — brief orientations to help you find better sources, not authoritative explanations… inclusion of a concept here is not an endorsement."
- **Trim all 5 new concept pages** to short orientation + DOD-sourced content + external links only (162 lines cut)

## Test plan

- [ ] Concepts index shows updated disclaimer
- [ ] Each concept page is short, links outward, and only has depth where sourced from DOD events
- [ ] No unsourced factual claims remain

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_