### PR TITLE
Add international democracy org pages and Electoral Reform Act draft post

### DIFF
--- a/docs/blog/posts/2026-05-25-electoral-reform-act-2025.md
+++ b/docs/blog/posts/2026-05-25-electoral-reform-act-2025.md
@@ -1,0 +1,58 @@
+---
+draft: true
+authors:
+  - DOD
+categories:
+  - Policy
+  - Australia
+date: 2026-05-25 00:00:00
+tags:
+  - Electoral Reform
+  - Campaign Finance
+  - Australia
+  - Legislation
+title: "Australia's Electoral Reform Act 2025: What Changed and What's Still Contested"
+summary: "The Electoral Legislation Amendment (Electoral Reform) Act 2025 — royal assent February 2025, commencement deferred to January 2027 — introduces donation caps and lower disclosure thresholds for the first time in federal Australian politics. Here's a summary of the key changes and the ongoing debate."
+---
+
+> **DRAFT — Human review required before publishing.**
+> This post was written as an AI-assisted draft and has not been reviewed for accuracy or framing. Key claims should be verified against primary sources before this is published. In particular: check commencement dates, exact cap figures, and whether the charities exemption status has changed. Do not publish without a human author taking responsibility for the content.
+
+Australia's federal parliament passed the **Electoral Legislation Amendment (Electoral Reform) Act 2025**, receiving royal assent on **20 February 2025**. It represents the most significant change to federal campaign finance law in decades — introducing donation caps and tightening disclosure requirements that have been debated in Australia for many years.
+
+<!-- more -->
+
+## What the Act does
+
+The key changes introduced by the Act:
+
+- **Lower disclosure threshold** — the threshold at which political donations must be disclosed was reduced from approximately $16,900 (the previously indexed figure) to **$5,000**
+- **Donation caps** — introduced caps limiting how much individuals and organisations can donate to political parties and candidates
+- **Electoral expenditure caps** — introduced limits on how much parties and candidates can spend during election campaigns
+- **Faster disclosure** — shortened the time lag between donations occurring and being published on the AEC register
+
+## Delayed commencement
+
+Despite receiving royal assent in February 2025, the commencement of key provisions was subsequently deferred to **1 January 2027**. This was announced in March 2026, meaning a full federal election cycle will pass before the donation caps and new disclosure rules take effect.
+
+## Who advocated for the reforms
+
+The **Australian Democracy Network** (ADN) and its member organisations ran a multi-year campaign, **#OurDemocracy** (jointly with the Australian Conservation Foundation and the Human Rights Law Centre), explicitly calling for donation disclosure, donation caps, and spending limits. The ADN describes the passage of the Act as a significant step.
+
+The **Australia Institute's Democracy & Accountability Program** and the **Grattan Institute's democracy program** had also published research supporting tighter campaign finance rules. Grattan's *Orange Book 2025* supported donation transparency and caps, while being critical of the expenditure cap level as being set too high.
+
+## The charities controversy
+
+After the Act passed, a major point of ongoing controversy emerged: the legislation applies campaign finance restrictions to **charities and civil society organisations** in ways that advocacy groups say treats them like political parties.
+
+The **Stronger Charities Alliance** — a coalition of over 100 charities convened through the ADN's work — called for a **charities exemption** from the spending caps. The concern is that caps designed to limit political party spending would also constrain legitimate civil society advocacy on policy issues, even where those organisations are not running candidates or directly campaigning for parties.
+
+The ADN, which was central to advocating for the Act's passage, subsequently raised this concern publicly — arguing that the implementation needed to be adjusted to distinguish civil society advocacy from electoral spending.
+
+## What comes next
+
+With commencement deferred to 1 January 2027, there is a period before the new rules take effect in which the charities exemption question, and other implementation details, could potentially be addressed. Whether that happens through regulation, AEC guidance, or further legislation remains to be seen.
+
+---
+
+*For context on the organisations working in this space, see the Democracy Landscape pages for the [Australian Democracy Network](../../organisations/australian-democracy-network.md), the [Australia Institute Democracy & Accountability Program](../../organisations/australia-institute-democracy.md), and the [Grattan Institute](../../organisations/grattan-institute.md).*

