### PR TITLE
Knowledge graph: spread concepts in a ring, cluster orgs around them

### DIFF
--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -168,15 +168,34 @@
       node.lock();
     });
 
+    // Pre-position each org/project near the centroid of its connected
+    // concepts so cose starts with reasonable positions and edge springs
+    // can pull nodes to the right part of the ring.
+    cy.nodes('[type != "concept"]').forEach(function(node) {
+      var linked = node.connectedEdges().connectedNodes('[type = "concept"]');
+      var tx = 0, ty = 0;
+      if (linked.length > 0) {
+        linked.forEach(function(c) { tx += c.position('x'); ty += c.position('y'); });
+        tx /= linked.length;
+        ty /= linked.length;
+      }
+      // scatter slightly so they don't all pile on the same spot
+      var jitter = 60;
+      node.position({
+        x: tx + (Math.random() - 0.5) * jitter,
+        y: ty + (Math.random() - 0.5) * jitter,
+      });
+    });
+
     cy.layout({
       name:            'cose',
       animate:         false,
-      nodeRepulsion:   function() { return 8000; },
+      randomize:       false,   // use our pre-set starting positions
+      nodeRepulsion:   function() { return 6000; },
       idealEdgeLength: function() { return 60; },
-      edgeElasticity:  function() { return 0.45; },
-      gravity:         0.3,
-      numIter:         1000,
-      randomize:       false,
+      edgeElasticity:  function() { return 0.8; },
+      gravity:         0.05,
+      numIter:         1500,
     }).run();
 
     concepts.unlock();

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -157,6 +157,18 @@
       wheelSensitivity: 0.3,
     });
 
+    // Apply active-only filter before layout so inactive nodes don't
+    // compete for space and distort active node positions.
+    cy.nodes().forEach(function(node) {
+      var d = node.data();
+      if (d.type !== 'concept' && d.status !== 'active') node.addClass('hidden');
+    });
+    cy.edges().forEach(function(edge) {
+      if (cy.getElementById(edge.data('source')).hasClass('hidden') ||
+          cy.getElementById(edge.data('target')).hasClass('hidden'))
+        edge.addClass('hidden');
+    });
+
     // Spread concept nodes evenly around a circle so they act as
     // visible hubs, then lock them before running cose so the layout
     // arranges orgs/projects around them rather than clustering concepts.
@@ -171,7 +183,7 @@
     // Pre-position each org/project near the centroid of its connected
     // concepts so cose starts with reasonable positions and edge springs
     // can pull nodes to the right part of the ring.
-    cy.nodes('[type != "concept"]').forEach(function(node) {
+    cy.nodes('[type != "concept"]:visible').forEach(function(node) {
       var linked = node.connectedEdges().connectedNodes('[type = "concept"]');
       var tx = 0, ty = 0;
       if (linked.length > 0) {
@@ -179,7 +191,6 @@
         tx /= linked.length;
         ty /= linked.length;
       }
-      // scatter slightly so they don't all pile on the same spot
       var jitter = 60;
       node.position({
         x: tx + (Math.random() - 0.5) * jitter,
@@ -190,7 +201,7 @@
     cy.layout({
       name:            'cose',
       animate:         false,
-      randomize:       false,   // use our pre-set starting positions
+      randomize:       false,
       nodeRepulsion:   function() { return 6000; },
       idealEdgeLength: function() { return 60; },
       edgeElasticity:  function() { return 0.8; },
@@ -199,17 +210,6 @@
     }).run();
 
     concepts.unlock();
-
-    // Default: active nodes only
-    cy.nodes().forEach(function(node) {
-      var d = node.data();
-      if (d.type !== 'concept' && d.status !== 'active') node.addClass('hidden');
-    });
-    cy.edges().forEach(function(edge) {
-      if (cy.getElementById(edge.data('source')).hasClass('hidden') ||
-          cy.getElementById(edge.data('target')).hasClass('hidden'))
-        edge.addClass('hidden');
-    });
 
     cy.fit();
 


### PR DESCRIPTION
## Summary

Two-pass layout strategy to make the graph readable:

1. **Active-only filter runs first** — inactive/deregistered orgs are hidden before layout so they don't compete for space and push active nodes into bad positions
2. **Concepts pinned to a circle** — all 35 concept nodes are placed evenly around a ring (R=500) and locked before `cose` runs
3. **Orgs pre-positioned near their concepts** — each org/project node starts at the centroid of its connected concept nodes (+ small random jitter), giving `cose` good starting positions
4. **`cose` fine-tunes from there** — with `randomize: false`, stronger edge springs (`edgeElasticity: 0.8`), and low gravity (`0.05`), orgs stay clustered near their concept hubs
5. **Concepts unlocked after layout** — still draggable by the user

Result: a ring of concept labels with org/project clusters pulled in toward their connected concept hubs.

## Test plan

- [ ] Load `/knowledge-graph/` — concepts form a ring, active orgs cluster near connected concepts
- [ ] Zoom in on a concept — orgs connected to it are nearby
- [ ] Drag a concept node — it moves freely after layout
- [ ] Toggle "Active only" off — inactive orgs appear (positions set, just hidden)
- [ ] Filters, search, click info panel, reset all work

https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n)_