### PR TITLE
Knowledge graph: spread concept nodes around a circle

### DIFF
--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -151,20 +151,35 @@
       container: container,
       elements:  elements,
       style:     STYLE,
-      layout: {
-        name:         'cose',
-        animate:      false,
-        nodeRepulsion: function() { return 8000; },
-        idealEdgeLength: function() { return 60; },
-        edgeElasticity:  function() { return 0.45; },
-        gravity:      0.3,
-        numIter:      1000,
-        randomize:    true,
-      },
+      // Layout runs manually below so we can pre-position concept nodes first
       minZoom: 0.05,
       maxZoom: 5,
       wheelSensitivity: 0.3,
     });
+
+    // Spread concept nodes evenly around a circle so they act as
+    // visible hubs, then lock them before running cose so the layout
+    // arranges orgs/projects around them rather than clustering concepts.
+    var concepts = cy.nodes('[type = "concept"]');
+    var R = 500;
+    concepts.forEach(function(node, i) {
+      var angle = (2 * Math.PI * i) / concepts.length - Math.PI / 2;
+      node.position({ x: R * Math.cos(angle), y: R * Math.sin(angle) });
+      node.lock();
+    });
+
+    cy.layout({
+      name:            'cose',
+      animate:         false,
+      nodeRepulsion:   function() { return 8000; },
+      idealEdgeLength: function() { return 60; },
+      edgeElasticity:  function() { return 0.45; },
+      gravity:         0.3,
+      numIter:         1000,
+      randomize:       false,
+    }).run();
+
+    concepts.unlock();
 
     // Default: active nodes only
     cy.nodes().forEach(function(node) {


### PR DESCRIPTION
## Summary

Pre-positions all concept nodes evenly around a circle (radius 500) before running the `cose` layout. Concept nodes are locked during layout so `cose` only moves org and project nodes, which then cluster around their connected concept hubs.

Result: concepts are spread across the viewport as visible landmarks, with orgs and projects arranged around them rather than everything collapsing to the centre.

## Test plan

- [ ] Load `/knowledge-graph/` — concept labels form a ring, org/project nodes cluster around their connected concepts
- [ ] Concepts are draggable after layout (unlocked post-run)
- [ ] Filters, search, click, and reset all still work

https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n)_