### PR TITLE
Knowledge graph: fix empty graph and label sync

### DIFF
--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -49,7 +49,8 @@
 (function () {
   'use strict';
 
-  cytoscape.use(cytoscapeFcose);
+  // Both cytoscape-fcose and cytoscape-node-html-label auto-register
+  // when loaded as script tags after cytoscape. No cytoscape.use() needed.
 
   // ── node colours ──────────────────────────────────────────────────────────
   function nodeBg(data) {


### PR DESCRIPTION
## Summary

Two bug fixes for the knowledge graph (follow-up to #46):

- **Fix empty graph** — `cytoscape.use(cytoscapeFcose)` was throwing because both `cytoscape-fcose` and `cytoscape-node-html-label` auto-register when loaded as script tags after cytoscape.js. The redundant `use()` call aborted `init()` before any nodes rendered.
- **Fix label sync timing** — replaced `requestAnimationFrame` with `setTimeout(200)` so hidden-node labels don't flash visible on load; added a debounced `viewport` listener so filtered labels can't reappear after pan/zoom.

## Test plan

- [ ] Load `/knowledge-graph/` — graph renders with nodes and labels visible
- [ ] Inactive/deregistered org labels are hidden on load (active-only default)
- [ ] Pan and zoom — hidden labels stay hidden, no flash
- [ ] Toggle "Active only" off — inactive org labels appear; toggle back — they disappear

https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n)_