### PR TITLE
Knowledge graph: project→concept and project→org edges

### DIFF
--- a/docs/projects/civics-ecosystem-toolkit.md
+++ b/docs/projects/civics-ecosystem-toolkit.md
@@ -6,6 +6,7 @@ summary: "A practical toolkit for building participatory civics structures in Au
 contributors:
   - Brian Khuu
 website: https://www.designingopendemocracy.com/Civics-Ecosystem-Toolkit/01-civics-ecosystem-toolkit-index.html
+concepts: [cooperative, community-business, economic-democracy]
 ---
 
 The Civics Ecosystem Toolkit is a versioned reference document exploring how to design and sustain participatory civic structures within the Australian context.

--- a/docs/projects/deliberative-super.md
+++ b/docs/projects/deliberative-super.md
@@ -6,6 +6,7 @@ contributors:
   - Craig Lambie
 website: https://deliberativesuper.com.au
 summary: "A proxy advisory service that replaces opaque corporate governance recommendations with decisions made by randomly selected pension fund members — giving members real democratic power over how their retirement savings vote at company AGMs."
+concepts: [sortition, citizens-assembly, workplace-democracy]
 ---
 
 Deliberative Super is a project by DOD member Craig Lambie that applies sortition and deliberative democracy to corporate governance — specifically, to the proxy advisory industry.

--- a/docs/projects/electiondates.org.md
+++ b/docs/projects/electiondates.org.md
@@ -6,6 +6,7 @@ summary: "A crowdsourced website to make it easy to find and share the next elec
 contributors:
   - BrianKhuu
   - Usmaan
+concepts: [e-government]
 ---
 
 # Election Dates

--- a/docs/projects/myo-democracy.md
+++ b/docs/projects/myo-democracy.md
@@ -6,6 +6,7 @@ contributors:
   - Danny Johnson
 website: https://web.archive.org/web/*/https://myodemocracy.org/
 summary: "A Melbourne-based platform for collaborative democratic decision-making — citizens raise issues, propose options, review research, vote on solutions, and track outcomes. Non-partisan and designed to complement rather than replace existing government."
+concepts: [direct-democracy, issue-based-direct-democracy, e-government]
 ---
 
 MYO Democracy (Make Your Own Democracy) was a project by Melbourne-based civic technologist Danny Johnson, presented at a [joint Designing Open Democracy / Melbourne Geek Night event in May 2019](../blog/posts/2019-05-15.md).

--- a/docs/projects/polari.md
+++ b/docs/projects/polari.md
@@ -6,6 +6,7 @@ contributors:
   - Dausume
 website: https://github.com/dausume/Polari-Framework
 summary: "A self-hosted, modular research framework with a built-in policy scoring system — allowing communities to directly rate and analyse policies, politicians, and special interest groups using a participatory democratic methodology."
+concepts: [direct-democracy, issue-based-direct-democracy, e-government]
 ---
 
 Polari is a project by DOD member Dustin ("Dausume"), a Full Stack Engineer based in the US. It consists of two interconnected open-source platforms: a general-purpose research framework and a democracy/policy scoring application built on top of it.

--- a/docs/projects/policy-incubator.md
+++ b/docs/projects/policy-incubator.md
@@ -6,6 +6,7 @@ contributors:
   - Guy Kennedy
 website: https://web.archive.org/web/*/https://policyincubator.com/
 summary: "A Melbourne-based policy development platform intended to help the public, institutions, and politicians make better policies — presented at a Designing Open Democracy event in 2019."
+concepts: [e-government]
 ---
 
 Policy Incubator was a project by Melbourne-based DOD member Guy Kennedy. The platform was described as a policy development tool intended to assist the public, institutions, and politicians in making better policies.

--- a/docs/projects/prediki.md
+++ b/docs/projects/prediki.md
@@ -6,6 +6,7 @@ contributors:
   - Hubertus Hofkirchner
 website: https://www.prediki.com
 summary: "A prediction market platform that aggregates collective intelligence on policy questions — users stake structured predictions with reasons, and the system surfaces the informed consensus."
+concepts: [prediction-markets, cognitive-division-of-labour, isegoria, consensus-mapping]
 ---
 
 Prediki is a peer-to-peer platform for opinion research and collective intelligence built on prediction market methodology. Developed by DOD member Hubertus Hofkirchner, it was presented at the [2017 Designing Open Democracy event](../blog/posts/2017-08-21-podcast.md) alongside Nicolas Gruen's talk on isegoria and citizens' juries.

--- a/docs/projects/wiki-content-creation-project.md
+++ b/docs/projects/wiki-content-creation-project.md
@@ -6,6 +6,7 @@ summary: "Building short, factual articles on core democracy topics so the wiki 
 contributors:
   - Usmaan
   - Aya.elfadil
+concepts: [democracy, decentralized-autonomous-organization, community-business, cooperative, workplace-democracy]
 ---
 
 The goal is to build short, factual articles on core democracy topics — accessible to anyone, not just specialists. Articles should provide references where possible.