--- a/docs/organisations/afrobarometer.md
+++ b/docs/organisations/afrobarometer.md
@@ -1,0 +1,26 @@
+---
+title: Afrobarometer
+type: research
+status: active
+country: GH
+website: https://www.afrobarometer.org
+summary: "A pan-African survey research network headquartered in Accra conducting nationally representative surveys on democracy, governance, and quality of life in 35+ African countries — data freely available since 1999."
+location:
+  latitude: 5.6037
+  longitude: -0.1870
+  name: Accra, Ghana
+---
+
+Afrobarometer is a nonpartisan pan-African survey research network founded in 1999 and headquartered in Accra, Ghana. It conducts nationally representative face-to-face surveys in 35+ African countries (covering roughly three-quarters of the continent's population) every two to three years, producing freely accessible data on how Africans experience democracy and governance.
+
+Survey topics cover 21 areas including democratic attitudes, governance responsiveness, electoral behaviour, corruption, economic conditions, and civic participation. Data is open-access, including microdata available in partnership with the World Bank.
+
+## Notable outputs
+
+- Biennial/triennial *African Insights* flagship reports summarising continental democracy trends
+- Country-level reports on each survey round
+- Open microdata library
+
+## Links
+
+- Website: [afrobarometer.org](https://www.afrobarometer.org)

--- a/docs/organisations/aman-palestine.md
+++ b/docs/organisations/aman-palestine.md
@@ -1,0 +1,25 @@
+---
+title: AMAN – Coalition for Accountability and Integrity
+type: advocacy
+status: active
+country: PS
+website: https://www.aman-palestine.org/en
+summary: "Palestine's national anti-corruption and governance integrity coalition — established 2000, accredited as Transparency International's Palestinian chapter in 2006, producing integrity indices, corruption reports, and electoral integrity monitoring."
+---
+
+AMAN (Coalition for Accountability and Integrity) is a Palestinian civil society coalition established in 2000 to promote integrity, transparency, and accountability in Palestinian society. In 2006, AMAN was accredited as Transparency International's official Palestinian national chapter.
+
+AMAN functions as both a civil society coalition and a specialised knowledge centre, producing reports on corruption trends, governance challenges, and electoral integrity in Palestine and the broader Arab region.
+
+## What they do
+
+- Annual Integrity and Anti-Corruption Reports
+- Palestinian Integrity Index
+- National Integrity System studies
+- Electoral integrity monitoring
+- Anti-corruption advocacy and capacity-building
+- International Anti-Corruption Day coordination (9 December)
+
+## Links
+
+- Website: [aman-palestine.org/en](https://www.aman-palestine.org/en)

--- a/docs/organisations/bersih.md
+++ b/docs/organisations/bersih.md
@@ -1,0 +1,27 @@
+---
+title: BERSIH 2.0
+type: advocacy
+status: active
+country: MY
+website: https://bersih.org
+summary: "Malaysia's largest non-partisan coalition for electoral reform — a network of 90+ civil society organisations conducting independent election observation, voter registration drives, and public campaigns for free and fair elections since 2007."
+location:
+  latitude: 3.1569
+  longitude: 101.7123
+  name: Petaling Jaya, Malaysia
+---
+
+BERSIH 2.0 (Coalition for Clean and Fair Elections) is a non-partisan coalition of over 90 Malaysian civil society organisations, formally launched in April 2010 as a continuation of the original BERSIH coalition formed in 2007. It is Malaysia's most prominent electoral reform movement.
+
+BERSIH's work includes independent election observation (with trained observer teams for each general election), voter registration campaigns, and legal and public advocacy for electoral system reform. The coalition has organised major public rallies and produced detailed preliminary and final reports on Malaysian general elections.
+
+## What they do
+
+- Independent election monitoring — online monitors, field observers, media monitors
+- Voter registration and civic education campaigns
+- Electoral reform advocacy and legal action
+- Election observation reports on general elections
+
+## Links
+
+- Website: [bersih.org](https://bersih.org)

--- a/docs/organisations/cdd-west-africa.md
+++ b/docs/organisations/cdd-west-africa.md
@@ -1,0 +1,28 @@
+---
+title: Centre for Democracy and Development (CDD West Africa)
+type: research
+status: active
+country: NG
+website: https://www.cddwestafrica.org
+summary: "An Abuja-based independent research and advocacy organisation focused on democratic governance and human security in West Africa — founded in 1997 to support Nigeria's democratic transition, now a regional hub for policy analysis, electoral integrity, and civil society capacity-building."
+location:
+  latitude: 9.0579
+  longitude: 7.4951
+  name: Abuja, Nigeria
+---
+
+The Centre for Democracy and Development (CDD West Africa) is an independent, non-profit research and advocacy organisation founded in 1997 (and registered in Nigeria in 1999) to support democratic governance and people-centred development across West Africa. It was established during Nigeria's transition from military to civilian rule and has since grown into a regional institution.
+
+CDD operates offices in Abuja, Lagos, Maiduguri, and London. Its work spans policy analysis, electoral integrity, security governance, and capacity-building for civil society organisations.
+
+## What they do
+
+- **CDD Fact Check** — monitoring and countering political misinformation and disinformation
+- Electoral integrity monitoring and training
+- Policy research on democratic governance and economic governance
+- Civil society capacity-building and networking
+- Security governance research, including in conflict-affected states (e.g. North-East Nigeria)
+
+## Links
+
+- Website: [cddwestafrica.org](https://www.cddwestafrica.org)

--- a/docs/organisations/eisa.md
+++ b/docs/organisations/eisa.md
@@ -1,0 +1,27 @@
+---
+title: Electoral Institute for Sustainable Democracy in Africa (EISA)
+type: research
+status: active
+country: ZA
+website: https://www.eisa.org
+summary: "A Johannesburg-based independent non-profit supporting credible elections and strong democratic institutions across Africa — conducting election observation, technical assistance, and governance programming in 16+ African countries since 1996."
+location:
+  latitude: -26.2041
+  longitude: 28.0473
+  name: Johannesburg, South Africa
+---
+
+EISA (Electoral Institute for Sustainable Democracy in Africa) is an independent, non-partisan organisation founded in 1996, headquartered in Johannesburg with a regional office in Abidjan, Côte d'Ivoire. It works across sub-Saharan Africa supporting electoral processes and democratic institution-building.
+
+EISA has supported and observed over 100 electoral and political processes across the continent, operating field presence in 16+ African countries. Its work covers two main areas: Elections and Political Processes (EPP), and Good Governance programming.
+
+## What they do
+
+- Long-term and short-term election observation missions
+- Electoral technical assistance and capacity-building for election management bodies
+- Parliamentary strengthening and political party development
+- Good governance programming at national and regional levels
+
+## Links
+
+- Website: [eisa.org](https://www.eisa.org)

--- a/docs/organisations/lcps.md
+++ b/docs/organisations/lcps.md
@@ -1,0 +1,27 @@
+---
+title: Lebanese Center for Policy Studies (LCPS)
+type: research
+status: active
+country: LB
+website: https://www.lcps-lebanon.org
+summary: "An independent Beirut-based think tank founded in 1989 producing policy research and advocacy on governance, political representation, decentralisation, and electoral reform in Lebanon and the Arab region."
+location:
+  latitude: 33.8938
+  longitude: 35.5018
+  name: Beirut, Lebanon
+---
+
+The Lebanese Center for Policy Studies (LCPS) is an independent, non-partisan think tank founded in 1989 in Beirut. It produces research and advocates for policies aimed at improving governance in Lebanon and the broader Arab region. Its priority areas include political representation, decentralisation, transparency in natural resource governance, job creation, and youth empowerment.
+
+LCPS has published over 66 books and 100+ policy papers and briefs covering electoral law, administrative reform, rule of law, and sectarianism. The centre was instrumental in founding affiliated organisations including the **Lebanese Association for Democratic Elections** (1996) and the **Lebanese Transparency Association** (1999).
+
+## What they do
+
+- Policy research on governance, elections, and political representation
+- Electoral law analysis and reform advocacy
+- Roundtables, public advocacy, and capacity-building
+- Publishing policy papers and books on Arab governance
+
+## Links
+
+- Website: [lcps-lebanon.org](https://www.lcps-lebanon.org)

--- a/docs/organisations/memo98.md
+++ b/docs/organisations/memo98.md
@@ -1,0 +1,27 @@
+---
+title: MEMO 98
+type: research
+status: active
+country: SK
+website: https://memo98.sk
+summary: "A Bratislava-based media monitoring and democratic civic engagement organisation with 25+ years of experience — monitoring media integrity during elections, researching disinformation, and supporting democratic consolidation in post-authoritarian contexts."
+location:
+  latitude: 48.1486
+  longitude: 17.1077
+  name: Bratislava, Slovakia
+---
+
+MEMO 98 is a Slovak organisation founded in 1998 focused on media integrity and democratic civic engagement. It is best known for its election media monitoring work — assessing whether voters have access to quality, balanced information during electoral periods — and has applied this methodology across multiple countries.
+
+MEMO 98 is a member of the **European Platform for Democratic Elections (EPDE)** and joined the **European Partnership for Democracy (EPD)** as a full member in 2024. Its work has expanded to include disinformation research, digital media literacy, and support for democratic information environments in post-authoritarian contexts.
+
+## What they do
+
+- Media monitoring during elections (coverage balance, tone, access)
+- Disinformation and information environment research
+- Digital media literacy and critical thinking programs
+- Capacity building in post-authoritarian democratic consolidation
+
+## Links
+
+- Website: [memo98.sk](https://memo98.sk)

--- a/docs/organisations/namfrel.md
+++ b/docs/organisations/namfrel.md
@@ -1,0 +1,27 @@
+---
+title: NAMFREL (National Citizens' Movement for Free Elections)
+type: advocacy
+status: active
+country: PH
+website: https://namfrel.com.ph
+summary: "The Philippines' independent citizen election watchdog — founded in 1983, widely regarded as the world's first citizen-led election monitoring organisation, with 250,000+ volunteers conducting parallel vote counts and election observation."
+location:
+  latitude: 14.5995
+  longitude: 120.9842
+  name: Manila, Philippines
+---
+
+NAMFREL (National Citizens' Movement for Free Elections) was founded in October 1983 and is widely regarded as the world's first citizen-led election monitoring organisation. It draws on a volunteer base of over 250,000 members from religious, civic, business, professional, labour, and youth organisations across the Philippines.
+
+NAMFREL is accredited by the Commission on Elections (COMELEC) as the official "citizens' arm" for conducting an independent parallel vote count — a separate tally conducted simultaneously with the official count as a check on electoral integrity. This model has been influential for election monitoring movements elsewhere in Asia.
+
+## What they do
+
+- **Operation Quick Count** — independent parallel vote count for each national election
+- Citizen election observer training and deployment
+- Electoral integrity monitoring and post-election reporting
+- Data analytics and tracking platform
+
+## Links
+
+- Website: [namfrel.com.ph](https://namfrel.com.ph)

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -1,0 +1,28 @@
+---
+title: Civil Network OPORA
+type: advocacy
+status: active
+country: UA
+website: https://oporaua.org/en
+summary: "Ukraine's leading non-partisan election observation organisation — monitoring elections since 2006, conducting parliamentary oversight, and co-founding the European Platform for Democratic Elections (EPDE)."
+location:
+  latitude: 50.4501
+  longitude: 30.5234
+  name: Kyiv, Ukraine
+---
+
+Civil Network OPORA is Ukraine's primary independent election observation and civic oversight organisation, founded in 2006. It conducts comprehensive long-term and short-term election observation for presidential, parliamentary, and local elections, and publishes detailed analytical reports on each electoral cycle.
+
+OPORA co-founded the **European Platform for Democratic Elections (EPDE)** in 2012, a network of Eastern European and Eurasian election observation organisations. Alongside election monitoring, OPORA conducts parliamentary activity analysis and advocacy for electoral reforms aligned with international democratic standards.
+
+## What they do
+
+- Long-term election observation and monitoring
+- Parliamentary activity analysis
+- Electoral reform advocacy
+- Social media analysis and documentation of information environment
+- Post-war election preparation advocacy
+
+## Links
+
+- Website: [oporaua.org/en](https://oporaua.org/en)


### PR DESCRIPTION
## Summary

- **9 new org pages** covering democracy organisations in Africa, Asia, Eastern Europe, and West Asia — filling a significant geographic gap in the landscape reference
- **1 draft blog post** on the Electoral Reform Act 2025, marked `draft: true` with a prominent human review notice (not published)

## New org pages

**Africa**
- `eisa.md` — Electoral Institute for Sustainable Democracy in Africa (South Africa)
- `afrobarometer.md` — Pan-African democracy survey network (Ghana)
- `cdd-west-africa.md` — Centre for Democracy and Development West Africa (Nigeria)

**Asia**
- `bersih.md` — BERSIH 2.0 coalition for clean elections (Malaysia)
- `namfrel.md` — National Citizens' Movement for Free Elections (Philippines, est. 1983)

**Eastern Europe**
- `opora.md` — Civil Network OPORA election monitoring (Ukraine)
- `memo98.md` — MEMO 98 media monitoring and disinformation research (Slovakia)

**West Asia**
- `lcps.md` — Lebanese Center for Policy Studies (Lebanon)
- `aman-palestine.md` — AMAN Coalition / Transparency International Palestine chapter

## Draft blog post

`docs/blog/posts/2026-05-25-electoral-reform-act-2025.md` — marked `draft: true`, will not appear in the published site. Requires human review and authorship before publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_