### PR TITLE
Fix broken links on projects index page

### DIFF
--- a/docs/overrides/projects.html
+++ b/docs/overrides/projects.html
@@ -19,7 +19,7 @@
   <div class="projects-index-grid">
     {%- for file in pages %}
       {%- if file.page and file.page.url and file.page.url.startswith('projects/') and file.page.url != page.url and file.page.meta.get('status') == status_key %}
-      <a class="project-index-card" href="{{ file.page.url }}">
+      <a class="project-index-card" href="/{{ file.page.url }}">
         <div class="project-index-card-header">
           <span class="project-index-card-title">{{ file.page.title }}</span>
           <span class="project-status-badge status-{{ status_key }}">{{ status_label }}</span>


### PR DESCRIPTION
## Summary

One-line fix for broken links on `/projects/projects/`.

`file.page.url` returns a root-relative path (e.g. `projects/polari/`). Used as a relative `href` from `/projects/projects/`, the browser resolves it as `/projects/projects/projects/polari/` — wrong. Prepending `/` makes it an absolute path from the domain root.

Pre-existing bug, not introduced by recent changes.

## Test plan
- [ ] Visit `/projects/projects/` and confirm project cards link correctly

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_