### PR TITLE
Fill Australian democracy landscape gaps (10 new org pages)

### DIFF
--- a/docs/organisations/australia-institute-democracy.md
+++ b/docs/organisations/australia-institute-democracy.md
@@ -1,0 +1,25 @@
+---
+title: The Australia Institute — Democracy & Accountability Program
+type: research
+status: active
+country: AU
+website: https://australiainstitute.org.au/about/structure/democracy-accountability/
+summary: "A dedicated research and advocacy program within The Australia Institute focused on diagnosing and addressing Australia's democratic deficit — covering truth in political advertising, parliamentary reform, anti-corruption institutions, and campaign finance."
+---
+
+The Democracy & Accountability Program is a dedicated research and advocacy program within [The Australia Institute](https://australiainstitute.org.au), a Canberra-based progressive think tank. Established in 2021, it builds on the Institute's longer history of democracy-related research.
+
+The program is directed by **Bill Browne** and focuses on practical reforms to improve the functioning of Australian democracy.
+
+## Core focus areas
+
+- **Truth in political advertising** — advocates for laws making it illegal to make false claims in political advertising, modelled on South Australia's existing framework; polling has shown large public support
+- **Parliamentary expansion** — research on increasing the size of parliament to improve representation, given each MP now represents significantly more constituents than at Federation
+- **Anti-corruption and integrity** — work on strengthening the National Anti-Corruption Commission, whistleblower protections, and lobbying transparency
+- **Campaign finance** — research on donation disclosure, caps, and spending limits
+- **Senate and parliamentary procedure** — research on the Senate's role, four-year fixed terms, and related reforms
+
+## Links
+
+- Website: [australiainstitute.org.au](https://australiainstitute.org.au/about/structure/democracy-accountability/)
+- Annual review: [Australian Democracy in 2025](https://australiainstitute.org.au/report/australian-democracy-in-2025/)

--- a/docs/organisations/australian-democracy-network.md
+++ b/docs/organisations/australian-democracy-network.md
@@ -1,0 +1,24 @@
+---
+title: Australian Democracy Network
+type: advocacy
+status: active
+country: AU
+website: https://australiandemocracy.org.au
+summary: "A coalition of 200+ Australian civil society organisations working for a fairer, more open, and more accountable democracy — focused on campaign finance reform, protecting civil society advocacy rights, protest rights, and countering disinformation."
+---
+
+The Australian Democracy Network (ADN) is a registered charity and coalition infrastructure body for the Australian democracy reform sector. Founded in 2020 by the Human Rights Law Centre, Australian Conservation Foundation, and Australian Council of Social Service (ACOSS), it operates as a connector and convener — sharing resources, strategy, and campaigns across member organisations rather than acting primarily as a direct-action group.
+
+As of 2024, it has over 200 member civil society organisations and more than 14,000 individual supporters.
+
+## Campaigns and work areas
+
+- **#OurDemocracy** — flagship campaign (run jointly with ACF and HRLC) focused on campaign finance reform: donation disclosure, donation caps, spending limits, and reducing corporate influence in politics
+- **Stronger Charities Alliance** — coalition of 100+ charities focused on protecting the right of civil society organisations to advocate; successfully blocked proposed ACNC legislation that would have restricted charity advocacy
+- **Protest Rights** — cross-sector response to anti-protest laws proliferating across Australian states
+- **Disinformation** — building digital campaigning capacity across civil society
+
+## Links
+
+- Website: [australiandemocracy.org.au](https://australiandemocracy.org.au)
+- #OurDemocracy campaign: [ourdemocracy.com.au](https://www.ourdemocracy.com.au)

--- a/docs/organisations/cafsa.md
+++ b/docs/organisations/cafsa.md
@@ -1,0 +1,34 @@
+---
+title: Citizen Assemblies for South Australia (CAfSA)
+type: advocacy
+status: active
+country: AU
+website: https://cafsa.org.au
+summary: "An Adelaide-based incorporated association advocating for the use of citizens' assemblies in South Australian policy-making, with a cross-partisan advisory board including a former SA Premier, a former Liberal Senator, and the executive director of newDemocracy."
+location:
+  latitude: -34.9285
+  longitude: 138.6007
+  name: Adelaide, Australia
+---
+
+CAfSA is an incorporated association founded in Adelaide in 2023, advocating for randomly selected, broadly representative citizens' assemblies as a policy-making tool in South Australia. The organisation distinguishes citizens' assemblies from traditional consultation, positioning them as particularly suited to contested issues that are difficult for elected politicians to handle directly.
+
+## Advisory board
+
+CAfSA's advisory board is notably cross-partisan:
+
+- **Jay Weatherill AO** — former SA Premier (Labor, 2011–2018)
+- **Simon Birmingham** — former Liberal Senator for SA (2007–2025)
+- **Iain Walker** — Executive Director, [newDemocracy Foundation](newdemocracy.md)
+- **Dr Sonia Randhawa** — [Sortition Foundation Australia](sortition-foundation-australia.md)
+- **David Van Reybrouck** — Belgian cultural historian, founded the G1000 Citizens' Summit, author of *Against Elections*
+
+## Notable activity
+
+- **National Conference "Citizen Assemblies — Policy without Politics"** (June 2025, Woodville Town Hall, Adelaide) — featured Nick Gruen, Tim Dunlop, Jay Weatherill; David Van Reybrouck joined by video link
+- Regular newsletter series *CAfSA News* (from February 2025)
+- Educational resources on citizens' assemblies around the world
+
+## Links
+
+- Website: [cafsa.org.au](https://cafsa.org.au)

--- a/docs/organisations/capad.md
+++ b/docs/organisations/capad.md
@@ -1,0 +1,28 @@
+---
+title: Canberra Alliance for Participatory Democracy (CAPaD)
+type: advocacy
+status: active
+country: AU
+website: https://canberra-alliance.org.au
+summary: "A Canberra-based community nonprofit promoting good governance and civic participation in the ACT through candidate accountability forums, deliberative conversations, and civic education — independently funded and member-run since 2015."
+location:
+  latitude: -35.2809
+  longitude: 149.1300
+  name: Canberra, Australia
+---
+
+CAPaD is an ACT-based community organisation founded in 2015, focused on making elected representatives more accountable and democratic participation more meaningful for Canberra residents. It is independently funded — not by political parties, government, or corporations — and run by a voluntary committee.
+
+## What they do
+
+- **Kitchen Table Conversations** — community self-managed deliberative conversations as an entry point to civic participation
+- **Genuine Engagement Tool (GET)** — a framework for communities to assess government engagement processes
+- **Candidate accountability forums** — ahead of ACT elections, CAPaD develops community-derived assessment questions and runs deliberative forums to help voters evaluate candidates on integrity, community focus, and engagement
+- **Submissions** — to the ACT Parliament, ACT Budget consultations, and federal election inquiries
+- **Newsletter** — *Awakening Democracy* (ongoing since at least 2024)
+
+For the October 2024 ACT election, CAPaD ran three deliberative forums using six community-derived candidate assessment questions focused on integrity, resistance to vested interests, and engagement with marginalised communities.
+
+## Links
+
+- Website: [canberra-alliance.org.au](https://canberra-alliance.org.au)

--- a/docs/organisations/cddgg.md
+++ b/docs/organisations/cddgg.md
@@ -1,0 +1,33 @@
+---
+title: Centre for Deliberative Democracy and Global Governance (CDDGG)
+type: research
+status: active
+country: AU
+website: https://www.canberra.edu.au/research/centres/cddgg
+summary: "A world-leading academic research centre at the University of Canberra focused on deliberative democracy — home of the Journal of Deliberative Democracy, and the institution behind the 2009 Australian Citizens' Parliament."
+location:
+  latitude: -35.2457
+  longitude: 149.0745
+  name: Canberra, Australia
+---
+
+The Centre for Deliberative Democracy and Global Governance (CDDGG) is a research centre within the University of Canberra's Faculty of Business, Government and Law. Founded in 2014 (with earlier roots at ANU), it is one of the leading academic centres for deliberative democracy research globally.
+
+Co-founders include **John Dryzek** (Distinguished Professor) and **Simon Niemeyer**. Current director is **Hans Asenbaum** (from 2026). Other core staff include **Selen Ercan** and **Nicole Curato**.
+
+## Notable outputs
+
+- **Australian Citizens' Parliament (2008–2009)** — Designed and delivered by the centre. 150 randomly selected citizens deliberated at Old Parliament House on the question "How can Australia's political system be strengthened to serve us better?" and produced 13 proposals presented to Parliament.
+- **Journal of Deliberative Democracy** — The flagship journal of the field; the centre is its institutional home, published by University of Westminster Press.
+- **Deliberative Democracy Summer School** — Annual international event at UC.
+
+## Links
+
+- Website: [canberra.edu.au/research/centres/cddgg](https://www.canberra.edu.au/research/centres/cddgg)
+- Journal: [delibdemjournal.org](https://delibdemjournal.org/)
+
+## Related organisations
+
+- [newDemocracy Foundation](newdemocracy.md)
+- [MosaicLab](mosaiclab.md)
+- [DemocracyCo](democracyco.md)

--- a/docs/organisations/community-independents-project.md
+++ b/docs/organisations/community-independents-project.md
@@ -1,0 +1,27 @@
+---
+title: Community Independents Project
+type: advocacy
+status: active
+country: AU
+website: https://www.communityindependentsproject.org
+summary: "The national support and capacity-building body for Australia's community independent candidate movement — a decentralised network of locally organised, non-partisan groups that support community-driven independent candidates for parliament."
+---
+
+The Community Independents Project (CIP) is the coordinating body for Australia's community independent candidate movement — a network of locally organised, non-partisan groups that support community-driven independent candidates at federal, state, and local elections.
+
+The movement originated with **Voices for Indi**, founded in 2012 in the regional Victorian electorate of Indi by Cathy McGowan following a community meeting. McGowan went on to win the seat as an independent in 2013. The model spread gradually and then rapidly: by the 2022 federal election there were roughly 30 groups; by the 2025 federal election there were community groups in over 50 electorates — more than one in three Australian electorates.
+
+## What the movement is
+
+The groups are structurally independent of each other — deliberately so, to avoid the appearance of being a party. Each is locally run and locally funded. The CIP functions as a national network body providing resources, training, and community connection, and hosts an annual national convention.
+
+The movement is non-partisan: it does not endorse candidates based on party or policy platform. Its concern is the *process* by which communities engage with representation — building denser local democratic infrastructure rather than advancing a specific policy agenda.
+
+## Relationship to teal independents
+
+The "teal independents" label was applied by media to a subset of community-backed independents (primarily in inner-metropolitan seats held by the Liberal Party) who ran on climate and integrity platforms in 2022. **Climate 200** is a separate crowdfunding entity that provided financial backing to many of these candidates. The two streams — Voices groups and Climate 200-backed candidates — overlapped but are distinct structures.
+
+## Links
+
+- Website: [communityindependentsproject.org](https://www.communityindependentsproject.org)
+- [Voices movement — Wikipedia](https://en.wikipedia.org/wiki/Voices_movement_(Australia))

--- a/docs/organisations/democracy-in-colour.md
+++ b/docs/organisations/democracy-in-colour.md
@@ -1,0 +1,28 @@
+---
+title: Democracy in Colour
+type: advocacy
+status: active
+country: AU
+website: https://democracyincolour.org
+summary: "Australia's first national racial justice advocacy organisation led by people of colour, campaigning to address structural racism in Australian political, media, and civic institutions and to build the political power of communities of colour."
+---
+
+Democracy in Colour is a registered charity and advocacy organisation focused on racial justice in Australian democracy. Its focus is on *who* participates in democracy — addressing the structural barriers and systemic racism that shape whose voices are heard in political, media, and civic life — rather than procedural democratic reform.
+
+It was founded with Neha Madhok as National Director (approximately 2017–2024); the current National Director is Noura Mansour.
+
+## Campaigns and programs
+
+- **Racism Out of Politics** — flagship campaign targeting racial bias in political discourse
+- **Racism Out of Media** — targeting systemic racism in Australian media coverage
+- **Racial Justice Program** (formerly People of Colour Placement Program) — a leadership pipeline placing people of colour into political and civic institutions
+- **Western Sydney Climate Justice Fellowship** — builds climate leadership among PoC communities in Western Sydney
+- **Melbourne Create Change Fellowship** — similar fellowship for Melbourne-based PoC
+
+## Note on scope
+
+Democracy in Colour's work is distinct from electoral or procedural reform organisations. Its framing is racial justice and political power — changing who has a seat at the table — rather than changes to democratic mechanisms or institutions. It is included here as part of the broader democracy landscape because representation and participation are structural democratic questions.
+
+## Links
+
+- Website: [democracyincolour.org](https://democracyincolour.org)

--- a/docs/organisations/democracyco.md
+++ b/docs/organisations/democracyco.md
@@ -1,0 +1,29 @@
+---
+title: DemocracyCo
+type: practice
+status: active
+country: AU
+website: https://www.democracyco.com.au
+summary: "An Adelaide-based deliberative democracy facilitation practice co-founded by Emily Jenke and Emma Fletcher, designing and delivering citizens' juries and deliberative panels for government and industry across Australia and internationally."
+location:
+  latitude: -34.9285
+  longitude: 138.6007
+  name: Adelaide, Australia
+---
+
+DemocracyCo is one of Australia's most established deliberative democracy practices, providing end-to-end design, facilitation, and project management for citizens' juries, panels, and assemblies. It was co-founded by Emily Jenke and Emma Fletcher — both with backgrounds in SA public service and community engagement — out of a frustration that governments were not achieving quality reform commensurate with the scale of problems faced by communities.
+
+The practice does not advocate a single methodology; it selects approaches suited to each process. Its core principle is that giving citizens genuine influence means committing at the outset to implementing some or all of what they decide.
+
+## Notable processes
+
+- **SA Nuclear Fuel Cycle Citizens' Juries (2016)** — A two-stage process involving 50 then 350 South Australians deliberating on whether SA should store international nuclear waste; described at the time as the world's largest citizens' jury on nuclear waste storage
+- **Citizens' Jury: Sharing the Roads Safely, SA (2014)** — Explored road sharing between motorists and cyclists; facilitated by Emily Jenke
+- **Citizens' Jury: Reducing Unwanted Dogs and Cats, SA** — 50 citizens, 5 days, 13 recommendations, 11 adopted and legislated
+- **Citizens' Assembly on Responsible Social Media Discourse, Bosnia and Herzegovina** — International process designed by DemocracyCo with Sortition Foundation recruitment
+- **The People's House** — An ongoing methodology giving MPs tools to engage randomly selected constituents; piloted in ACT and Victoria
+
+## Related organisations
+
+- [newDemocracy Foundation](newdemocracy.md) — Sydney-based research and practice organisation in the same space
+- [MosaicLab](mosaiclab.md) — Melbourne-based deliberative practice

--- a/docs/organisations/grattan-institute.md
+++ b/docs/organisations/grattan-institute.md
@@ -1,0 +1,27 @@
+---
+title: Grattan Institute
+type: research
+status: active
+country: AU
+website: https://grattan.edu.au
+summary: "A Melbourne-based public policy think tank with a democracy and governance program — producing research on electoral integrity, parliamentary reform, campaign finance, and trust in government. Not democracy-specialist; covers a broad range of policy areas."
+location:
+  latitude: -37.8136
+  longitude: 144.9631
+  name: Melbourne, Australia
+---
+
+The Grattan Institute is a Melbourne-based public policy think tank covering a broad range of policy areas including energy, housing, education, health, and governance. It is independent of government, political parties, and industry.
+
+Grattan has a dedicated democracy and governance program, led by CEO **Dr Aruna Sathanapally** and **Kate Griffiths** (Deputy Program Director, Democracy). Their democracy work covers electoral integrity, campaign finance, parliamentary reform, trust in government, and public appointments.
+
+## Key democracy publications
+
+- **For the People: Future-Proofing Australia's Democracy** (April 2026) — identifies five priority areas including making parliament more representative, building civic engagement, protecting the public sphere, and ensuring government can deliver difficult public-interest reforms against vested interests
+- **Orange Book 2025: Policy Priorities for the Federal Government** — includes a governance chapter supporting donation transparency and caps; critical of the Electoral Reform Bill's expenditure cap as too high
+- Other reports: *Cleaning Up Australian Politics*, *Merit Over Mates: Fixing Public Appointments*, *Here's Who Funded the 2022 Election*
+
+## Links
+
+- Website: [grattan.edu.au](https://grattan.edu.au)
+- Democracy program: [grattan.edu.au/policy/democracy](https://grattan.edu.au/policy/democracy/)

--- a/docs/organisations/sortition-foundation-australia.md
+++ b/docs/organisations/sortition-foundation-australia.md
@@ -1,0 +1,29 @@
+---
+title: Sortition Foundation (Australia)
+type: advocacy
+status: active
+country: AU
+website: https://www.sortitionfoundation.org/become_a_member_australia
+summary: "The Australian chapter of the UK-based Sortition Foundation, running monthly community meetings and providing sortition recruitment services for Australian democratic processes — including Victorian council deliberations, federal electorate pilots, and national citizen assemblies."
+location:
+  latitude: -37.7749
+  longitude: 144.9934
+  name: Preston, Victoria
+---
+
+The Sortition Foundation is a UK-based organisation that campaigns for the use of stratified random selection (sortition) in government, primarily through citizens' assemblies. The Australian chapter operates within that global structure and is established by **Dr Sonia Randhawa**, based in Preston, Victoria, who works as a Project Manager at the Foundation.
+
+The UK Sortition Foundation already has a [landscape entry](sortition-foundation.md). The Australian chapter is noted separately because of its distinct operational activity in Australian democratic processes.
+
+## What the Australian chapter does
+
+- **Monthly online meetings** — second Thursday evening of each month, open to anyone interested
+- **Victorian council recruitment** — assisted 11 Victorian councils in using random selection for deliberative engagement under the Local Government Act
+- **Federal electorate pilots** — ran a service for federal MPs (ACT seat of Canberra, Victorian seat of Casey) randomly selecting voters to help identify electorate priorities
+- **National assemblies** — provided sortition recruitment for the 2025 AMPLIFY National Assembly on Housing: 36,000 invitations sent, 120 participants selected across 11 demographic categories
+- **Education** — developing deliberative democracy curriculum for Australian secondary school students
+
+## Links
+
+- Australian chapter: [sortitionfoundation.org/become_a_member_australia](https://www.sortitionfoundation.org/become_a_member_australia)
+- Parent organisation: [Sortition Foundation (UK)](sortition-foundation.md)


### PR DESCRIPTION
## Summary

Full audit of the Australian democracy landscape coverage identified significant gaps. This PR adds 10 org pages to fill them.

### Practitioners
- **DemocracyCo** — Adelaide deliberative democracy facilitation practice; SA nuclear jury, People's House methodology
- **CDDGG** (University of Canberra) — Journal of Deliberative Democracy; 2009 Australian Citizens' Parliament

### Advocacy / coalitions
- **Australian Democracy Network** — 200+ org coalition; #OurDemocracy campaign finance reform; Stronger Charities Alliance; protest rights
- **Community Independents Project** — coordinating body for the Voices / community independent candidate movement
- **CAfSA** — SA citizens' assembly advocacy; cross-partisan advisory board (Weatherill, Birmingham, Walker, Randhawa, Van Reybrouck)
- **CAPaD** — Canberra-based community nonprofit; candidate forums, Kitchen Table Conversations, GET framework; active since 2015
- **Democracy in Colour** — racial justice / political power org; noted as distinct from procedural reform

### Research
- **Australia Institute Democracy & Accountability Program** — truth in political advertising, parliamentary expansion, anti-corruption research
- **Grattan Institute** — general think tank; "For the People" (2026) is their major democracy reform report

### Sortition
- **Sortition Foundation Australia** — distinct from UK entry; Victorian council recruitment, AMPLIFY housing assembly, federal electorate pilots

## Test plan
- [ ] All 10 pages appear on the Democracy Landscape under correct status
- [ ] Australian section is now substantially more complete for a reader wanting the lay of the land
- [ ] Democracy in Colour page correctly notes it is a racial justice org, not procedural reform

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_