--- a/docs/projects/write-in-stone.md
+++ b/docs/projects/write-in-stone.md
@@ -6,6 +6,7 @@ summary: "A Windows desktop app that creates a verifiable, auditable record of r
 contributors:
   - Austin
 website: https://www.writeinstone.com
+concepts: [radical-transparency, accountability-sink, e-government]
 ---
 
 Write in Stone (Stone) is a Windows 10/11 desktop application built by DOD member Austin. It captures and preserves a verifiable record of research work — sources consulted, evidence gathered, editorial decisions made — so that the provenance of any piece of reporting or analysis can be traced and trusted.

--- a/hooks/graph_builder.py
+++ b/hooks/graph_builder.py
@@ -1,8 +1,9 @@
 """
 Build hook: extracts concept/org/project relationships → graph.json
 
-  - Org → Concept edges from `concepts:` frontmatter on org (and project) pages
+  - Org/Project → Concept edges from `concepts:` frontmatter
   - Concept → Concept edges from "See also" sections in concept page markdown
+  - Project → Org edges from "../organisations/" links in project page "See also" sections
   - Writes {site_dir}/graph.json after every build (compatible with `mkdocs serve`)
 """
 import json
@@ -25,26 +26,38 @@ def on_pre_build(config):
 
 def on_page_markdown(markdown, *, page, config, files):
     src = page.file.src_path
-    if not src.startswith('concepts/') or src == 'concepts/concepts.md':
-        return markdown
-
-    slug = src[len('concepts/'):].replace('.md', '')
     m = _SEE_ALSO_RE.search(markdown)
-    if not m:
-        return markdown
 
-    for link_m in _MD_LINK_RE.finditer(m.group(1)):
-        href = link_m.group(1)
-        # Local concept-to-concept links only — skip ../ org links and http URLs
-        if href.startswith('..') or href.startswith('http') or '/' in href:
-            continue
-        target_slug = href.replace('.md', '')
-        if target_slug:
-            _edges.append({
-                'source': f'concept:{slug}',
-                'target': f'concept:{target_slug}',
-                'type': 'see_also',
-            })
+    if src.startswith('concepts/') and src != 'concepts/concepts.md':
+        slug = src[len('concepts/'):].replace('.md', '')
+        if m:
+            for link_m in _MD_LINK_RE.finditer(m.group(1)):
+                href = link_m.group(1)
+                # Local concept-to-concept links only
+                if href.startswith('..') or href.startswith('http') or '/' in href:
+                    continue
+                target_slug = href.replace('.md', '')
+                if target_slug:
+                    _edges.append({
+                        'source': f'concept:{slug}',
+                        'target': f'concept:{target_slug}',
+                        'type': 'see_also',
+                    })
+
+    elif src.startswith('projects/') and src != 'projects/projects.md':
+        slug = src[len('projects/'):].replace('.md', '')
+        if m:
+            for link_m in _MD_LINK_RE.finditer(m.group(1)):
+                href = link_m.group(1)
+                if href.startswith('../organisations/') and not href.startswith('http'):
+                    target_slug = href[len('../organisations/'):].replace('.md', '')
+                    if target_slug:
+                        _edges.append({
+                            'source': f'project:{slug}',
+                            'target': f'org:{target_slug}',
+                            'type': 'relates_to',
+                        })
+
     return markdown
 
 


### PR DESCRIPTION
## Summary

- Adds `concepts:` frontmatter to 9 project pages so they appear connected to their relevant concept nodes in the knowledge graph
- Extends `graph_builder.py` to parse `../organisations/` links from project page See Also sections, automatically creating project→org edges (picks up 5 edges: civics-ecosystem-toolkit→capad/cooperative-bonds, deliberative-super→newdemocracy/sortition-foundation, prediki→prediki)

Graph now has 370 edges (up from 339 after the previous PR merged).

## Project→concept mappings added

| Project | Concepts |
|---|---|
| Civics Ecosystem Toolkit | cooperative, community-business, economic-democracy |
| Deliberative Super | sortition, citizens-assembly, workplace-democracy |
| ElectionDates.org | e-government |
| MYO Democracy | direct-democracy, issue-based-direct-democracy, e-government |
| Polari | direct-democracy, issue-based-direct-democracy, e-government |
| Policy Incubator | e-government |
| Prediki | prediction-markets, cognitive-division-of-labour, isegoria, consensus-mapping |
| Wiki Content Creation | democracy, decentralized-autonomous-organization, community-business, cooperative, workplace-democracy |
| Write in Stone | radical-transparency, accountability-sink, e-government |

## Test plan

- [ ] `mkdocs build` reports 370 edges
- [ ] Project nodes appear near their related concept nodes on the graph
- [ ] Project nodes connect directly to org nodes (Prediki, CAPAD, etc.) where See Also links exist

https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n)_