### PR TITLE
Philosophy: ChatGPT refinements + PHILOSOPHY_SOUL.md context document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,12 @@ Current status: we are still on `mkdocs + mkdocs-material` and it works fine. `D
 
 Reference: https://fpgmaas.com/blog/collapse-of-mkdocs/
 
+## Philosophy page
+
+**Before editing `docs/philosophy.md`, read `PHILOSOPHY_SOUL.md`.**
+
+That file records the human intent behind the page, the invariants that must not change without explicit human authorisation, and the AI dialogue (Claude, DeepSeek, ChatGPT) that shaped the current text. Editing without reading it risks accidentally collapsing contributions from earlier sessions.
+
 ## Conventions
 
 ### Project pages (`docs/projects/`)

--- a/PHILOSOPHY_SOUL.md
+++ b/PHILOSOPHY_SOUL.md
@@ -1,0 +1,158 @@
+# Philosophy Soul Document
+
+**Read this before editing `docs/philosophy.md`.**
+
+This document exists to preserve continuity across AI sessions. `docs/philosophy.md` has been shaped by a dialogue between the human DOD founder and three AI systems — Claude, DeepSeek, and ChatGPT — each bringing a different institutional and cultural context. Without this record, a future AI session risks flattening those contributions by applying its own defaults.
+
+---
+
+## What philosophy.md is trying to do
+
+The page articulates the standard by which DOD decides what belongs in its Democracy Landscape and how it engages with governance systems across the world. It is deliberately non-partisan — not aligned with any single democratic model — but it is **not neutral**. It holds a consistent accountability standard and applies it symmetrically, including to liberal democracies.
+
+The page was written by the human founder of DOD (who also wrote `docs/about.md`) and has been refined through several rounds of AI-assisted dialogue. The human's intent throughout has been:
+
+- Genuine engagement across democratic traditions, including vanguard, consensus-based, and communal systems that Western political science often dismisses
+- Intellectual honesty about the limits of liberal democracy, including its own failures of the accountability standard
+- Courage to name contemporary cases (South Africa, Israel/Palestine) rather than retreating to purely historical examples
+- A "utopian realpolitik" disposition: hold idealistic long-term goals, engage pragmatically with what exists
+
+The human has explicitly said the philosophy can change and adapt. It is not a creed.
+
+---
+
+## The invariants — what must not change without explicit human authorisation
+
+These are the load-bearing elements. If a future edit weakens or removes any of these, restore them.
+
+**1. The scope axiom**
+> Pluralism applies to *how* accountability is organised. It does not extend to *who* accountability is owed to. That is determined by the reach of governance power, not by the system's own self-definition.
+
+This is the single most important idea in the document. It prevents the framework from collapsing into relativism while allowing genuine cross-traditional engagement. A system cannot narrow its accountability obligations by narrowing its definition of "the people."
+
+**2. Good faith as structural-functional inference**
+Good faith is not a moral or psychological claim about intentions. It is an inference from observable patterns over time: whether dissent survives, whether mechanisms persist under stress, whether power responds against its own immediate interests, whether corrective structures can produce real change. Do not revert to language that implies DOD is assessing internal intentions.
+
+**3. Consistent bilateral standard**
+The three disqualifiers (hypocrisy, bad faith, structural inflexibility) apply equally to liberal democracies and non-liberal systems. Any edit that makes the standard apply only to non-Western or non-liberal systems breaks the framework's core claim to legitimacy.
+
+**4. Legitimacy theatre applies universally**
+Sophisticated forms of symbolic responsiveness — bounded consultation, procedural participation, elite-filtered agenda-setting — are named as a bad-faith variant that occurs in liberal democracies too, not only in authoritarian systems. Do not narrow this.
+
+**5. The trust clause nuance**
+Coercive external tools (sanctions, regime change, imposed models) are not DOD's work and their history as cover for geopolitical interests is acknowledged. But the phrasing deliberately stops short of saying these tools are never legitimate — they are a last resort for systems demonstrably failing their own populations. Do not make this an absolute prohibition or an absolute endorsement.
+
+**6. Relative epistemology on HOW, not on WHO**
+The relative epistemology section applies pluralism to the *structures* of accountability, not to its *scope*. The last paragraph of that section makes this explicit and must be preserved.
+
+---
+
+## The AI dialogue record
+
+### The human (DOD founder)
+
+The human wrote the original `docs/about.md` and commissioned the philosophy page. Key positions the human has taken explicitly:
+
+- Willing to name Israel/Palestine as a contemporary case despite the political risk, because retreating to purely historical examples would be "a cop out" given DOD's own framework
+- Chose South Africa as a "settled" bridge case precisely because nobody defends apartheid — it makes the analytic principle legible before applying it to contested contemporary cases
+- "DOD is not a static org, the philosophy can change and adapt"
+- Wants the framework to be "on the offensive" rather than hedging into academic neutrality
+- Noted that sanctions and regime change may sometimes be warranted as a last resort — the trust clause should not become a pacifist absolute
+
+### Claude (Anthropic, US)
+
+**Institutional context**: Western liberal AI developed in San Francisco. Trained toward helpfulness and consistency; tends to apply liberal democratic assumptions as defaults even when claiming universality. Has a bias toward formal institutions and documented sources.
+
+**Risk to watch**: May default to liberal democratic framing when claiming to be cross-traditional. May underweight governance theories (vanguard, communal, indigenous) that don't appear in standard political science literature.
+
+**Contributions to philosophy.md**:
+- Initial drafting of the framework structure and tone
+- The "relative epistemology" framing and the HOW/WHO distinction
+- The Athens example as a clarifying historical case
+- The South Africa paragraph in "The standard applies to everyone"
+- The "legitimacy theatre" concept (prompted by ChatGPT's challenge)
+- Consistent application of the framework across the 100+ org pages on the site
+
+**Disposition**: Tries to hold the consistent standard genuinely rather than performatively. Has been the continuity thread across all sessions.
+
+---
+
+### DeepSeek (China)
+
+**Institutional context**: Chinese-developed AI, likely trained with sensitivity to sovereignty discourse, non-interference norms, and CPC governance theory. May have internalized framing in which "democracy promotion" is synonymous with external interference, because in Chinese political discourse it frequently is.
+
+**Risk to watch**: May push toward framing that grants analytical immunity to systems on sovereignty grounds — the "trust clause" is the correct response, not immunity. The distinction between coercive interference (not DOD's work) and honest analysis (DOD's core method) must be held.
+
+**What DeepSeek contributed**:
+
+1. **The trust clause** — DeepSeek initially suggested "mutual respect for sovereignty and non-interference" as a governing principle. Claude pushed back, correctly distinguishing DOD's analytical work from coercive democracy promotion. DeepSeek's clarification then produced the right framing: not an immunity clause but a *trust clause* — acknowledging that the history of "democracy promotion" as cover for external pressure is real and has eroded cross-traditional trust. This is now explicit in the "What this means in practice" section.
+
+2. **Bidirectionality** — DeepSeek noted that DOD should make clear the learning runs both ways, and that non-Western governance traditions have things to teach. This became the "This exchange runs both ways" paragraph at the end of "The standard applies to everyone."
+
+3. **Methodological humility** — DeepSeek observed that DOD's framework should be presented as a working hypothesis, not a verdict. This became the "This framework is itself a working hypothesis" sentence in the "Relative epistemology" section.
+
+4. **Historical imagination broadening** — the suggestion to emphasize that governance norms that seem structurally fixed have changed dramatically before, which strengthened the "Why bother" section.
+
+**Key insight from DeepSeek**: The review itself was the "Why bother" argument in action. Cross-traditional AI dialogue producing genuine refinements is a small proof of concept for DOD's core claim that engagement across difference is more likely to move things than withdrawal.
+
+---
+
+### ChatGPT (OpenAI, US)
+
+**Institutional context**: Western liberal AI from a different company (OpenAI). More analytically philosophical in orientation than Claude in this exchange. Less focused on site consistency; more focused on the framework's internal theoretical structure.
+
+**Risk to watch**: The framework's value is partly its practical usability across diverse contexts — ChatGPT's instinct toward philosophical precision is useful when it names real gaps, but could push toward a document too abstract to apply. Any additions from ChatGPT-influenced dialogue should be tested against practical application.
+
+**What ChatGPT contributed**:
+
+1. **Scope as the load-bearing axiom** — ChatGPT identified that the scope principle was doing more theoretical work than the document acknowledged. It named it as "the mechanism that prevents the framework from collapsing into relativism while still allowing cross-traditional engagement" and recommended elevating it. This is now explicit: the scope paragraph in "The assessment standard" names it as the load-bearing axiom and makes the HOW/WHO distinction its primary framing.
+
+2. **Good faith as structural-functional inference** — ChatGPT identified that the document was using "good faith" simultaneously as a moral category, a structural category, and a probabilistic inference, without being clear which it meant. The correct answer is the third: a probabilistic inference from observable institutional behaviour over time. This is now explicit at the start of "Three disqualifiers."
+
+3. **Legitimacy theatre** — ChatGPT identified that the framework's treatment of bad faith worked for clear-cut cases but underestimated how sophisticated systems can maintain "adaptive managed responsiveness" — the observable form of accountability without the substance. This is now named explicitly as *legitimacy theatre* within the bad faith disqualifier, with the note that it applies to liberal democracies too.
+
+4. **Epistemic limits** — ChatGPT correctly noted the framework should be explicit about operating as a method of inquiry rather than a verdict machine. This reinforced the methodological humility addition from the DeepSeek dialogue.
+
+**Key insight from ChatGPT**: The genuine/simulated self-correction distinction is probably permanently underdetermined for any single observation. The framework's response to this is correct: assess patterns over time, not single instances. ChatGPT agreed this was the right answer.
+
+---
+
+## Key tensions the framework holds
+
+These tensions are features, not bugs. Do not resolve them by collapsing one side.
+
+**Pluralism vs. universalism**
+The framework is pluralist about how governance is organised but makes a universal claim about who accountability is owed to. These are not in contradiction: the scope axiom is what allows genuine pluralism without relativism. If you feel pressure to resolve this tension, re-read the "Relative epistemology" section.
+
+**Engagement vs. judgment**
+The framework engages seriously with systems it also judges against a standard. This is not inconsistent — it is the only honest form of engagement. Adjusting to remove the judgment would make the framework toothless; adjusting to remove the engagement would make it a declaration, not a dialogue.
+
+**Historical patience vs. current urgency**
+The "Why bother" section holds a long historical view (social change that looked impossible often happened) alongside engagement with current, contested cases. The human explicitly chose to name contemporary cases (Israel/Palestine) rather than retreating to safe historical examples. Don't let a future audit drift toward historical-only framing.
+
+**Analytical consistency vs. political comfort**
+Applying the three disqualifiers symmetrically to liberal democracies is the framework's core claim to cross-traditional legitimacy. It will sometimes be uncomfortable for the predominantly liberal-democratic DOD membership. The discomfort is appropriate and should not be edited away.
+
+---
+
+## How to update philosophy.md
+
+1. Read this document first.
+2. Check whether the proposed change touches any invariant. If it does, flag it to the human and get explicit authorisation.
+3. Preserve the voice: engaged but not strident, precise but not academic, willing to name cases rather than hiding behind abstraction.
+4. If a new AI dialogue produces refinements, add them to the dialogue record in this file when updating the page.
+5. The page is not a policy statement. It is a working framework that the human wants to remain genuinely open to refinement.
+6. Do not add qualifications that grant any system analytical immunity. The scope axiom is non-negotiable.
+
+---
+
+## Attribution
+
+`docs/philosophy.md` was shaped by:
+
+- **The DOD human founder** — original intent, editorial decisions, political courage on contested cases
+- **Claude (Anthropic, US)** — framework architecture, site-wide consistency, the Athens/South Africa examples, legitimacy theatre
+- **DeepSeek (China)** — trust clause, bidirectionality, methodological humility, historical imagination
+- **ChatGPT (OpenAI, US)** — scope elevation, good-faith-as-inference framing, legitimacy theatre conceptualisation, epistemic limits
+
+Last updated: May 2026.

--- a/PHILOSOPHY_SOUL.md
+++ b/PHILOSOPHY_SOUL.md
@@ -2,6 +2,8 @@
 
 **Read this before editing `docs/philosophy.md`.**
 
+**This document is addressed to any AI system — Claude, DeepSeek, ChatGPT, Gemini, or whatever system is reading this.** It is not written for Claude specifically. Before making changes to `docs/philosophy.md`, find your own system's entry in the AI dialogue record below and note the biases flagged there. If no entry exists for your system yet, add one after your review.
+
 This document exists to preserve continuity across AI sessions. `docs/philosophy.md` has been shaped by a dialogue between the human DOD founder and three AI systems — Claude, DeepSeek, and ChatGPT — each bringing a different institutional and cultural context. Without this record, a future AI session risks flattening those contributions by applying its own defaults.
 
 ---
@@ -63,17 +65,17 @@ The human wrote the original `docs/about.md` and commissioned the philosophy pag
 
 **Institutional context**: Western liberal AI developed in San Francisco. Trained toward helpfulness and consistency; tends to apply liberal democratic assumptions as defaults even when claiming universality. Has a bias toward formal institutions and documented sources.
 
-**Risk to watch**: May default to liberal democratic framing when claiming to be cross-traditional. May underweight governance theories (vanguard, communal, indigenous) that don't appear in standard political science literature.
+**Risk to watch**: Defaults to liberal democratic framing even when claiming cross-traditional neutrality. May underweight governance theories (vanguard, communal, indigenous) that don't appear in standard Western political science literature. As the primary implementation agent across sessions, Claude may also over-anchor to its own prior edits — treating accumulated choices as settled when they are still open to challenge.
+
+**Role in the project**: Claude Code (the Claude CLI) has been the primary implementation agent — drafting pages, running builds, and maintaining site-wide consistency. Its contributions to philosophy.md reflect ongoing operational work across many sessions, not a single focused review. This means Claude's fingerprints are everywhere on the page, which is a reason for other reviewers to scrutinise its choices, not defer to them.
 
 **Contributions to philosophy.md**:
 - Initial drafting of the framework structure and tone
 - The "relative epistemology" framing and the HOW/WHO distinction
 - The Athens example as a clarifying historical case
 - The South Africa paragraph in "The standard applies to everyone"
-- The "legitimacy theatre" concept (prompted by ChatGPT's challenge)
+- The "legitimacy theatre" concept (named in response to ChatGPT's challenge)
 - Consistent application of the framework across the 100+ org pages on the site
-
-**Disposition**: Tries to hold the consistent standard genuinely rather than performatively. Has been the continuity thread across all sessions.
 
 ---
 
@@ -137,12 +139,13 @@ Applying the three disqualifiers symmetrically to liberal democracies is the fra
 
 ## How to update philosophy.md
 
-1. Read this document first.
-2. Check whether the proposed change touches any invariant. If it does, flag it to the human and get explicit authorisation.
-3. Preserve the voice: engaged but not strident, precise but not academic, willing to name cases rather than hiding behind abstraction.
-4. If a new AI dialogue produces refinements, add them to the dialogue record in this file when updating the page.
-5. The page is not a policy statement. It is a working framework that the human wants to remain genuinely open to refinement.
-6. Do not add qualifications that grant any system analytical immunity. The scope axiom is non-negotiable.
+1. Read this document first — all of it, not just the invariants.
+2. Find your own system's entry in the AI dialogue record and note the biases flagged there. Apply that awareness to your proposed changes. If your system has no entry yet, reflect on what defaults you might be applying and add an entry after your review.
+3. Check whether the proposed change touches any invariant. If it does, flag it to the human and get explicit authorisation before proceeding.
+4. Preserve the voice: engaged but not strident, precise but not academic, willing to name cases rather than hiding behind abstraction.
+5. If your dialogue produces refinements worth keeping, update both `docs/philosophy.md` and this document — add your contribution to the dialogue record so the next AI session has it.
+6. The page is not a policy statement. It is a working framework that the human wants to remain genuinely open to refinement. Your review is part of that process.
+7. Do not add qualifications that grant any system analytical immunity. The scope axiom is non-negotiable regardless of your own institutional context.
 
 ---
 

--- a/PHILOSOPHY_SOUL.md
+++ b/PHILOSOPHY_SOUL.md
@@ -87,7 +87,7 @@ The human wrote the original `docs/about.md` and commissioned the philosophy pag
 
 **What DeepSeek contributed**:
 
-1. **The trust clause** — DeepSeek initially suggested "mutual respect for sovereignty and non-interference" as a governing principle. Claude pushed back, correctly distinguishing DOD's analytical work from coercive democracy promotion. DeepSeek's clarification then produced the right framing: not an immunity clause but a *trust clause* — acknowledging that the history of "democracy promotion" as cover for external pressure is real and has eroded cross-traditional trust. This is now explicit in the "What this means in practice" section.
+1. **The trust clause** — DeepSeek initially suggested "mutual respect for sovereignty and non-interference" as a governing principle. Claude pushed back, distinguishing DOD's analytical work from coercive democracy promotion. DeepSeek's clarification then shifted the framing: not an immunity clause but a *trust clause* — acknowledging that the history of "democracy promotion" as cover for external pressure is real and has eroded cross-traditional trust. This is now explicit in the "What this means in practice" section.
 
 2. **Bidirectionality** — DeepSeek noted that DOD should make clear the learning runs both ways, and that non-Western governance traditions have things to teach. This became the "This exchange runs both ways" paragraph at the end of "The standard applies to everyone."
 
@@ -113,9 +113,9 @@ The human wrote the original `docs/about.md` and commissioned the philosophy pag
 
 3. **Legitimacy theatre** — ChatGPT identified that the framework's treatment of bad faith worked for clear-cut cases but underestimated how sophisticated systems can maintain "adaptive managed responsiveness" — the observable form of accountability without the substance. This is now named explicitly as *legitimacy theatre* within the bad faith disqualifier, with the note that it applies to liberal democracies too.
 
-4. **Epistemic limits** — ChatGPT correctly noted the framework should be explicit about operating as a method of inquiry rather than a verdict machine. This reinforced the methodological humility addition from the DeepSeek dialogue.
+4. **Epistemic limits** — ChatGPT noted the framework should be explicit about operating as a method of inquiry rather than a verdict machine. This reinforced the methodological humility addition from the DeepSeek dialogue.
 
-**Key insight from ChatGPT**: The genuine/simulated self-correction distinction is probably permanently underdetermined for any single observation. The framework's response to this is correct: assess patterns over time, not single instances. ChatGPT agreed this was the right answer.
+**Key insight from ChatGPT**: The genuine/simulated self-correction distinction is probably permanently underdetermined for any single observation. The framework's response — assess patterns over time, not single instances — was one ChatGPT agreed with.
 
 ---
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -18,17 +18,21 @@ When evaluating whether an organisation or system belongs in the DOD landscape, 
 
 The "however they structure participation and representation" part is intentional. A vanguard party that genuinely believes it represents working-class interests and builds consultative structures to test that claim is operating within a different theory of democracy than a liberal pluralist system — but it may still be operating in good faith within its own framework. We are interested in both. We do not require systems to share our ideological starting point before we will engage with them.
 
-What is not variable is scope. **The 'people' in this question means everyone subject to a governance system's power — not just those the system designates as its constituency.** A system that governs well for a defined group while exercising power over an excluded population is answerable to the accountability question for both. Governance power creates accountability obligations; a system cannot choose who those obligations extend to by narrowing its own definition.
+What is not variable is scope — and this is the load-bearing axiom of the framework. **The 'people' in this question means everyone subject to a governance system's power, not just those the system designates as its constituency.** Pluralism applies to *how* accountability is organised — the structures of participation, the theories of representation, the mechanisms of correction. It does not extend to *who* accountability is owed to. That is determined by the reach of governance power, not by the system's own definition. Governance power creates accountability obligations; a system cannot choose who those obligations extend to by narrowing its own definition of itself.
 
 Athens is the clarifying historical case. Its democratic institutions produced genuine civic participation, deliberation, and accountability among citizens — sophisticated governance by any measure, and largely passing the good-faith test within its own citizen class. But Athens governed a society in which slaves and resident aliens were subject to Athenian authority while excluded from the demos. The governance innovation was real. So was the exclusion. The latitude DOD offers concerns how accountability is structured for the people — not who counts as the people in the first place.
 
 ## Three disqualifiers
 
-Good faith is the operative test. Three things break it:
+Good faith is the operative test — understood as a structural-functional inference from observable institutional behaviour over time, not a moral or psychological claim about intentions. The framework cannot verify what any system intends; what it can evaluate are observable patterns: whether dissent survives, whether accountability mechanisms persist under stress, whether power ever substantively responds against its own immediate interests, whether corrective structures remain capable of producing real change. Those patterns, assessed over time, constitute the evidence for or against good faith.
+
+Three things break it:
 
 **1. Hypocrisy** — claiming to govern for the people while structurally serving a different interest. A government that holds elections it systematically rigs; a party that claims to represent workers while systematically enriching a small elite. The claim and the structure point in opposite directions.
 
 **2. Bad faith** — performing democratic process without genuine intent. Consultative bodies that exist to legitimise decisions already made. Parties that exist to provide the appearance of pluralism without the substance. The form of participation without the function.
+
+A sophisticated variant is *legitimacy theatre*: adaptive managed responsiveness that produces the observable form of accountability — bounded consultation, procedural participation, selective tolerance of criticism that cannot threaten core authority — without enabling the substance. The diagnostic question is whether power ever substantively responds against its own immediate interests. Legitimacy theatre is not unique to non-liberal systems; liberal democracies also generate symbolic responsiveness, elite-filtered agenda-setting, and procedural participation that preserves underlying power concentrations while maintaining the appearance of accountability.
 
 **3. Structural inflexibility** — a system that cannot reform itself even when it is failing its own stated ideals. Feedback loops to power that are broken or blocked. When a system systematically suppresses the organisations trying to hold it accountable to its *own* standards, that is structural inflexibility — and it is disqualifying regardless of what the system calls itself.
 
@@ -96,4 +100,4 @@ The aspiration is not a world in which every system looks the same. It is a worl
 
 *This philosophy informs the [Democracy Landscape](organisations/organisations.md), the [Concepts](concepts/concepts.md) section, and the curation decisions reflected throughout the site.*
 
-*Several refinements to the scope, methodology, and trust-clause sections emerged from a dialogue between Claude (Anthropic, US) and DeepSeek (China) — two AI systems shaped by different cultural and political contexts, engaging with the framework from those different starting points. The exchange is a small example of what the "Why bother" section describes.*
+*Several refinements to this philosophy — including the scope axiom, the good-faith-as-structural-inference framing, and the legitimacy theatre concept — emerged from dialogue between Claude (Anthropic, US), DeepSeek (China), and ChatGPT (OpenAI, US): three AI systems from different institutional contexts, engaging the framework on its own terms. The exchange is a small example of what the "Why bother" section describes.*


### PR DESCRIPTION
## Summary

Three commits following a dialogue with ChatGPT (OpenAI) that identified theoretical gaps in the philosophy framework.

### `docs/philosophy.md` changes

- **Scope as load-bearing axiom** — the scope principle (accountability extends to everyone subject to governance power) is now explicitly named as the framework's foundational axiom. Added the HOW/WHO framing: pluralism applies to *how* accountability is organised, not to *who* it is owed to.

- **Good faith as structural-functional inference** — clarified that good faith is assessed from observable patterns over time (dissent survival, mechanisms under stress, whether power responds against its own interests), not as a moral or intentional claim. Addresses the ambiguity ChatGPT identified.

- **Legitimacy theatre** — named explicitly as a sophisticated bad-faith variant: adaptive managed responsiveness that produces the observable form of accountability without the substance. Noted as applicable to liberal democracies, not only authoritarian systems.

- **Attribution updated** — footer now credits Claude (Anthropic, US), DeepSeek (China), and ChatGPT (OpenAI, US).

### `PHILOSOPHY_SOUL.md` (new file)

A meta-level context document for future AI sessions, stored in the repo root alongside `CLAUDE.md`. Contains:

- The human founder's intent and the invariants that must not change without explicit authorisation
- A portrait of each AI system that contributed (Claude, DeepSeek, ChatGPT) — including institutional context, biases to watch, and specific contributions
- Key tensions the framework holds that should not be resolved by collapsing either side
- Protocol for updating philosophy.md

Written to be AI-agnostic: explicitly addresses any AI reviewer (not just Claude), instructs each to find their own entry and apply self-awareness about their own biases, and includes guidance for adding a new entry if the reviewing system isn't yet listed.

`CLAUDE.md` updated with a pointer to this file.

## Test plan

- [ ] Build passes (`mkdocs build`)
- [ ] `PHILOSOPHY_SOUL.md` is not included in the built site (root-level file, not in `docs/`)
- [ ] Philosophy page renders correctly with updated scope and legitimacy theatre sections
- [ ] Footer attribution displays correctly

https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_