### PR TITLE
Fix internal org/project links in event post (relative .md paths)

### DIFF
--- a/docs/blog/posts/2026-05-29-people-powered-democracy-forum.md
+++ b/docs/blog/posts/2026-05-29-people-powered-democracy-forum.md
@@ -32,10 +32,10 @@ location:
 
 Beyond Billionaires is hosting a public forum on practical ways to give ordinary people more power in democratic decisions. The lineup is strong for anyone interested in how deliberative democracy actually works in practice:
 
-- **Sonia Randhawa** from the [Sortition Foundation](https://www.sortitionfoundation.org/) ([DOD org page](/organisations/sortition-foundation/)) on citizens assemblies around the world — including how they've broken political deadlocks that elected representatives couldn't
-- **Andrew George** ([Remake the World](https://revolutionorcollapse.substack.com/p/remake-the-world-newsletter-1)) on the [Lismore People's Assembly](/organisations/lismore-peoples-assembly/) — a community-run deliberative body set up after the 2022 floods when normal governance failed the community
-- **Eddie Kowalski** from [Conversations at the Crossroads](/organisations/conversations-at-the-crossroads/) on a large-scale deliberation on nuclear energy using a Stanford method — he also co-organised the recent Reclaiming Democracy event at Melbourne Town Hall
-- **Craig Lambie** on using local deliberative processes as the basis for choosing and guiding independent candidates. Craig is a DOD member and founder of [Deliberative Super](https://deliberativesuper.com.au) ([DOD project page](/projects/deliberative-super/)), which applies sortition to superannuation proxy voting
+- **Sonia Randhawa** from the [Sortition Foundation](https://www.sortitionfoundation.org/) ([DOD org page](../../organisations/sortition-foundation.md)) on citizens assemblies around the world — including how they've broken political deadlocks that elected representatives couldn't
+- **Andrew George** ([Remake the World](https://revolutionorcollapse.substack.com/p/remake-the-world-newsletter-1)) on the [Lismore People's Assembly](../../organisations/lismore-peoples-assembly.md) — a community-run deliberative body set up after the 2022 floods when normal governance failed the community
+- **Eddie Kowalski** from [Conversations at the Crossroads](../../organisations/conversations-at-the-crossroads.md) on a large-scale deliberation on nuclear energy using a Stanford method — he also co-organised the recent Reclaiming Democracy event at Melbourne Town Hall
+- **Craig Lambie** on using local deliberative processes as the basis for choosing and guiding independent candidates. Craig is a DOD member and founder of [Deliberative Super](https://deliberativesuper.com.au) ([DOD project page](../../projects/deliberative-super.md)), which applies sortition to superannuation proxy voting
 - **Jane Morton** from Beyond Billionaires on their wealth redistribution campaign
 
 Plenty of Q&A and discussion time built in.


### PR DESCRIPTION
Fixes 404s on the internal DOD org/project links in the People Powered Democracy Forum post.

The blog plugin remaps post URLs, so absolute `/organisations/...` paths break. Converts all four internal links to relative `.md` paths, matching the convention used everywhere else in the site.

**Changed links:**
- `Sortition Foundation` DOD org page
- `Lismore People's Assembly` DOD org page
- `Conversations at the Crossroads` DOD org page
- `Deliberative Super` DOD project page

https://claude.ai/code/session_01GJpdYM1vwnvZRTv3pewSTR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJpdYM1vwnvZRTv3pewSTR)_