### PR TITLE
Add Philosophy summary page and restructure philosophy section

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,8 @@
 
 - [Home](index.md)
 - [About](about.md)
-    - [Philosophy](philosophy/index.md)
+    - [Philosophy](philosophy/summary.md)
+        - [Full Framework](philosophy/index.md)
         - [Soul Document](philosophy/soul.md)
         - [AI Dialogues](philosophy/ai-dialogues/index.md)
             - philosophy/ai-dialogues/*.md

--- a/docs/philosophy/index.md
+++ b/docs/philosophy/index.md
@@ -1,6 +1,8 @@
 ---
-title: Philosophy
+title: Philosophy — Full Framework
 ---
+
+*Looking for the short version? See [Philosophy in Brief](summary.md).*
 
 The [About](../about.md) page says DOD is non-partisan and agnostic about which democratic model is superior. This page explains what that means in practice — and what it doesn't mean.
 

--- a/docs/philosophy/summary.md
+++ b/docs/philosophy/summary.md
@@ -1,0 +1,36 @@
+---
+title: Philosophy
+---
+
+DOD is non-partisan and agnostic about which democratic model is superior. This page explains what that means — and what it doesn't.
+
+*For the full framework, see [Philosophy: Full Framework](index.md).*
+
+---
+
+**[Non-partisan is not neutral.](index.md#non-partisan-is-not-the-same-as-neutral)**  
+DOD doesn't take sides between parties or presume any single democratic system is correct for all contexts. But we hold a consistent standard — one that applies to every system equally, including the liberal democracies most of our members live in.
+
+**[The standard is simple: good faith.](index.md#the-assessment-standard)**  
+Is this system genuinely trying to govern for and with its people? We don't require it to look like Australian or European democracy. We ask whether it is honestly trying to live up to what it claims to be.
+
+**[Scope is not negotiable.](index.md#the-assessment-standard)**  
+"The people" means everyone subject to a governance system's power — not just those it designates as its constituency. A system cannot narrow its accountability obligations by narrowing its own definition of itself. This is what disqualified apartheid South Africa's democratic institutions. It applies equally to every contemporary case.
+
+**[Three things break good faith.](index.md#three-disqualifiers)**  
+— **Hypocrisy**: claiming to govern for the people while structurally serving a different interest.  
+— **Bad faith**: performing democratic process without genuine intent — including sophisticated "legitimacy theatre" that produces the appearance of accountability without the substance.  
+— **Structural inflexibility**: a system that cannot reform itself even when failing its own stated ideals.
+
+**[The standard applies to everyone.](index.md#the-standard-applies-to-everyone)**  
+Elite capture, legitimacy theatre, selective application of principles — these disqualify a system whether it happens in Canberra, Beijing, or Washington. Consistency is what makes the framework trustworthy across traditions.
+
+**[We judge systems by their own values.](index.md#relative-epistemology)**  
+The most honest question isn't "does this look like our democracy?" It is "is this system living up to what it claims to be?" That question can be asked of any system — and any system can engage with it honestly.
+
+**[What we are not.](index.md#what-this-means-in-practice)**  
+Not a human rights observatory. Not a democracy promotion organisation. Not trying to export a model. We are interested in how governance can be made more accountable and more participatory — on each system's own terms.
+
+---
+
+*This philosophy informs the [Democracy Landscape](../organisations/organisations.md), the [Concepts](../concepts/concepts.md) section, and the curation decisions reflected throughout the site.*


### PR DESCRIPTION
## Summary

Introduces a new "Philosophy in Brief" summary page to make the DOD philosophy framework more accessible, while restructuring the philosophy section to clearly distinguish between the summary and full framework.

## Changes

- **New page**: `docs/philosophy/summary.md` — a concise overview of DOD's non-partisan approach, covering:
  - Non-partisan vs. neutral distinction
  - The good faith assessment standard
  - Scope and the three disqualifiers (hypocrisy, bad faith, structural inflexibility)
  - How the standard applies universally
  - Relative epistemology and what DOD is not
  - Links back to the full framework for deeper reading

- **Updated**: `docs/philosophy/index.md` — retitled to "Philosophy — Full Framework" with a link to the summary for users seeking the shorter version

- **Updated**: `docs/SUMMARY.md` — restructured navigation:
  - Philosophy now points to the summary page as the entry point
  - Full Framework moved under Philosophy as a sub-item
  - Soul Document and AI Dialogues remain as sub-items under Full Framework

## Implementation notes

The summary page is designed as a discovery aid — it presents the core principles with inline links to the full framework sections for readers who want to dive deeper. This follows the pattern established for concept pages (brief orientation, point outward for depth) while respecting the philosophy section's special status as documented in `soul.md`.

The navigation restructuring makes the summary the primary entry point while preserving the full framework as the authoritative reference, improving discoverability without losing depth.

https://claude.ai/code/session_01SChse4HwehXkodzTphUpof