### PR TITLE
Add knowledge graph visualisation (concepts / orgs / projects)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,5 +17,6 @@
     - organisations/*.md
 - [Research](research/research.md)
     - research/*.md
+- [Knowledge Graph](knowledge-graph.md)
 
 

--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -495,3 +495,134 @@
   .md-overlay { display: none !important; }
 }
 
+/* ── Knowledge Graph ─────────────────────────────────────────────────── */
+
+#kg-container {
+  width: 100%;
+  height: 70vh;
+  min-height: 480px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 4px;
+  margin: 0.75rem 0 1.5rem;
+  background: var(--md-code-bg-color);
+}
+
+.kg-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  align-items: center;
+  padding: 0.4rem 0;
+  margin-bottom: 0.25rem;
+  font-size: 0.82em;
+}
+
+.kg-filter-group,
+.kg-search-group,
+.kg-action-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  align-items: center;
+}
+
+.kg-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  cursor: pointer;
+  user-select: none;
+}
+
+.kg-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.kg-swatch--concept { background: #3949ab; }
+.kg-swatch--org     { background: #1565c0; }
+.kg-swatch--project { background: #2e7d32; }
+
+#kg-search {
+  padding: 3px 8px;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 3px;
+  background: var(--md-code-bg-color);
+  color: var(--md-default-fg-color);
+  font-size: 0.82em;
+  width: 180px;
+}
+
+.kg-btn {
+  padding: 2px 10px;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--md-default-fg-color);
+  font-size: 0.8em;
+  cursor: pointer;
+  font-family: inherit;
+}
+.kg-btn:hover {
+  background: var(--md-default-fg-color--lightest);
+}
+
+/* info panel */
+.kg-info {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 250px;
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 6px;
+  padding: 1rem 1rem 0.75rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  z-index: 1000;
+}
+.kg-info--hidden { display: none; }
+
+.kg-info__close {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.55rem;
+  background: none;
+  border: none;
+  font-size: 1.2em;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--md-default-fg-color--light);
+  padding: 0;
+}
+
+.kg-info__badge {
+  display: inline-block;
+  font-size: 0.68em;
+  padding: 1px 7px;
+  border-radius: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-bottom: 0.4rem;
+}
+.kg-info__badge--concept      { background: #e8eaf6; color: #3949ab; }
+.kg-info__badge--organisation { background: #e3f2fd; color: #1565c0; }
+.kg-info__badge--project      { background: #e8f5e9; color: #2e7d32; }
+
+.kg-info__title {
+  font-size: 0.95em;
+  margin: 0 0 0.2rem;
+  line-height: 1.3;
+}
+.kg-info__meta {
+  font-size: 0.78em;
+  color: var(--md-default-fg-color--light);
+  margin: 0 0 0.5rem;
+  min-height: 1em;
+}
+.kg-info__link {
+  font-size: 0.82em;
+}
+

--- a/docs/knowledge-graph.md
+++ b/docs/knowledge-graph.md
@@ -1,0 +1,14 @@
+---
+title: Knowledge Graph
+template: knowledge-graph.html
+---
+
+Explore the connections between concepts, organisations, and projects tracked on this site.
+
+- **Concepts** (indigo) — governance and democracy ideas
+- **Organisations** (blue / grey) — groups in the democracy landscape; darker = active, grey = inactive or deregistered
+- **Projects** (green) — Designing Open Democracy's own work
+- **Solid edges** — organisation or project relates to a concept (`concepts:` frontmatter)
+- **Dashed purple edges** — concept links to another concept (from *See also* sections)
+
+Click any node to see details and navigate to its page. Use the toolbar to filter by type, show only active entries, search by name, or zoom to fit.

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -1,0 +1,292 @@
+{% extends "main.html" %}
+{% block content %}
+<div class="kg-page md-typeset">
+  {{ super() }}
+
+  <div class="kg-toolbar">
+    <div class="kg-filter-group">
+      <label class="kg-toggle">
+        <input type="checkbox" id="kg-show-concepts" checked>
+        <span class="kg-swatch kg-swatch--concept"></span> Concepts
+      </label>
+      <label class="kg-toggle">
+        <input type="checkbox" id="kg-show-orgs" checked>
+        <span class="kg-swatch kg-swatch--org"></span> Organisations
+      </label>
+      <label class="kg-toggle">
+        <input type="checkbox" id="kg-show-projects" checked>
+        <span class="kg-swatch kg-swatch--project"></span> Projects
+      </label>
+      <label class="kg-toggle">
+        <input type="checkbox" id="kg-active-only">
+        Active&nbsp;only
+      </label>
+    </div>
+    <div class="kg-search-group">
+      <input type="search" id="kg-search" placeholder="Search nodes…" autocomplete="off">
+    </div>
+    <div class="kg-action-group">
+      <button id="kg-fit" class="kg-btn">Fit</button>
+      <button id="kg-reset" class="kg-btn">Reset</button>
+    </div>
+  </div>
+
+  <div id="kg-container"></div>
+
+  <div id="kg-info" class="kg-info kg-info--hidden">
+    <button id="kg-info-close" class="kg-info__close" aria-label="Close">&times;</button>
+    <span id="kg-info-badge" class="kg-info__badge"></span>
+    <h3 id="kg-info-title" class="kg-info__title"></h3>
+    <p id="kg-info-meta" class="kg-info__meta"></p>
+    <a id="kg-info-link" class="kg-info__link" href="#">View page &rarr;</a>
+  </div>
+</div>
+
+<script src="https://unpkg.com/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
+<script>
+(function () {
+  'use strict';
+
+  // ── colour palette ────────────────────────────────────────────────────────
+  function nodeStyle(data) {
+    if (data.type === 'concept') {
+      return { bg: '#3949ab', fg: '#fff', border: '#1a237e' };
+    }
+    if (data.type === 'organisation') {
+      if (data.status === 'active')       return { bg: '#1565c0', fg: '#fff', border: '#0d47a1' };
+      if (data.status === 'deregistered') return { bg: '#78909c', fg: '#fff', border: '#546e7a' };
+      return { bg: '#607d8b', fg: '#fff', border: '#455a64' };   // inactive
+    }
+    if (data.type === 'project') {
+      return data.status === 'active'
+        ? { bg: '#2e7d32', fg: '#fff', border: '#1b5e20' }
+        : { bg: '#66bb6a', fg: '#fff', border: '#388e3c' };
+    }
+    return { bg: '#9e9e9e', fg: '#fff', border: '#616161' };
+  }
+
+  // ── build Cytoscape element list ─────────────────────────────────────────
+  function buildElements(graphData) {
+    const nodes = graphData.nodes.map(n => ({ data: { ...n } }));
+    const edges = graphData.edges.map((e, i) => ({
+      data: { id: `e${i}`, source: e.source, target: e.target, type: e.type || 'relates_to' }
+    }));
+    return [...nodes, ...edges];
+  }
+
+  // ── Cytoscape stylesheet ─────────────────────────────────────────────────
+  const CYTO_STYLE = [
+    {
+      selector: 'node',
+      style: {
+        'label': 'data(label)',
+        'font-size': '9px',
+        'font-family': 'var(--md-text-font, sans-serif)',
+        'color': function (ele) { return nodeStyle(ele.data()).fg; },
+        'background-color': function (ele) { return nodeStyle(ele.data()).bg; },
+        'border-color': function (ele) { return nodeStyle(ele.data()).border; },
+        'border-width': '1.5px',
+        'text-valign': 'center',
+        'text-halign': 'center',
+        'text-wrap': 'wrap',
+        'text-max-width': '90px',
+        'shape': 'round-rectangle',
+        'padding': '6px',
+        'width': 'label',
+        'height': 'label',
+        'min-width': '30px',
+        'min-height': '20px',
+        'cursor': 'pointer',
+      }
+    },
+    {
+      selector: 'node[type = "concept"]',
+      style: {
+        'font-size': '10px',
+        'font-weight': 'bold',
+        'min-width': '40px',
+      }
+    },
+    {
+      selector: 'edge',
+      style: {
+        'width': 1,
+        'line-color': '#90a4ae',
+        'opacity': 0.55,
+        'curve-style': 'bezier',
+      }
+    },
+    {
+      selector: 'edge[type = "see_also"]',
+      style: {
+        'line-color': '#9c27b0',
+        'line-style': 'dashed',
+        'opacity': 0.45,
+      }
+    },
+    {
+      selector: 'node.highlighted',
+      style: {
+        'border-width': '3px',
+        'border-color': '#ffeb3b',
+        'font-size': '11px',
+        'z-index': 10,
+      }
+    },
+    {
+      selector: 'node.faded',
+      style: { 'opacity': 0.12 }
+    },
+    {
+      selector: 'edge.faded',
+      style: { 'opacity': 0.05 }
+    },
+    {
+      selector: '.hidden',
+      style: { 'display': 'none' }
+    },
+  ];
+
+  // ── main ─────────────────────────────────────────────────────────────────
+  async function init() {
+    const container = document.getElementById('kg-container');
+
+    let graphData;
+    try {
+      const resp = await fetch('/graph.json');
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      graphData = await resp.json();
+    } catch (err) {
+      container.innerHTML =
+        `<p style="padding:1.5em;color:#e53935">Could not load graph.json: ${err.message}</p>`;
+      return;
+    }
+
+    const cy = cytoscape({
+      container,
+      elements: buildElements(graphData),
+      style: CYTO_STYLE,
+      layout: {
+        name: 'cose',
+        animate: false,
+        nodeRepulsion: () => 10000,
+        idealEdgeLength: () => 70,
+        edgeElasticity: () => 0.45,
+        gravity: 0.35,
+        numIter: 1000,
+        initialTemp: 200,
+        coolingFactor: 0.95,
+        minTemp: 1.0,
+        randomize: true,
+      },
+      minZoom: 0.05,
+      maxZoom: 5,
+      wheelSensitivity: 0.3,
+    });
+
+    cy.fit();
+
+    // ── info panel ─────────────────────────────────────────────────────────
+    const infoEl    = document.getElementById('kg-info');
+    const infoBadge = document.getElementById('kg-info-badge');
+    const infoTitle = document.getElementById('kg-info-title');
+    const infoMeta  = document.getElementById('kg-info-meta');
+    const infoLink  = document.getElementById('kg-info-link');
+
+    function showInfo(data) {
+      infoTitle.textContent = data.label;
+      infoBadge.textContent = data.type + (data.status ? ` · ${data.status}` : '');
+      infoBadge.className = `kg-info__badge kg-info__badge--${data.type}`;
+      const meta = [];
+      if (data.org_type) meta.push(data.org_type);
+      infoMeta.textContent = meta.join(' · ');
+      infoLink.href = data.url;
+      infoEl.classList.remove('kg-info--hidden');
+    }
+
+    function hideInfo() {
+      infoEl.classList.add('kg-info--hidden');
+      cy.elements().removeClass('faded highlighted');
+    }
+
+    document.getElementById('kg-info-close').addEventListener('click', hideInfo);
+
+    cy.on('tap', 'node', function (evt) {
+      const node = evt.target;
+      showInfo(node.data());
+      cy.elements().addClass('faded').removeClass('highlighted');
+      node.removeClass('faded').addClass('highlighted');
+      node.connectedEdges().removeClass('faded').connectedNodes().removeClass('faded');
+    });
+
+    cy.on('tap', function (evt) {
+      if (evt.target === cy) hideInfo();
+    });
+
+    // double-click / double-tap → navigate
+    cy.on('dblclick dbltap', 'node', function (evt) {
+      const url = evt.target.data('url');
+      if (url) window.location.href = url;
+    });
+
+    // ── filter controls ────────────────────────────────────────────────────
+    function applyFilters() {
+      const showConcepts = document.getElementById('kg-show-concepts').checked;
+      const showOrgs     = document.getElementById('kg-show-orgs').checked;
+      const showProjects = document.getElementById('kg-show-projects').checked;
+      const activeOnly   = document.getElementById('kg-active-only').checked;
+
+      cy.nodes().forEach(node => {
+        const d = node.data();
+        let hide = false;
+        if (d.type === 'concept'      && !showConcepts) hide = true;
+        if (d.type === 'organisation' && !showOrgs)     hide = true;
+        if (d.type === 'project'      && !showProjects) hide = true;
+        if (activeOnly && d.type !== 'concept' && d.status !== 'active') hide = true;
+        node.toggleClass('hidden', hide);
+      });
+
+      cy.edges().forEach(edge => {
+        const hidden =
+          cy.getElementById(edge.data('source')).hasClass('hidden') ||
+          cy.getElementById(edge.data('target')).hasClass('hidden');
+        edge.toggleClass('hidden', hidden);
+      });
+    }
+
+    ['kg-show-concepts', 'kg-show-orgs', 'kg-show-projects', 'kg-active-only']
+      .forEach(id => document.getElementById(id).addEventListener('change', applyFilters));
+
+    // ── search ─────────────────────────────────────────────────────────────
+    document.getElementById('kg-search').addEventListener('input', function () {
+      const q = this.value.trim().toLowerCase();
+      if (!q) {
+        cy.elements().removeClass('faded highlighted');
+        return;
+      }
+      cy.elements().addClass('faded').removeClass('highlighted');
+      cy.nodes()
+        .filter(n => n.data('label').toLowerCase().includes(q))
+        .removeClass('faded').addClass('highlighted')
+        .connectedEdges().removeClass('faded');
+    });
+
+    // ── fit / reset ────────────────────────────────────────────────────────
+    document.getElementById('kg-fit').addEventListener('click', () => cy.fit());
+
+    document.getElementById('kg-reset').addEventListener('click', () => {
+      document.getElementById('kg-show-concepts').checked = true;
+      document.getElementById('kg-show-orgs').checked     = true;
+      document.getElementById('kg-show-projects').checked = true;
+      document.getElementById('kg-active-only').checked   = false;
+      document.getElementById('kg-search').value          = '';
+      cy.elements().removeClass('faded highlighted hidden');
+      cy.fit();
+      hideInfo();
+    });
+  }
+
+  init();
+})();
+</script>
+{% endblock %}

--- a/hooks/graph_builder.py
+++ b/hooks/graph_builder.py
@@ -1,0 +1,114 @@
+"""
+Build hook: extracts concept/org/project relationships → graph.json
+
+  - Org → Concept edges from `concepts:` frontmatter on org (and project) pages
+  - Concept → Concept edges from "See also" sections in concept page markdown
+  - Writes {site_dir}/graph.json after every build (compatible with `mkdocs serve`)
+"""
+import json
+import os
+import re
+
+_nodes: dict = {}
+_edges: list = []
+
+_SEE_ALSO_RE = re.compile(
+    r'##\s+See\s+[Aa]lso\b[^\n]*\n([\s\S]*?)(?=\n##\s|\Z)',
+)
+_MD_LINK_RE = re.compile(r'\[[^\]]+\]\(([^)#\s]+\.md)(?:#[^)]*)?\)')
+
+
+def on_pre_build(config):
+    _nodes.clear()
+    _edges.clear()
+
+
+def on_page_markdown(markdown, *, page, config, files):
+    src = page.file.src_path
+    if not src.startswith('concepts/') or src == 'concepts/concepts.md':
+        return markdown
+
+    slug = src[len('concepts/'):].replace('.md', '')
+    m = _SEE_ALSO_RE.search(markdown)
+    if not m:
+        return markdown
+
+    for link_m in _MD_LINK_RE.finditer(m.group(1)):
+        href = link_m.group(1)
+        # Local concept-to-concept links only — skip ../ org links and http URLs
+        if href.startswith('..') or href.startswith('http') or '/' in href:
+            continue
+        target_slug = href.replace('.md', '')
+        if target_slug:
+            _edges.append({
+                'source': f'concept:{slug}',
+                'target': f'concept:{target_slug}',
+                'type': 'see_also',
+            })
+    return markdown
+
+
+def on_page_context(context, *, page, config, nav):
+    url = page.url or ''
+
+    if url.startswith('concepts/') and url not in ('concepts/', 'concepts/concepts/'):
+        slug = url.replace('concepts/', '').rstrip('/')
+        _nodes[f'concept:{slug}'] = {
+            'id': f'concept:{slug}',
+            'label': page.title or slug,
+            'type': 'concept',
+            'url': f'/{url}',
+        }
+
+    elif url.startswith('organisations/') and url not in ('organisations/', 'organisations/organisations/'):
+        slug = url.replace('organisations/', '').rstrip('/')
+        node_id = f'org:{slug}'
+        _nodes[node_id] = {
+            'id': node_id,
+            'label': page.title or slug,
+            'type': 'organisation',
+            'status': page.meta.get('status', ''),
+            'org_type': page.meta.get('type', ''),
+            'url': f'/{url}',
+        }
+        for c in (page.meta.get('concepts') or []):
+            _edges.append({'source': node_id, 'target': f'concept:{c}', 'type': 'relates_to'})
+
+    elif url.startswith('projects/') and url not in ('projects/', 'projects/projects/'):
+        slug = url.replace('projects/', '').rstrip('/')
+        node_id = f'project:{slug}'
+        _nodes[node_id] = {
+            'id': node_id,
+            'label': page.title or slug,
+            'type': 'project',
+            'status': page.meta.get('status', ''),
+            'url': f'/{url}',
+        }
+        for c in (page.meta.get('concepts') or []):
+            _edges.append({'source': node_id, 'target': f'concept:{c}', 'type': 'relates_to'})
+
+    return context
+
+
+def on_post_build(config):
+    valid_ids = set(_nodes)
+
+    seen: set = set()
+    unique_edges = []
+    for e in _edges:
+        if e['source'] not in valid_ids or e['target'] not in valid_ids:
+            continue
+        key = (e['source'], e['target'], e['type'])
+        if key not in seen:
+            seen.add(key)
+            unique_edges.append(e)
+
+    graph = {'nodes': list(_nodes.values()), 'edges': unique_edges}
+
+    out_path = os.path.join(config['site_dir'], 'graph.json')
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(graph, f, ensure_ascii=False, indent=2)
+
+    print(
+        f'[graph_builder] {len(_nodes)} nodes, {len(unique_edges)} edges → graph.json'
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ extra:
 
 hooks:
   - hooks/org_template.py
+  - hooks/graph_builder.py
 
 extra_javascript:
   - https://unpkg.com/leaflet@1.9.4/dist/leaflet.js


### PR DESCRIPTION
- hooks/graph_builder.py: new build hook that collects all concept,
  organisation, and project pages; extracts org→concept edges from
  `concepts:` frontmatter and concept→concept edges from "See also"
  sections; writes site/graph.json after every build (works with
  mkdocs serve).  Produces 129 nodes and 339 edges on current content.

- docs/overrides/knowledge-graph.html: Cytoscape.js template with
  filter toggles (by type, active-only), text search, fit/reset
  buttons, and a click info-panel that links to the selected page.
  Double-click a node to navigate directly.

- docs/knowledge-graph.md: dedicated page using the new template.

- mkdocs.yml: register graph_builder hook.
- docs/SUMMARY.md: add Knowledge Graph to nav.
- docs/assets/css/customizations.css: kg-* component styles.

https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n