### PR TITLE
Knowledge graph: simplify to plain Cytoscape.js

### DIFF
--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -626,31 +626,4 @@
   font-size: 0.82em;
 }
 
-/* HTML node labels (rendered by cytoscape-node-html-label, screen-space) */
-.kg-label {
-  display: inline-block;
-  font-size: 9px;
-  font-family: var(--md-text-font, sans-serif);
-  line-height: 1.3;
-  white-space: nowrap;
-  pointer-events: none;
-  padding: 1px 5px;
-  border-radius: 8px;
-  margin-top: 3px;
-  color: #fff;
-  transition: opacity 0.15s;
-}
-.kg-label--concept {
-  font-size: 11px;
-  font-weight: 600;
-  background: #3949ab;
-  border: 1px solid #1a237e;
-  margin-top: 5px;
-}
-.kg-label--organisation              { background: #1565c0; }
-.kg-label--organisation.kg-label--inactive,
-.kg-label--organisation.kg-label--deregistered { background: #607d8b; }
-.kg-label--project                   { background: #2e7d32; }
-.kg-label--project.kg-label--mothballed,
-.kg-label--project.kg-label--cancelled { background: #388e3c; }
 

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -43,58 +43,69 @@
 </div>
 
 <script src="https://unpkg.com/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
-<script src="https://unpkg.com/cytoscape-fcose@2.2.0/cytoscape-fcose.js"></script>
-<script src="https://unpkg.com/cytoscape-node-html-label@1.2.1/dist/cytoscape-node-html-label.min.js"></script>
 <script>
 (function () {
   'use strict';
 
-  // Both cytoscape-fcose and cytoscape-node-html-label auto-register
-  // when loaded as script tags after cytoscape. No cytoscape.use() needed.
-
-  // ── node colours ──────────────────────────────────────────────────────────
-  function nodeBg(data) {
-    if (data.type === 'concept') return '#3949ab';
-    if (data.type === 'organisation') {
-      if (data.status === 'active')       return '#1565c0';
-      if (data.status === 'deregistered') return '#78909c';
+  // ── colours ───────────────────────────────────────────────────────────────
+  function bgColor(d) {
+    if (d.type === 'concept') return '#3949ab';
+    if (d.type === 'organisation') {
+      if (d.status === 'active')       return '#1565c0';
+      if (d.status === 'deregistered') return '#78909c';
       return '#607d8b';
     }
-    if (data.type === 'project') {
-      return data.status === 'active' ? '#2e7d32' : '#66bb6a';
-    }
+    if (d.type === 'project') return d.status === 'active' ? '#2e7d32' : '#66bb6a';
     return '#9e9e9e';
   }
 
-  function nodeBorder(data) {
-    if (data.type === 'concept') return '#1a237e';
-    if (data.type === 'organisation') {
-      if (data.status === 'active')       return '#0d47a1';
-      if (data.status === 'deregistered') return '#546e7a';
-      return '#455a64';
-    }
-    if (data.type === 'project') {
-      return data.status === 'active' ? '#1b5e20' : '#388e3c';
-    }
-    return '#616161';
-  }
-
-  // ── Cytoscape stylesheet (dots only — labels are HTML) ────────────────────
-  const NODE_SIZE = { concept: 22, project: 14, organisation: 10 };
-
-  const CYTO_STYLE = [
+  // ── stylesheet ────────────────────────────────────────────────────────────
+  const STYLE = [
     {
       selector: 'node',
       style: {
-        'label': '',
-        'background-color': ele => nodeBg(ele.data()),
-        'border-color':     ele => nodeBorder(ele.data()),
-        'border-width': '2px',
-        'shape': 'ellipse',
-        'width':  ele => (NODE_SIZE[ele.data().type] || 10) + 'px',
-        'height': ele => (NODE_SIZE[ele.data().type] || 10) + 'px',
-        'cursor': 'pointer',
+        'label':          'data(label)',
+        'background-color': ele => bgColor(ele.data()),
+        'color':          '#fff',
+        'font-size':      '10px',
+        'font-family':    'var(--md-text-font, sans-serif)',
+        'text-valign':    'center',
+        'text-halign':    'center',
+        'text-wrap':      'wrap',
+        'text-max-width': '90px',
+        'shape':          'round-rectangle',
+        'padding':        '5px',
+        'width':          'label',
+        'height':         'label',
+        'border-width':   '1px',
+        'border-color':   'rgba(0,0,0,0.3)',
+        'cursor':         'pointer',
       }
+    },
+    {
+      selector: 'node[type = "concept"]',
+      style: { 'font-size': '11px', 'font-weight': 'bold', 'padding': '6px' }
+    },
+    {
+      selector: 'node[type = "organisation"]',
+      style: { 'font-size': '9px' }
+    },
+    {
+      selector: 'node[type = "project"]',
+      style: { 'font-size': '9px' }
+    },
+    {
+      selector: 'edge',
+      style: {
+        'width':       1,
+        'line-color':  '#90a4ae',
+        'opacity':     0.5,
+        'curve-style': 'bezier',
+      }
+    },
+    {
+      selector: 'edge[type = "see_also"]',
+      style: { 'line-color': '#9c27b0', 'line-style': 'dashed', 'opacity': 0.4 }
     },
     {
       selector: 'node.highlighted',
@@ -105,16 +116,8 @@
       style: { 'opacity': 0.15 }
     },
     {
-      selector: 'edge',
-      style: { 'width': 1, 'line-color': '#90a4ae', 'opacity': 0.45, 'curve-style': 'bezier' }
-    },
-    {
-      selector: 'edge[type = "see_also"]',
-      style: { 'line-color': '#9c27b0', 'line-style': 'dashed', 'opacity': 0.35 }
-    },
-    {
       selector: 'edge.faded',
-      style: { 'opacity': 0.04 }
+      style: { 'opacity': 0.05 }
     },
     {
       selector: '.hidden',
@@ -122,55 +125,53 @@
     },
   ];
 
-  // ── main ──────────────────────────────────────────────────────────────────
+  // ── init ──────────────────────────────────────────────────────────────────
   async function init() {
     const container = document.getElementById('kg-container');
 
     let graphData;
     try {
       const resp = await fetch('/graph.json');
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
       graphData = await resp.json();
     } catch (err) {
       container.innerHTML =
-        `<p style="padding:1.5em;color:#e53935">Could not load graph.json: ${err.message}</p>`;
+        '<p style="padding:1.5em;color:#e53935">Could not load graph.json: ' + err.message + '</p>';
       return;
     }
 
-    const cy = cytoscape({
-      container,
-      elements: [
-        ...graphData.nodes.map(n => ({ data: { ...n } })),
-        ...graphData.edges.map((e, i) => ({
-          data: { id: `e${i}`, source: e.source, target: e.target, type: e.type || 'relates_to' }
-        })),
-      ],
-      style: CYTO_STYLE,
+    const elements = [
+      ...graphData.nodes.map(n => ({ data: Object.assign({}, n) })),
+      ...graphData.edges.map(function(e, i) {
+        return { data: { id: 'e' + i, source: e.source, target: e.target, type: e.type || 'relates_to' } };
+      }),
+    ];
+
+    var cy = cytoscape({
+      container: container,
+      elements:  elements,
+      style:     STYLE,
       layout: {
-        name: 'fcose',
-        animate: false,
-        quality: 'default',
-        randomize: true,
-        nodeRepulsion: 6500,
-        idealEdgeLength: 80,
-        edgeElasticity: 0.45,
-        gravity: 0.25,
-        numIter: 2500,
-        tile: true,
-        tilingPaddingVertical: 12,
-        tilingPaddingHorizontal: 12,
+        name:         'cose',
+        animate:      false,
+        nodeRepulsion: function() { return 8000; },
+        idealEdgeLength: function() { return 60; },
+        edgeElasticity:  function() { return 0.45; },
+        gravity:      0.3,
+        numIter:      1000,
+        randomize:    true,
       },
       minZoom: 0.05,
       maxZoom: 5,
       wheelSensitivity: 0.3,
     });
 
-    // Default filter: active only
-    cy.nodes().forEach(node => {
-      const d = node.data();
+    // Default: active nodes only
+    cy.nodes().forEach(function(node) {
+      var d = node.data();
       if (d.type !== 'concept' && d.status !== 'active') node.addClass('hidden');
     });
-    cy.edges().forEach(edge => {
+    cy.edges().forEach(function(edge) {
       if (cy.getElementById(edge.data('source')).hasClass('hidden') ||
           cy.getElementById(edge.data('target')).hasClass('hidden'))
         edge.addClass('hidden');
@@ -178,98 +179,64 @@
 
     cy.fit();
 
-    // ── HTML labels via plugin ─────────────────────────────────────────────
-    // Labels are DOM elements in screen space — zoom-invariant by nature.
-    // The plugin positions one div per node; we embed a data-kg-id so we
-    // can sync faded/hidden state without knowing the plugin's internals.
-    cy.nodeHtmlLabel([{
-      query: 'node',
-      halign: 'center',
-      valign: 'bottom',
-      halignBox: 'center',
-      valignBox: 'top',
-      tpl: function (data) {
-        const statusCls = data.status ? ` kg-label--${data.status}` : '';
-        return `<span class="kg-label kg-label--${data.type}${statusCls}" data-kg-id="${data.id}">${data.label}</span>`;
-      }
-    }]);
-
-    // Sync faded / hidden state to the HTML label elements.
-    // The plugin owns the wrapper div; we set opacity/display on it.
-    function syncLabels() {
-      cy.nodes().forEach(node => {
-        const inner = document.querySelector(`[data-kg-id="${node.id()}"]`);
-        if (!inner) return;
-        const wrap = inner.parentElement;
-        if (wrap) wrap.style.display = node.hasClass('hidden') ? 'none' : '';
-        inner.style.opacity = node.hasClass('faded') ? '0.15' : '';
-      });
-    }
-
-    // Wait for the plugin to render its divs before syncing hidden state.
-    // rAF alone isn't enough on slow machines; 200 ms covers layout + paint.
-    setTimeout(syncLabels, 200);
-
-    // Re-sync on every viewport change — the plugin updates label positions
-    // on pan/zoom and could reset display properties we set manually.
-    let _syncTimer = null;
-    cy.on('viewport', () => {
-      if (_syncTimer) clearTimeout(_syncTimer);
-      _syncTimer = setTimeout(syncLabels, 50);
+    // Zoom-invariant font size
+    cy.on('zoom', function() {
+      var z = cy.zoom();
+      cy.nodes('[type = "concept"]').style('font-size',      (11 / z) + 'px');
+      cy.nodes('[type = "organisation"]').style('font-size', ( 9 / z) + 'px');
+      cy.nodes('[type = "project"]').style('font-size',      ( 9 / z) + 'px');
     });
 
     // ── info panel ────────────────────────────────────────────────────────
-    const infoEl    = document.getElementById('kg-info');
-    const infoBadge = document.getElementById('kg-info-badge');
-    const infoTitle = document.getElementById('kg-info-title');
-    const infoMeta  = document.getElementById('kg-info-meta');
-    const infoLink  = document.getElementById('kg-info-link');
+    var infoEl    = document.getElementById('kg-info');
+    var infoBadge = document.getElementById('kg-info-badge');
+    var infoTitle = document.getElementById('kg-info-title');
+    var infoMeta  = document.getElementById('kg-info-meta');
+    var infoLink  = document.getElementById('kg-info-link');
 
-    function showInfo(data) {
-      infoTitle.textContent = data.label;
-      infoBadge.textContent = data.type + (data.status ? ` · ${data.status}` : '');
-      infoBadge.className   = `kg-info__badge kg-info__badge--${data.type}`;
-      infoMeta.textContent  = data.org_type || '';
-      infoLink.href         = data.url;
+    function showInfo(d) {
+      infoTitle.textContent = d.label;
+      infoBadge.textContent = d.type + (d.status ? ' · ' + d.status : '');
+      infoBadge.className   = 'kg-info__badge kg-info__badge--' + d.type;
+      infoMeta.textContent  = d.org_type || '';
+      infoLink.href         = d.url;
       infoEl.classList.remove('kg-info--hidden');
     }
 
     function hideInfo() {
       infoEl.classList.add('kg-info--hidden');
       cy.elements().removeClass('faded highlighted');
-      syncLabels();
     }
 
     document.getElementById('kg-info-close').addEventListener('click', hideInfo);
 
-    cy.on('tap', 'node', function (evt) {
-      const node = evt.target;
+    cy.on('tap', 'node', function(evt) {
+      var node = evt.target;
       showInfo(node.data());
       cy.elements().addClass('faded').removeClass('highlighted');
       node.removeClass('faded').addClass('highlighted');
       node.connectedEdges().removeClass('faded').connectedNodes().removeClass('faded');
-      syncLabels();
     });
 
-    cy.on('tap', function (evt) {
+    cy.on('tap', function(evt) {
       if (evt.target === cy) hideInfo();
     });
 
-    cy.on('dblclick dbltap', 'node', function (evt) {
-      const url = evt.target.data('url');
+    cy.on('dblclick dbltap', 'node', function(evt) {
+      var url = evt.target.data('url');
       if (url) window.location.href = url;
     });
 
     // ── filters ───────────────────────────────────────────────────────────
     function applyFilters() {
-      const showConcepts = document.getElementById('kg-show-concepts').checked;
-      const showOrgs     = document.getElementById('kg-show-orgs').checked;
-      const showProjects = document.getElementById('kg-show-projects').checked;
-      const activeOnly   = document.getElementById('kg-active-only').checked;
+      var showConcepts = document.getElementById('kg-show-concepts').checked;
+      var showOrgs     = document.getElementById('kg-show-orgs').checked;
+      var showProjects = document.getElementById('kg-show-projects').checked;
+      var activeOnly   = document.getElementById('kg-active-only').checked;
 
-      cy.nodes().forEach(node => {
-        const d = node.data();
-        const hide =
+      cy.nodes().forEach(function(node) {
+        var d = node.data();
+        var hide =
           (d.type === 'concept'      && !showConcepts) ||
           (d.type === 'organisation' && !showOrgs)     ||
           (d.type === 'project'      && !showProjects) ||
@@ -277,36 +244,35 @@
         node.toggleClass('hidden', hide);
       });
 
-      cy.edges().forEach(edge => {
+      cy.edges().forEach(function(edge) {
         edge.toggleClass('hidden',
           cy.getElementById(edge.data('source')).hasClass('hidden') ||
           cy.getElementById(edge.data('target')).hasClass('hidden'));
       });
-
-      syncLabels();
     }
 
     ['kg-show-concepts', 'kg-show-orgs', 'kg-show-projects', 'kg-active-only']
-      .forEach(id => document.getElementById(id).addEventListener('change', applyFilters));
+      .forEach(function(id) {
+        document.getElementById(id).addEventListener('change', applyFilters);
+      });
 
     // ── search ────────────────────────────────────────────────────────────
-    document.getElementById('kg-search').addEventListener('input', function () {
-      const q = this.value.trim().toLowerCase();
+    document.getElementById('kg-search').addEventListener('input', function() {
+      var q = this.value.trim().toLowerCase();
       cy.elements().removeClass('faded highlighted');
       if (q) {
-        cy.elements().addClass('faded').removeClass('highlighted');
-        cy.nodes()
-          .filter(n => n.data('label').toLowerCase().includes(q))
-          .removeClass('faded').addClass('highlighted')
+        cy.elements().addClass('faded');
+        cy.nodes().filter(function(n) {
+          return n.data('label').toLowerCase().indexOf(q) !== -1;
+        }).removeClass('faded').addClass('highlighted')
           .connectedEdges().removeClass('faded');
       }
-      syncLabels();
     });
 
     // ── fit / reset ───────────────────────────────────────────────────────
-    document.getElementById('kg-fit').addEventListener('click', () => cy.fit());
+    document.getElementById('kg-fit').addEventListener('click', function() { cy.fit(); });
 
-    document.getElementById('kg-reset').addEventListener('click', () => {
+    document.getElementById('kg-reset').addEventListener('click', function() {
       document.getElementById('kg-show-concepts').checked = true;
       document.getElementById('kg-show-orgs').checked     = true;
       document.getElementById('kg-show-projects').checked = true;


### PR DESCRIPTION
## Summary

Replaces the broken plugin-based implementation with plain Cytoscape.js basics that are well-documented and reliable.

**What changed:**
- Drop `cytoscape-fcose` and `cytoscape-node-html-label` — both caused registration/timing issues that left the graph empty
- Single `<script>` tag, no plugin registration
- Built-in `cose` layout
- Native text labels (`label: 'data(label)'`) on all nodes at all times — org names always visible
- One `zoom` listener for zoom-invariant font size (concept 11 px, others 9 px on screen regardless of zoom level)

**Kept from previous iterations:**
- Active-only default (inactive/deregistered orgs hidden on load)
- Filter toggles (concepts / orgs / projects / active-only)
- Text search with highlight/fade
- Click node → info panel with link; double-click → navigate
- Fit and Reset buttons

## Test plan

- [ ] Load `/knowledge-graph/` — graph renders with all active node labels visible
- [ ] Zoom in and out — labels stay the same physical size on screen
- [ ] Click a node — info panel appears, connected nodes stay bright, others fade
- [ ] Double-click a node — navigates to its page
- [ ] Toggle "Active only" off — inactive orgs appear with their names
- [ ] Search for a term — matching nodes highlight, others dim
- [ ] Reset — restores active-only default

https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n)_