### PR TITLE
Knowledge graph: full-width layout and fullscreen button

### DIFF
--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -1,4 +1,22 @@
 {% extends "main.html" %}
+{% block styles %}
+{{ super() }}
+<style>
+  /* Full-width layout for the knowledge graph page only */
+  .md-content        { max-width: 100% !important; }
+  .md-content__inner { max-width: 100% !important; margin: 0 !important; padding: 0 1.2rem !important; }
+  #kg-container      { height: 82vh; min-height: 560px; }
+
+  /* Fullscreen mode */
+  #kg-container:fullscreen,
+  #kg-container:-webkit-full-screen {
+    width: 100vw !important;
+    height: 100vh !important;
+    background: var(--md-code-bg-color);
+    border-radius: 0;
+  }
+</style>
+{% endblock %}
 {% block content %}
 <div class="kg-page md-typeset">
   {{ super() }}
@@ -28,6 +46,7 @@
     <div class="kg-action-group">
       <button id="kg-fit" class="kg-btn">Fit</button>
       <button id="kg-reset" class="kg-btn">Reset</button>
+      <button id="kg-fullscreen" class="kg-btn">⛶ Fullscreen</button>
     </div>
   </div>
 
@@ -301,6 +320,22 @@
       applyFilters();
       cy.fit();
       hideInfo();
+    });
+
+    // ── fullscreen ────────────────────────────────────────────────────────
+    document.getElementById('kg-fullscreen').addEventListener('click', function() {
+      var el = document.getElementById('kg-container');
+      if (!document.fullscreenElement) {
+        (el.requestFullscreen || el.webkitRequestFullscreen).call(el);
+      } else {
+        (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+      }
+    });
+
+    document.addEventListener('fullscreenchange', function() {
+      document.getElementById('kg-fullscreen').textContent =
+        document.fullscreenElement ? '✕ Exit fullscreen' : '⛶ Fullscreen';
+      cy.fit();
     });
   }
 


### PR DESCRIPTION
## Summary

- Overrides Material theme's content column max-width for the knowledge graph page only (no other pages affected)
- Bumps `#kg-container` height from `70vh` to `82vh` (560px min)
- Adds a **Fullscreen** button using the browser Fullscreen API — clicking enters fullscreen on the graph container, button label changes to "Exit fullscreen", `cy.fit()` fires on both enter and exit to re-centre the graph

## Test plan

- [ ] Graph page is noticeably wider — fills the browser window rather than a narrow content column
- [ ] Fullscreen button enters fullscreen; graph fills the screen
- [ ] Exit fullscreen (button or Escape) returns to normal; graph re-fits
- [ ] Other pages are unaffected (content column unchanged)

https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHo1v1Wdmpw4GtPZyFWv5n)_