### PR TITLE
Add wiki maintenance toolkit (util/)

### DIFF
--- a/docs/organisations/conversations-at-the-crossroads.md
+++ b/docs/organisations/conversations-at-the-crossroads.md
@@ -2,7 +2,7 @@
 title: Conversations at the Crossroads
 type: advocacy
 status: active
-country: Australia
+country: AU
 website: https://www.crossroadsconversation.com.au
 summary: "An independent Melbourne-based civic network running deliberative democracy initiatives, including large-scale citizens assemblies and a national program to scale deliberative participation."
 concepts:

--- a/docs/organisations/democracy-foundation.md
+++ b/docs/organisations/democracy-foundation.md
@@ -3,7 +3,7 @@ title: The Democracy Foundation
 type: research
 status: inactive
 country: US
-website: https://democracy.foundation
+website: https://web.archive.org/web/*/https://democracy.foundation/
 summary: "An internet project dedicated to research and design of innovative decision-making methods, best known for a curated list of e-democracy and e-voting projects that remains maintained."
 concepts:
   - direct-democracy

--- a/docs/organisations/electoral-royal-commission.md
+++ b/docs/organisations/electoral-royal-commission.md
@@ -3,7 +3,7 @@ title: Electoral Royal Commission (Australia)
 type: advocacy
 status: inactive
 country: AU
-website: https://pirateparty.org.au
+website: https://web.archive.org/web/*/https://electionroyalcommission.org.au/
 summary: "An Australian campaign initiated by Pirate Party Australia calling for a formal Royal Commission into electoral and voting reform — the dedicated site now redirects to the Pirate Party."
 location:
   latitude: -33.8688

--- a/docs/organisations/lismore-peoples-assembly.md
+++ b/docs/organisations/lismore-peoples-assembly.md
@@ -2,7 +2,7 @@
 title: Lismore People's Assembly
 type: practice
 status: active
-country: Australia
+country: AU
 website: https://reclaim.org.au/lpa-home/
 summary: "A grassroots deliberative assembly in Lismore, NSW, set up in the aftermath of the 2022 floods to give residents a direct voice in decisions shaping the city's future."
 concepts:

--- a/docs/organisations/namfrel.md
+++ b/docs/organisations/namfrel.md
@@ -29,7 +29,7 @@ NAMFREL is accredited by the Commission on Elections (COMELEC) as the official "
 
 ## Links
 
-- Archive: [namfrel.com.ph (Wayback Machine)](https://web.archive.org/web/*/https://namfrel.com.ph) — both `.com.ph` and `.org.ph` are currently unreachable (Cloudflare 522); `namfrel.com` is a different Philippine democracy advocacy site unrelated to NAMFREL
+- Archive: [namfrel.com.ph (Wayback Machine)](https://web.archive.org/web/*/https://namfrel.com.ph) — domains exist but origin server is down (Cloudflare 522 on both `.com.ph` and `.org.ph`); `namfrel.com` is a different Philippine democracy advocacy site unrelated to NAMFREL
 
 ## See also
 

--- a/docs/organisations/namfrel.md
+++ b/docs/organisations/namfrel.md
@@ -4,6 +4,7 @@ type: advocacy
 status: active
 country: PH
 website: https://web.archive.org/web/*/https://namfrel.com.ph
+last_checked: "2026-05-30"
 summary: "The Philippines' independent citizen election watchdog — founded in 1983, widely regarded as the world's first citizen-led election monitoring organisation, with 250,000+ volunteers conducting parallel vote counts and election observation."
 location:
   latitude: 14.5995
@@ -28,7 +29,7 @@ NAMFREL is accredited by the Commission on Elections (COMELEC) as the official "
 
 ## Links
 
-- Archive: [namfrel.com.ph (Wayback Machine)](https://web.archive.org/web/*/https://namfrel.com.ph) — `.com.ph` currently unreachable; `namfrel.com` is a different Philippine democracy advocacy site unrelated to NAMFREL
+- Archive: [namfrel.com.ph (Wayback Machine)](https://web.archive.org/web/*/https://namfrel.com.ph) — both `.com.ph` and `.org.ph` are currently unreachable (Cloudflare 522); `namfrel.com` is a different Philippine democracy advocacy site unrelated to NAMFREL
 
 ## See also
 

--- a/docs/organisations/peoplecount.md
+++ b/docs/organisations/peoplecount.md
@@ -3,7 +3,7 @@ title: PeopleCount
 type: platform
 status: inactive
 country: US
-website: https://peoplecount.org/
+website: https://web.archive.org/web/*/https://peoplecount.org/
 summary: "A US civic technology project focused on restoring political accountability through structured many-to-many communication between citizens and representatives."
 contributors:
   - RandStrauss

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -20,6 +20,56 @@ The Landscape is a living reference, not a snapshot. Orgs close, URLs rot, conce
 
 ## Scripts
 
+### `add_org.py` — Scaffold a new org page
+
+Interactive CLI that prompts for all standard frontmatter fields and validates
+them inline: ISO country code, concept slugs against known list, Wayback URL
+convention for inactive/deregistered orgs, location prompt for active orgs.
+Writes `docs/organisations/<slug>.md` ready to fill in.
+
+```bash
+python util/add_org.py
+```
+
+No dependencies beyond stdlib.
+
+---
+
+### `find.py` — Full-text search
+
+Searches title, summary (frontmatter), and body across org and concept pages.
+Use before adding a new org to check for existing coverage, or to find pages
+that mention a topic without explicitly tagging it.
+
+```bash
+python util/find.py "participatory budgeting"
+python util/find.py "stafford beer" --concepts
+python util/find.py "liquid" --orgs --context 2
+```
+
+No dependencies beyond stdlib.
+
+---
+
+### `check_urls.py` — External URL reachability
+
+HTTP-checks the `website:` field on org pages. Active orgs with Wayback URLs
+(known exceptions) are skipped. Inactive orgs skipped by default. Reports
+OK, REDIRECT (with final URL), CLIENT_ERROR, SERVER_ERROR, TIMEOUT,
+SSL_ERROR, CONNECTION_ERROR.
+
+```bash
+python util/check_urls.py              # active orgs not checked in 365 days
+python util/check_urls.py --all        # ignore last_checked
+python util/check_urls.py --inactive   # also check inactive orgs
+python util/check_urls.py --timeout 15 --delay 1
+```
+
+Requires `requests` (`util/requirements.txt`). Slow — run periodically, not
+on every maintenance pass.
+
+---
+
 ### `stamp.py` — Set last_checked: today
 
 Updates `last_checked` in-place on one or more pages without reordering other keys. Use immediately after verifying a page.
@@ -163,7 +213,7 @@ python util/check_links.py --all       # all links
 
 ## Requirements
 
-`stamp.py` and `stats.py` use stdlib only. All other scripts use `python-frontmatter`, `python-dateutil` — both in `util/requirements.txt`.
+`add_org.py`, `find.py`, `stamp.py`, and `stats.py` use stdlib only. All other scripts use `python-frontmatter`, `python-dateutil`, and `requests` (for `check_urls.py`) — all in `util/requirements.txt`.
 
 ```bash
 pip install -r util/requirements.txt

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -20,6 +20,57 @@ The Landscape is a living reference, not a snapshot. Orgs close, URLs rot, conce
 
 ## Scripts
 
+### `suggest_tags.py` — Suggest concept tags for org pages
+
+Given a concept slug, finds org pages that don't have it tagged but mention
+related keywords in their body. Keywords are derived from the concept slug
+and its page; overly common words (appearing in >40% of orgs) are dropped
+automatically. Extend with `--keywords` for better recall on niche concepts.
+
+```bash
+python util/suggest_tags.py deliberative-democracy
+python util/suggest_tags.py citizens-assembly --keywords "mini-public" "citizen panel"
+python util/suggest_tags.py sortition --threshold 2
+```
+
+Useful after adding a new concept page to surface which existing orgs should
+be back-tagged, and after adding a batch of org pages to catch missed tags.
+
+---
+
+### `new_concept.py` — Scaffold a new concept page
+
+Interactive CLI that creates `docs/concepts/<slug>.md` with the standard
+discovery-aid structure: title, summary, Wikipedia link, See also.
+
+```bash
+python util/new_concept.py
+```
+
+Per CLAUDE.md conventions: concept pages are brief orientations pointing to
+better sources, not authoritative explanations. The scaffolder reminds you.
+
+---
+
+### `pre_commit_check.py` — Run all checks in one pass
+
+Runs `lint_orgs`, `check_concepts`, and `check_links` in sequence. Exits
+non-zero if any hard check fails. Safe to install as a git pre-commit hook.
+
+```bash
+python util/pre_commit_check.py
+python util/pre_commit_check.py --fix-hints
+
+# Install as git hook:
+echo 'python util/pre_commit_check.py' > .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+Hard failures: broken internal links, invalid concept slugs.
+Informational only: `lint_orgs` (4 known Wayback exceptions always appear).
+
+---
+
 ### `add_org.py` — Scaffold a new org page
 
 Interactive CLI that prompts for all standard frontmatter fields and validates

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -20,6 +20,32 @@ The Landscape is a living reference, not a snapshot. Orgs close, URLs rot, conce
 
 ## Scripts
 
+### `stamp.py` — Set last_checked: today
+
+Updates `last_checked` in-place on one or more pages without reordering other keys. Use immediately after verifying a page.
+
+```bash
+python util/stamp.py namfrel                        # by slug
+python util/stamp.py docs/organisations/namfrel.md  # by path
+python util/stamp.py namfrel flacso-cuba            # multiple at once
+python util/stamp.py --all-active                   # every active org
+```
+
+Slugs resolve against `docs/organisations/` first, then `docs/concepts/`. Running twice is safe — already-current pages are skipped. No dependencies beyond stdlib.
+
+---
+
+### `stats.py` — Landscape snapshot
+
+Situational overview: org counts by status, geographic spread, type breakdown, `last_checked` freshness, and concept coverage. Run at the start of a session.
+
+```bash
+python util/stats.py
+python util/stats.py --concepts   # also list orphaned concept pages
+```
+
+---
+
 ### `check_orgs.py` — Staleness report
 
 Who to re-verify next. Orders active orgs by: no `last_checked` date first, then oldest first.
@@ -106,15 +132,20 @@ The `*` gives a calendar of all captures rather than a single snapshot. `lint_or
 ### AI-assisted recheck pass
 
 ```bash
-# 1. See what needs attention
+# 1. Situational overview
+python util/stats.py
+
+# 2. See what needs attention
 python util/check_orgs.py --days 365 --active
 
-# 2. Pick the oldest N pages, verify each one (check website, status, content)
-# 3. Update last_checked in frontmatter after verifying
-# 4. Run lint to catch anything structural
+# 3. Pick the oldest N pages, verify each one (check website, status, content)
+# 4. Stamp verified pages
+python util/stamp.py slug1 slug2 slug3
+
+# 5. Run lint to catch anything structural
 python util/lint_orgs.py --fix-hints
 
-# 5. Run concept and link checks
+# 6. Run concept and link checks
 python util/check_concepts.py --all
 python util/check_links.py --all
 ```
@@ -131,7 +162,7 @@ python util/check_links.py --all       # all links
 
 ## Requirements
 
-All scripts use `python-frontmatter`, `python-dateutil` — both in `util/requirements.txt`.
+`stamp.py` and `stats.py` use stdlib only. All other scripts use `python-frontmatter`, `python-dateutil` — both in `util/requirements.txt`.
 
 ```bash
 pip install -r util/requirements.txt

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -1,0 +1,140 @@
+# util/ — Maintenance Scripts: Intent and Conventions
+
+This directory holds scripts for maintaining the Democracy Landscape wiki. Read this before running or modifying any of them — it records the *why*, not just the *what*.
+
+---
+
+## The maintenance philosophy
+
+The Landscape is a living reference, not a snapshot. Orgs close, URLs rot, concept pages get renamed. The scripts here exist to surface those problems systematically rather than discovering them by accident.
+
+**The `last_checked` convention** is the foundation: any org or concept page that has been recently verified (by a human or an AI with source access) should have `last_checked: "YYYY-MM-DD"` in its frontmatter. All scripts respect a `--days N` threshold: pages checked within N days are skipped as presumably correct. This means:
+
+- Each maintenance pass focuses work on what actually needs attention.
+- After verifying a page, update `last_checked` and commit it — that resets the clock.
+- Set `--days 0` (or `--all`) to check everything regardless.
+
+**Active orgs are highest priority.** Inactive/deregistered orgs still need checking but less urgently — they've already been marked as closed, so there's less harm in a stale URL or missing detail.
+
+---
+
+## Scripts
+
+### `check_orgs.py` — Staleness report
+
+Who to re-verify next. Orders active orgs by: no `last_checked` date first, then oldest first.
+
+```bash
+python util/check_orgs.py              # active + inactive, 365-day threshold
+python util/check_orgs.py --days 180   # flag pages not checked in 6 months
+python util/check_orgs.py --active     # active orgs only
+```
+
+Run this to plan a maintenance pass — gives you a prioritised queue.
+
+---
+
+### `check_concepts.py` — Concept slug validator
+
+Two checks:
+1. **Invalid slugs**: org pages listing concept slugs that don't match any file in `docs/concepts/`. These silently produce broken concept chips in the UI.
+2. **Orphaned concepts**: concept pages not referenced by any org. May indicate a renamed file or a concept that needs org coverage.
+
+```bash
+python util/check_concepts.py              # pages not checked in 365 days
+python util/check_concepts.py --days 90
+python util/check_concepts.py --all        # check all pages
+python util/check_concepts.py --no-orphans # skip orphan check
+```
+
+Check 1 respects `--days`. Check 2 always runs against all pages (orphan status depends on the whole corpus, not individual page age).
+
+---
+
+### `check_links.py` — Internal link checker
+
+Finds `[text](path.md)` links that resolve to non-existent files. Only checks `.md` links (not external URLs).
+
+**MkDocs link resolution**: with `use_directory_urls: true` (default), relative link paths resolve differently for cross-section links vs. blog post links. Two strategies are tried for each link and a link is only flagged if both fail. See the script's docstring for the full explanation if you need to debug false positives.
+
+```bash
+python util/check_links.py              # both sections, 365-day threshold
+python util/check_links.py --all        # check all pages
+python util/check_links.py --dir concepts   # only check concept pages
+```
+
+---
+
+### `lint_orgs.py` — Structural linter
+
+Enforces conventions from CLAUDE.md that are easy to get wrong when marking orgs inactive or adding new entries:
+
+| Rule | What it checks |
+|---|---|
+| `website-active` | Active org with a Wayback Machine URL — should be a live URL |
+| `website-inactive` | Inactive/deregistered org with a live URL — should point to Wayback |
+| `location` | Active org missing `location:` coordinates — won't appear on the interactive map |
+| `concepts` | Concept slugs not matching any `docs/concepts/` file (also in `check_concepts.py`) |
+| `status` | Status value outside `active \| inactive \| deregistered` |
+
+Structural rules don't go stale — a wrong URL is still wrong regardless of `last_checked`. So `--days` defaults to 0 (check all). Use `--days N` to suppress noise during rapid-edit sessions.
+
+```bash
+python util/lint_orgs.py               # check all pages
+python util/lint_orgs.py --days 30     # suppress pages touched this month
+python util/lint_orgs.py --fix-hints   # print suggested frontmatter corrections
+```
+
+---
+
+## Wayback Machine convention
+
+From CLAUDE.md: **defunct orgs** should have their `website:` field pointing to the Wayback Machine calendar URL:
+
+```yaml
+website: https://web.archive.org/web/*/https://originalurl.com/
+```
+
+The `*` gives a calendar of all captures rather than a single snapshot. `lint_orgs.py` enforces this.
+
+**Known exceptions**: a small number of `active` orgs intentionally use Wayback URLs because their live site is in a restricted or unreliable jurisdiction (e.g. FLACSO-Cuba, Kongra Star in AANES/Syria). `lint_orgs.py` will flag these — they are false positives. Do not "fix" them to a live URL unless you can verify the live site is reliably accessible to international readers.
+
+---
+
+## Typical maintenance workflows
+
+### AI-assisted recheck pass
+
+```bash
+# 1. See what needs attention
+python util/check_orgs.py --days 365 --active
+
+# 2. Pick the oldest N pages, verify each one (check website, status, content)
+# 3. Update last_checked in frontmatter after verifying
+# 4. Run lint to catch anything structural
+python util/lint_orgs.py --fix-hints
+
+# 5. Run concept and link checks
+python util/check_concepts.py --all
+python util/check_links.py --all
+```
+
+### Quick pre-PR check
+
+```bash
+python util/lint_orgs.py --days 0      # full structural scan
+python util/check_concepts.py --all    # all concept slugs
+python util/check_links.py --all       # all links
+```
+
+---
+
+## Requirements
+
+All scripts use `python-frontmatter`, `python-dateutil` — both in `util/requirements.txt`.
+
+```bash
+pip install -r util/requirements.txt
+```
+
+Scripts are standalone; no shared library needed.

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -102,6 +102,7 @@ Enforces conventions from CLAUDE.md that are easy to get wrong when marking orgs
 | `location` | Active org missing `location:` coordinates — won't appear on the interactive map |
 | `concepts` | Concept slugs not matching any `docs/concepts/` file (also in `check_concepts.py`) |
 | `status` | Status value outside `active \| inactive \| deregistered` |
+| `country` | Country field is not a 2-letter ISO 3166-1 alpha-2 code |
 
 Structural rules don't go stale — a wrong URL is still wrong regardless of `last_checked`. So `--days` defaults to 0 (check all). Use `--days N` to suppress noise during rapid-edit sessions.
 

--- a/util/add_org.py
+++ b/util/add_org.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+add_org.py — Interactive CLI to scaffold a new org page
+
+Prompts for all standard frontmatter fields, validates inline (ISO country
+code, concept slugs, Wayback URL convention for inactive orgs), and writes
+docs/organisations/<slug>.md ready to fill in.
+
+Usage:
+    python util/add_org.py
+
+Requirements: none (stdlib only)
+"""
+
+import glob
+import os
+import re
+import sys
+from datetime import date
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
+WAYBACK_PREFIX = "https://web.archive.org"
+ALLOWED_STATUSES = ("active", "inactive", "deregistered")
+ALLOWED_TYPES = (
+    "research", "education", "advocacy", "platform", "civic_tech",
+    "practice", "philanthropy", "cooperative", "party", "political_party",
+    "political_movement", "governance", "government",
+)
+ISO2_RE = re.compile(r'^[A-Z]{2}$')
+TODAY = date.today().isoformat()
+
+
+def load_concept_slugs():
+    slugs = set()
+    for path in glob.glob(os.path.join(CONCEPTS_DIR, "*.md")):
+        slug = os.path.basename(path)[:-3]
+        if slug != "concepts":
+            slugs.add(slug)
+    return slugs
+
+
+def slugify(text):
+    slug = text.lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug
+
+
+def ask(prompt, required=True, default=None):
+    suffix = f" [{default}]" if default else (" (required)" if required else " (optional, Enter to skip)")
+    while True:
+        val = input(f"  {prompt}{suffix}: ").strip()
+        if not val and default:
+            return default
+        if val or not required:
+            return val or None
+        print("    Required.")
+
+
+def ask_choice(prompt, choices):
+    print(f"\n  {prompt}:")
+    for i, c in enumerate(choices, 1):
+        print(f"    {i:>2}. {c}")
+    while True:
+        val = input("  Choice (number or name): ").strip().lower()
+        try:
+            n = int(val)
+            if 1 <= n <= len(choices):
+                return choices[n - 1]
+        except ValueError:
+            pass
+        if val in choices:
+            return val
+        matches = [c for c in choices if c.startswith(val)]
+        if len(matches) == 1:
+            return matches[0]
+        print(f"    Enter a number 1–{len(choices)} or start of a name.")
+
+
+def ask_concepts(valid_slugs):
+    print(f"\n  Concepts — comma-separated slugs ({len(valid_slugs)} known).")
+    print(f"  Enter ? to list all, or press Enter to skip.")
+    while True:
+        raw = input("  > ").strip()
+        if raw == "?":
+            for slug in sorted(valid_slugs):
+                print(f"    {slug}")
+            continue
+        if not raw:
+            return []
+        slugs = [s.strip() for s in raw.split(",") if s.strip()]
+        unknown = [s for s in slugs if s not in valid_slugs]
+        if unknown:
+            print(f"  Warning: unknown slug(s): {unknown}  (saved but won't render as chips)")
+        return slugs
+
+
+def main():
+    valid_slugs = load_concept_slugs()
+
+    print("\n── New org page ──\n")
+
+    title = ask("Title")
+
+    org_type = ask_choice("Type", list(ALLOWED_TYPES))
+
+    status = ask_choice("Status", list(ALLOWED_STATUSES))
+
+    # Country
+    while True:
+        country = ask("Country (2-letter ISO code, e.g. AU  GB  US  DE)")
+        if country and ISO2_RE.match(country.upper()):
+            country = country.upper()
+            break
+        print("    Must be a 2-letter ISO 3166-1 alpha-2 code.")
+
+    # Website
+    website = ask("Website URL", required=False)
+    if website:
+        if status in ("inactive", "deregistered") and not website.startswith(WAYBACK_PREFIX):
+            suggested = f"https://web.archive.org/web/*/{website.rstrip('/')}/"
+            print(f"\n  {status.capitalize()} orgs should point to the Wayback Machine calendar URL.")
+            print(f"  Suggested: {suggested}")
+            use_wb = input("  Use Wayback URL? [Y/n]: ").strip().lower()
+            if use_wb != "n":
+                website = suggested
+        elif status == "active" and website.startswith(WAYBACK_PREFIX):
+            print("  Warning: active orgs normally use a live URL (Wayback is for defunct orgs).")
+
+    summary = ask("Summary (one sentence for the metadata box)", required=False)
+
+    concepts = ask_concepts(valid_slugs)
+
+    # Location — active orgs need this to appear on the map
+    location = None
+    if status == "active":
+        print("\n  Location — required for the org to appear on the interactive map.")
+        lat = ask("    Latitude (decimal, e.g. -37.8136)", required=False)
+        if lat:
+            lon = ask("    Longitude (decimal, e.g. 144.9631)")
+            loc_name = ask("    Name (e.g. Melbourne, Australia)")
+            try:
+                location = {"latitude": float(lat), "longitude": float(lon), "name": loc_name}
+            except ValueError:
+                print("  Invalid coordinates — location skipped. Add manually later.")
+
+    # Build frontmatter
+    slug = slugify(title)
+    file_path = os.path.join(ORGS_DIR, f"{slug}.md")
+
+    if os.path.exists(file_path):
+        print(f"\n  File already exists: {file_path}")
+        overwrite = input("  Overwrite? [y/N]: ").strip().lower()
+        if overwrite != "y":
+            print("  Aborted.")
+            return
+
+    lines = ["---"]
+    lines.append(f"title: {title}")
+    lines.append(f"type: {org_type}")
+    lines.append(f"status: {status}")
+    lines.append(f"country: {country}")
+    if website:
+        lines.append(f"website: {website}")
+    if summary:
+        lines.append(f'summary: "{summary.replace(chr(34), chr(92)+chr(34))}"')
+    if concepts:
+        lines.append("concepts:")
+        for c in concepts:
+            lines.append(f"  - {c}")
+    if location:
+        lines.append("location:")
+        lines.append(f"  latitude: {location['latitude']}")
+        lines.append(f"  longitude: {location['longitude']}")
+        lines.append(f'  name: "{location["name"]}"')
+    lines.append(f'last_checked: "{TODAY}"')
+    lines.append("---")
+    lines.append("")
+    lines.append(f"{title} is a …")
+    lines.append("")
+    lines.append("## Links")
+    lines.append("")
+    if website:
+        if website.startswith(WAYBACK_PREFIX):
+            lines.append(f"- Archive: [{title} (Wayback Machine)]({website})")
+        else:
+            domain = re.sub(r"https?://", "", website).rstrip("/")
+            lines.append(f"- Website: [{domain}]({website})")
+    lines.append("")
+    lines.append("## See also")
+    lines.append("")
+    for c in concepts[:3]:
+        lines.append(f"- [{c.replace('-', ' ').title()}](../concepts/{c}.md)")
+
+    with open(file_path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"\n  Created: {file_path}")
+    print(f"  Slug: {slug}")
+    if not location and status == "active":
+        print(f"  Remember to add location: coordinates (needed for the map).")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/util/check_concepts.py
+++ b/util/check_concepts.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+check_concepts.py — Concept slug validator
+
+Two checks:
+  1. Org pages whose `concepts:` frontmatter lists slugs that don't match any
+     file in docs/concepts/ (typo, stale slug, concept page renamed/deleted).
+
+  2. Concept files that no org page references — possible orphans or naming
+     mismatches that mean the concept chip never appears anywhere.
+
+Filtering:
+  Pages with a recent `last_checked` date are skipped for check 1 (they were
+  presumably verified). Orphan check 2 always runs across all pages.
+
+Usage:
+    python util/check_concepts.py              # default: flag pages not checked in 365 days
+    python util/check_concepts.py --days 90    # stricter threshold
+    python util/check_concepts.py --all        # ignore last_checked, check everything
+    python util/check_concepts.py --no-orphans # skip orphan concept check
+
+Requirements: python-frontmatter (util/requirements.txt)
+"""
+
+import argparse
+import glob
+import os
+import sys
+from datetime import date, datetime
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
+SKIP_FILES = {"organisations.md", "concepts.md"}
+
+
+def parse_date(val):
+    if val is None:
+        return None
+    if isinstance(val, (datetime, date)):
+        return val.date() if isinstance(val, datetime) else val
+    try:
+        return date.fromisoformat(str(val).strip('"'))
+    except ValueError:
+        return None
+
+
+def days_since(d):
+    return (date.today() - d).days if d else None
+
+
+def load_concept_slugs():
+    slugs = set()
+    for path in glob.glob(os.path.join(CONCEPTS_DIR, "*.md")):
+        slug = os.path.basename(path)[:-3]
+        if slug != "concepts":
+            slugs.add(slug)
+    return slugs
+
+
+def load_org_pages(threshold_days, ignore_threshold):
+    pages = []
+    for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        meta = post.metadata
+        last_checked = parse_date(meta.get("last_checked"))
+        age = days_since(last_checked)
+        skip = (not ignore_threshold) and (age is not None) and (age < threshold_days)
+        pages.append({
+            "path": path,
+            "slug": os.path.basename(path)[:-3],
+            "title": meta.get("title", os.path.basename(path)[:-3]),
+            "status": meta.get("status", "unknown"),
+            "concepts": meta.get("concepts") or [],
+            "last_checked": last_checked,
+            "age": age,
+            "skip": skip,
+        })
+    return pages
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate concept slugs in org pages")
+    parser.add_argument("--days", type=int, default=365,
+                        help="Skip pages checked within this many days (default: 365)")
+    parser.add_argument("--all", action="store_true",
+                        help="Ignore last_checked, check all pages")
+    parser.add_argument("--no-orphans", action="store_true",
+                        help="Skip orphaned concept check")
+    args = parser.parse_args()
+
+    valid_slugs = load_concept_slugs()
+    pages = load_org_pages(args.days, args.all)
+
+    print(f"\n=== Concept slug validation  (threshold: {'all' if args.all else f'{args.days} days'}) ===\n")
+
+    # --- Check 1: invalid slugs on org pages ---
+    bad_found = False
+    checked = skipped = 0
+    for p in pages:
+        if p["skip"]:
+            skipped += 1
+            continue
+        checked += 1
+        bad = [s for s in p["concepts"] if s not in valid_slugs]
+        if bad:
+            lc = f"last_checked: {p['last_checked']}" if p["last_checked"] else "never checked"
+            print(f"  INVALID SLUG  {p['title']}")
+            print(f"    File: {os.path.relpath(p['path'])}")
+            print(f"    Bad slugs: {bad}")
+            print(f"    ({lc})")
+            print()
+            bad_found = True
+
+    if not bad_found:
+        print(f"  No invalid concept slugs found ({checked} pages checked, {skipped} skipped as recently verified)")
+    else:
+        print(f"  ({checked} pages checked, {skipped} skipped as recently verified)")
+    print()
+
+    # --- Check 2: orphaned concept pages (always runs) ---
+    if not args.no_orphans:
+        all_referenced = set()
+        for p in pages:
+            all_referenced.update(p["concepts"])
+
+        orphans = sorted(valid_slugs - all_referenced)
+        if orphans:
+            print(f"ORPHANED concept pages — not referenced by any org's concepts: list ({len(orphans)}):")
+            for slug in orphans:
+                print(f"  docs/concepts/{slug}.md")
+        else:
+            print("No orphaned concept pages — all concepts are referenced by at least one org.")
+        print()
+
+    print(f"Known concept slugs: {len(valid_slugs)}")
+    print(f"Org pages checked: {checked}  |  skipped (recently verified): {skipped}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/check_concepts.py
+++ b/util/check_concepts.py
@@ -143,6 +143,7 @@ def main():
 
     print(f"Known concept slugs: {len(valid_slugs)}")
     print(f"Org pages checked: {checked}  |  skipped (recently verified): {skipped}\n")
+    sys.exit(1 if bad_found else 0)
 
 
 if __name__ == "__main__":

--- a/util/check_links.py
+++ b/util/check_links.py
@@ -177,6 +177,7 @@ def main():
     else:
         print(f"Total: {total_broken} broken link(s) across {total_files} file(s)")
     print()
+    sys.exit(1 if total_broken > 0 else 0)
 
 
 if __name__ == "__main__":

--- a/util/check_links.py
+++ b/util/check_links.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+check_links.py — Internal markdown link checker (MkDocs-aware)
+
+Scans docs/organisations/ and docs/concepts/ for broken internal .md links.
+Accounts for MkDocs use_directory_urls=True, which changes how relative links
+resolve. Two resolution strategies are tried (see RESOLUTION NOTE below).
+
+RESOLUTION NOTE (MkDocs use_directory_urls=True):
+  With use_directory_urls, each page foo.md is served at /section/foo/ — one
+  level deeper than the source file. This affects ../../-style links to blog
+  posts but NOT ../sibling/ links. Two strategies are tried for each link:
+
+    Strategy 1 (source-file): resolve relative to the source file's directory.
+      Works for:  ../concepts/bar.md  from  docs/organisations/foo.md
+                  → docs/concepts/bar.md ✓
+
+    Strategy 2 (URL-based): resolve relative to the source file treated as a
+      directory (simulating use_directory_urls output depth).
+      Works for:  ../../blog/posts/bar.md  from  docs/organisations/foo.md
+                  → docs/blog/posts/bar.md ✓
+
+  A link is only reported as broken if BOTH strategies fail.
+
+Filtering:
+  Pages with a recent last_checked date are skipped (default: 365 days).
+  Use --all to check everything regardless.
+
+Usage:
+    python util/check_links.py              # default threshold: 365 days
+    python util/check_links.py --days 90
+    python util/check_links.py --all        # ignore last_checked
+    python util/check_links.py --dir concepts   # only check concept pages
+
+Requirements: python-frontmatter (util/requirements.txt)
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+from datetime import date, datetime
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+SKIP_FILES = {"organisations.md", "concepts.md"}
+
+
+def parse_date(val):
+    if val is None:
+        return None
+    if isinstance(val, (datetime, date)):
+        return val.date() if isinstance(val, datetime) else val
+    try:
+        return date.fromisoformat(str(val).strip('"'))
+    except ValueError:
+        return None
+
+
+def days_since(d):
+    return (date.today() - d).days if d else None
+
+
+def is_recently_checked(meta, threshold_days):
+    d = parse_date(meta.get("last_checked"))
+    age = days_since(d)
+    return age is not None and age < threshold_days
+
+
+def resolve_link(source_file, link_target):
+    """
+    Try both resolution strategies. Returns (resolved_path, strategy) if found,
+    or (None, None) if both fail.
+    """
+    # Strip anchor and query string
+    path = link_target.split('#')[0].split('?')[0]
+    if not path.endswith('.md'):
+        return None, None  # only validate .md links
+
+    # Strategy 1: relative to source file's directory
+    source_dir = os.path.dirname(source_file)
+    c1 = os.path.normpath(os.path.join(source_dir, path))
+    if os.path.isfile(c1):
+        return c1, "source-dir"
+
+    # Strategy 2: relative to source file treated as a directory
+    # (simulates use_directory_urls output structure)
+    virtual_dir = source_file[:-3]  # strip .md
+    c2 = os.path.normpath(os.path.join(virtual_dir, path))
+    if os.path.isfile(c2):
+        return c2, "url-based"
+
+    return None, None
+
+
+def check_file(path, docs_dir):
+    """Return list of (line_no, label, target) for broken links."""
+    broken = []
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except Exception:
+        return broken
+
+    for i, line in enumerate(lines, 1):
+        for label, target in LINK_RE.findall(line):
+            # Skip external links and anchors
+            if target.startswith(('http://', 'https://', '#', 'mailto:')):
+                continue
+            if not target.endswith('.md') and '.md#' not in target:
+                continue
+            resolved, _ = resolve_link(path, target)
+            if resolved is None:
+                broken.append((i, label, target))
+    return broken
+
+
+def scan_dir(directory, threshold_days, ignore_threshold):
+    results = []
+    for path in sorted(glob.glob(os.path.join(directory, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        if not ignore_threshold and is_recently_checked(post.metadata, threshold_days):
+            continue
+        broken = check_file(path, DOCS_DIR)
+        if broken:
+            results.append((path, broken))
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find broken internal .md links")
+    parser.add_argument("--days", type=int, default=365,
+                        help="Skip pages checked within this many days (default: 365)")
+    parser.add_argument("--all", action="store_true",
+                        help="Ignore last_checked, check all pages")
+    parser.add_argument("--dir", choices=["organisations", "concepts", "both"],
+                        default="both", help="Which section to scan (default: both)")
+    args = parser.parse_args()
+
+    dirs_to_scan = []
+    if args.dir in ("organisations", "both"):
+        dirs_to_scan.append(os.path.join(DOCS_DIR, "organisations"))
+    if args.dir in ("concepts", "both"):
+        dirs_to_scan.append(os.path.join(DOCS_DIR, "concepts"))
+
+    threshold = args.days
+    ignore = args.all
+
+    print(f"\n=== Internal link checker  (threshold: {'all' if ignore else f'{threshold} days'}) ===\n")
+
+    total_broken = 0
+    total_files = 0
+    for d in dirs_to_scan:
+        section = os.path.basename(d)
+        results = scan_dir(d, threshold, ignore)
+        if results:
+            print(f"── {section} ──")
+            for path, broken in results:
+                print(f"  {os.path.relpath(path)}:")
+                for line_no, label, target in broken:
+                    print(f"    line {line_no}: [{label}]({target})")
+                total_files += 1
+                total_broken += len(broken)
+            print()
+
+    if total_broken == 0:
+        print("  No broken internal links found.")
+    else:
+        print(f"Total: {total_broken} broken link(s) across {total_files} file(s)")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/util/check_orgs.py
+++ b/util/check_orgs.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+check_orgs.py — Landscape maintenance checker
+
+Scans docs/organisations/*.md and reports which pages are due for a re-check,
+ordered by priority: active orgs with no last_checked date first, then oldest
+last_checked date first. Inactive/deregistered orgs are listed separately at
+the bottom as lower priority.
+
+Usage:
+    python util/check_orgs.py              # show all
+    python util/check_orgs.py --days 180   # flag pages not checked in 180+ days
+    python util/check_orgs.py --active     # active orgs only
+
+Requirements: python-frontmatter (already in util/requirements.txt)
+"""
+
+import argparse
+import glob
+import os
+import sys
+from datetime import date, datetime
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs", "organisations")
+SKIP_FILES = {"organisations.md"}
+
+
+def load_orgs():
+    orgs = []
+    for path in sorted(glob.glob(os.path.join(DOCS_DIR, "*.md"))):
+        filename = os.path.basename(path)
+        if filename in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        meta = post.metadata
+
+        last_checked = meta.get("last_checked")
+        if last_checked:
+            if isinstance(last_checked, (datetime, date)):
+                last_checked = last_checked if isinstance(last_checked, date) else last_checked.date()
+            else:
+                try:
+                    last_checked = date.fromisoformat(str(last_checked).strip('"'))
+                except ValueError:
+                    last_checked = None
+
+        orgs.append({
+            "path": path,
+            "slug": filename[:-3],
+            "title": meta.get("title", filename[:-3]),
+            "status": meta.get("status", "unknown"),
+            "type": meta.get("type", ""),
+            "country": meta.get("country", ""),
+            "last_checked": last_checked,
+        })
+    return orgs
+
+
+def days_since(d):
+    if d is None:
+        return None
+    return (date.today() - d).days
+
+
+def format_row(org):
+    lc = org["last_checked"]
+    if lc is None:
+        age = "never checked"
+    else:
+        n = days_since(lc)
+        age = f"{lc}  ({n}d ago)"
+
+    flag = ""
+    if org["status"] == "active" and lc is None:
+        flag = " *** MISSING"
+
+    return f"  {org['title']:<45}  {age}{flag}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check which org pages need re-verification")
+    parser.add_argument("--days", type=int, default=365,
+                        help="Flag pages not checked within this many days (default: 365)")
+    parser.add_argument("--active", action="store_true",
+                        help="Show active orgs only")
+    args = parser.parse_args()
+
+    orgs = load_orgs()
+    today = date.today()
+
+    active = [o for o in orgs if o["status"] == "active"]
+    inactive = [o for o in orgs if o["status"] != "active"]
+
+    # Sort active: never-checked first, then oldest last_checked
+    active_no_date = sorted([o for o in active if o["last_checked"] is None], key=lambda o: o["title"])
+    active_dated = sorted([o for o in active if o["last_checked"] is not None], key=lambda o: o["last_checked"])
+
+    # Split dated into stale vs fresh
+    stale = [o for o in active_dated if days_since(o["last_checked"]) >= args.days]
+    fresh = [o for o in active_dated if days_since(o["last_checked"]) < args.days]
+
+    print(f"\n=== Org Landscape maintenance report  (threshold: {args.days} days) ===\n")
+
+    if active_no_date:
+        print(f"ACTIVE — no last_checked date ({len(active_no_date)} pages):")
+        for o in active_no_date:
+            print(format_row(o))
+        print()
+
+    if stale:
+        print(f"ACTIVE — stale (>{args.days} days since last check) ({len(stale)} pages):")
+        for o in stale:
+            print(format_row(o))
+        print()
+
+    if fresh:
+        print(f"ACTIVE — up to date (<{args.days} days) ({len(fresh)} pages):")
+        for o in fresh:
+            print(format_row(o))
+        print()
+
+    if not args.active and inactive:
+        inactive_no_date = sorted([o for o in inactive if o["last_checked"] is None], key=lambda o: o["title"])
+        inactive_dated = sorted([o for o in inactive if o["last_checked"] is not None], key=lambda o: o["last_checked"])
+        print(f"INACTIVE/DEREGISTERED ({len(inactive)} pages — lower priority):")
+        for o in inactive_no_date + inactive_dated:
+            print(format_row(o))
+        print()
+
+    total_missing = len(active_no_date)
+    total_stale = len(stale)
+    print(f"Summary: {len(active)} active orgs | {total_missing} missing date | {total_stale} stale | {len(fresh)} fresh")
+    print(f"         {len(inactive)} inactive/deregistered orgs\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/check_urls.py
+++ b/util/check_urls.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+check_urls.py — External URL reachability checker for org pages
+
+Checks that website: URLs in org frontmatter actually respond. Active orgs
+with Wayback URLs are skipped (known exceptions — see SOUL.md). Inactive
+orgs are skipped by default (Wayback URLs are always reachable).
+
+Results: OK · REDIRECT (notes final URL) · CLIENT_ERROR · SERVER_ERROR ·
+         TIMEOUT · SSL_ERROR · CONNECTION_ERROR
+
+Usage:
+    python util/check_urls.py              # active orgs not checked in 365 days
+    python util/check_urls.py --all        # ignore last_checked
+    python util/check_urls.py --inactive   # also check inactive/deregistered
+    python util/check_urls.py --timeout 15
+    python util/check_urls.py --delay 1    # polite crawl delay (seconds)
+
+Requirements: python-frontmatter, requests (util/requirements.txt)
+"""
+
+import argparse
+import glob
+import os
+import sys
+import time
+from datetime import date, datetime
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+try:
+    import requests
+    requests.packages.urllib3.disable_warnings()
+except ImportError:
+    print("Missing dependency: pip install requests")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+SKIP_FILES = {"organisations.md"}
+WAYBACK_PREFIX = "https://web.archive.org"
+TODAY = date.today()
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (compatible; DOD-wiki-checker/1.0; "
+        "+https://designingopendemocracy.github.io)"
+    )
+}
+
+
+def parse_date(val):
+    if val is None:
+        return None
+    if isinstance(val, (datetime, date)):
+        return val.date() if isinstance(val, datetime) else val
+    try:
+        return date.fromisoformat(str(val).strip('"'))
+    except ValueError:
+        return None
+
+
+def check_url(url, timeout):
+    """Return (result_code, http_status, detail_string)."""
+    try:
+        r = requests.head(url, timeout=timeout, headers=HEADERS,
+                          allow_redirects=True, verify=False)
+        code = r.status_code
+        final = r.url.rstrip("/")
+        original = url.rstrip("/")
+
+        # HEAD blocked — retry with GET
+        if code in (403, 405):
+            r2 = requests.get(url, timeout=timeout, headers=HEADERS,
+                              allow_redirects=True, verify=False, stream=True)
+            r2.close()
+            code = r2.status_code
+            final = r2.url.rstrip("/")
+
+        if code < 400:
+            if final != original:
+                return "REDIRECT", code, final
+            return "OK", code, None
+        if 400 <= code < 500:
+            return "CLIENT_ERROR", code, None
+        return "SERVER_ERROR", code, None
+
+    except requests.exceptions.Timeout:
+        return "TIMEOUT", None, None
+    except requests.exceptions.SSLError as e:
+        return "SSL_ERROR", None, str(e)[:80]
+    except requests.exceptions.ConnectionError:
+        return "CONNECTION_ERROR", None, None
+    except Exception as e:
+        return "ERROR", None, str(e)[:80]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check external URLs in org frontmatter")
+    parser.add_argument("--days", type=int, default=365,
+                        help="Skip pages checked within N days (default: 365)")
+    parser.add_argument("--all", action="store_true",
+                        help="Ignore last_checked, check all")
+    parser.add_argument("--inactive", action="store_true",
+                        help="Also check inactive/deregistered orgs")
+    parser.add_argument("--timeout", type=int, default=10,
+                        help="Request timeout in seconds (default: 10)")
+    parser.add_argument("--delay", type=float, default=0.5,
+                        help="Delay between requests in seconds (default: 0.5)")
+    args = parser.parse_args()
+
+    pages = []
+    skipped_wayback = skipped_recent = 0
+
+    for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        m = post.metadata
+        status = m.get("status", "")
+        website = (m.get("website") or "").strip()
+
+        if not website or status not in ("active", "inactive", "deregistered"):
+            continue
+        if status != "active" and not args.inactive:
+            continue
+        # Active orgs with Wayback URLs are known exceptions — don't check
+        if status == "active" and website.startswith(WAYBACK_PREFIX):
+            skipped_wayback += 1
+            continue
+
+        if not args.all:
+            lc = parse_date(m.get("last_checked"))
+            if lc and (TODAY - lc).days < args.days:
+                skipped_recent += 1
+                continue
+
+        pages.append({
+            "path": path,
+            "title": m.get("title", os.path.basename(path)[:-3]),
+            "status": status,
+            "website": website,
+        })
+
+    if not pages:
+        print(f"\nNothing to check ({skipped_recent} skipped as recently verified, "
+              f"{skipped_wayback} Wayback exceptions).\n")
+        return
+
+    print(f"\n=== URL checker  ({len(pages)} pages, timeout: {args.timeout}s, "
+          f"delay: {args.delay}s) ===")
+    print(f"    {skipped_recent} skipped (recently verified)  "
+          f"|  {skipped_wayback} Wayback exceptions skipped\n")
+
+    ok = redirects = errors = 0
+
+    for p in pages:
+        result, code, detail = check_url(p["website"], args.timeout)
+        code_str = f" ({code})" if code else ""
+
+        if result == "OK":
+            print(f"  ✓  {p['title']}")
+            ok += 1
+        elif result == "REDIRECT":
+            print(f"  →  {p['title']}{code_str}")
+            print(f"       {p['website']}")
+            print(f"       → {detail}")
+            redirects += 1
+        else:
+            print(f"  ✗  {p['title']}  [{result}{code_str}]")
+            print(f"       {p['website']}")
+            if detail:
+                print(f"       {detail}")
+            errors += 1
+
+        if args.delay:
+            time.sleep(args.delay)
+
+    print(f"\nSummary: {ok} OK  |  {redirects} redirect(s)  |  {errors} error(s)"
+          f"  ({len(pages)} checked)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/createPost.py
+++ b/util/createPost.py
@@ -1,58 +1,109 @@
 #!/usr/bin/env python3
+"""
+createPost.py — Interactive CLI to scaffold a new blog post
+
+Creates a new file in docs/blog/posts/ with frontmatter pre-filled from
+your answers. Open the file in your editor to write the body.
+
+Usage:
+    python util/createPost.py
+"""
 
 import os
+import re
 from datetime import datetime
 
-# Function to ask for user input
-def ask(question):
-    return input(question + ": ")
 
-# Generate front matter for the document
-def generate_front_matter(title, authors, summary, tags, date):
-    authors_list = "\n".join([f"- {a.strip()}" for a in authors.split(',')])
-    tags_list = "\n".join([f"- {tag.strip()}" for tag in tags.split(',')])
-    summary_escaped = summary.replace('"', '\\"')
-    front_matter = (f"---\n"
-                    f"authors:\n"
-                    f"{authors_list}\n"
-                    f"categories: []\n"
-                    f"date: {date} 00:00:00\n"
-                    f'summary: "{summary_escaped}"\n'
-                    f"tags:\n"
-                    f"{tags_list}\n"
-                    f"title: {title}\n"
-                    "---\n\n")
-    return front_matter
+def ask(question, optional=False):
+    suffix = " (optional, Enter to skip): " if optional else ": "
+    val = input(question + suffix).strip()
+    return val if val else None
 
 
+def slugify(text):
+    slug = text.lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug
 
-# Create a new document in the docs/blog directory
-def create_new_doc():
-    title = ask("Document title")
-    authors = ask("Authors (comma-separated for multiple authors, will take first as primary)")
-    summary = ask("Summary")
-    tags = ask("Tags (comma-separated)")
-    date = ask("Date (YYYY-MM-DD), leave blank for today's date")
 
-    if not date:
-        date = datetime.now().strftime('%Y-%m-%d')
-    
-    filename = f"{date}-{title.lower().replace(' ', '-')}.md"
-    
-    # Adjusted to point to 'docs/blog' directory
-    docs_path = os.path.join(os.getcwd(), 'docs', 'blog', 'posts')
-    file_path = os.path.join(docs_path, filename)
-    
-    # Check if docs/blog directory exists, create if not
-    if not os.path.isdir(docs_path):
-        os.makedirs(docs_path, exist_ok=True)
-    
-    front_matter = generate_front_matter(title, authors, summary, tags, date)
-    
-    with open(file_path, 'w') as f:
-        f.write(front_matter)
-    
-    print(f"New document created at: {file_path}")
+def list_field(items):
+    return "\n".join(f"- {item.strip()}" for item in items if item.strip())
+
+
+def main():
+    print("\n── New blog post ──\n")
+
+    title = ask("Title")
+    while not title:
+        print("  Title is required.")
+        title = ask("Title")
+
+    authors_raw = ask("Author(s) (comma-separated)")
+    authors = [a.strip() for a in (authors_raw or "").split(",") if a.strip()]
+    if not authors:
+        authors = [""]
+
+    categories_raw = ask("Categories (comma-separated, e.g. podcast, meetup)")
+    categories = [c.strip() for c in (categories_raw or "").split(",") if c.strip()]
+
+    tags_raw = ask("Tags (comma-separated)")
+    tags = [t.strip() for t in (tags_raw or "").split(",") if t.strip()]
+
+    summary = ask("Summary (one paragraph)")
+
+    link = ask("Link (URL for meetup/event, if any)", optional=True)
+
+    date_str = ask("Date (YYYY-MM-DD, Enter for today)", optional=True)
+    if not date_str:
+        date_str = datetime.now().strftime("%Y-%m-%d")
+
+    # Build frontmatter
+    lines = ["---"]
+    lines.append(f"title: {title}")
+    lines.append("authors:")
+    for a in authors:
+        lines.append(f"- {a}")
+    if categories:
+        lines.append("categories:")
+        for c in categories:
+            lines.append(f"- {c}")
+    else:
+        lines.append("categories: []")
+    if tags:
+        lines.append("tags:")
+        for t in tags:
+            lines.append(f"- {t}")
+    lines.append(f"date: {date_str} 00:00:00")
+    if summary:
+        escaped = summary.replace('"', '\\"')
+        lines.append(f'summary: "{escaped}"')
+    if link:
+        lines.append(f"link: {link}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"## {title}")
+    lines.append("")
+
+    slug = slugify(title)
+    filename = f"{date_str}-{slug}.md"
+    posts_dir = os.path.join(os.path.dirname(__file__), "..", "docs", "blog", "posts")
+    os.makedirs(posts_dir, exist_ok=True)
+    file_path = os.path.join(posts_dir, filename)
+
+    if os.path.exists(file_path):
+        print(f"\n  File already exists: {file_path}")
+        overwrite = input("  Overwrite? [y/N]: ").strip().lower()
+        if overwrite != "y":
+            print("  Aborted.")
+            return
+
+    with open(file_path, "w") as f:
+        f.write("\n".join(lines))
+
+    print(f"\n  Created: {file_path}\n")
+
 
 if __name__ == "__main__":
-    create_new_doc()
+    main()

--- a/util/find.py
+++ b/util/find.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+find.py — Full-text search across org and concept pages
+
+Searches title, summary (frontmatter) and body text. Case-insensitive by
+default. Use before adding a new org to check for existing coverage, or to
+find pages that mention a keyword without explicitly tagging it.
+
+Usage:
+    python util/find.py "participatory budgeting"
+    python util/find.py "stafford beer" --concepts
+    python util/find.py "liquid" --orgs --context 2
+    python util/find.py "Porto Alegre" --case-sensitive
+
+Requirements: none (stdlib only)
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+SKIP_FILES = {"organisations.md", "concepts.md"}
+FM_RE = re.compile(r'^---\s*$', re.MULTILINE)
+TITLE_RE = re.compile(r'^title:\s*(.+)$', re.MULTILINE)
+
+
+def read_file(path):
+    with open(path) as f:
+        content = f.read()
+    title_match = TITLE_RE.search(content)
+    title = title_match.group(1).strip().strip('"') if title_match else os.path.basename(path)[:-3]
+    return title, content.splitlines()
+
+
+def search_file(path, pattern, context_n):
+    title, lines = read_file(path)
+    hits = []
+    for i, line in enumerate(lines):
+        if pattern.search(line):
+            start = max(0, i - context_n)
+            end = min(len(lines), i + context_n + 1)
+            hits.append((i + 1, lines[start:end], i - start))
+    return title, hits
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Full-text search across org/concept pages")
+    parser.add_argument("query", help="Search term or regex")
+    parser.add_argument("--orgs", action="store_true", help="Search org pages only")
+    parser.add_argument("--concepts", action="store_true", help="Search concept pages only")
+    parser.add_argument("--context", "-c", type=int, default=1,
+                        help="Context lines around each match (default: 1)")
+    parser.add_argument("--case-sensitive", action="store_true")
+    args = parser.parse_args()
+
+    flags = 0 if args.case_sensitive else re.IGNORECASE
+    try:
+        pattern = re.compile(args.query, flags)
+    except re.error as e:
+        print(f"Invalid regex: {e}")
+        sys.exit(1)
+
+    sections = []
+    if not args.orgs and not args.concepts:
+        sections = ["organisations", "concepts"]
+    else:
+        if args.orgs:
+            sections.append("organisations")
+        if args.concepts:
+            sections.append("concepts")
+
+    total_hits = total_files = 0
+    print(f"\n=== find: '{args.query}' ===\n")
+
+    for section in sections:
+        section_dir = os.path.join(DOCS_DIR, section)
+        results = []
+        for path in sorted(glob.glob(os.path.join(section_dir, "*.md"))):
+            if os.path.basename(path) in SKIP_FILES:
+                continue
+            try:
+                title, hits = search_file(path, pattern, args.context)
+            except Exception:
+                continue
+            if hits:
+                results.append((path, title, hits))
+
+        if results:
+            print(f"── {section} ──")
+            for path, title, hits in results:
+                print(f"  {title}  ({os.path.relpath(path)})")
+                shown = 0
+                for lineno, ctx, match_offset in hits:
+                    for j, ctx_line in enumerate(ctx):
+                        marker = ">" if j == match_offset else " "
+                        print(f"   {marker} {lineno - match_offset + j:>4}  {ctx_line}")
+                    shown += 1
+                    if shown < len(hits):
+                        print()
+                print()
+                total_files += 1
+                total_hits += len(hits)
+
+    if total_hits == 0:
+        print("  No matches found.")
+    else:
+        print(f"Found {total_hits} match(es) in {total_files} file(s)")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/util/lint_orgs.py
+++ b/util/lint_orgs.py
@@ -51,6 +51,7 @@ CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
 SKIP_FILES = {"organisations.md"}
 WAYBACK_PREFIX = "https://web.archive.org"
 ALLOWED_STATUSES = {"active", "inactive", "deregistered"}
+ISO2_RE = __import__("re").compile(r'^[A-Z]{2}$')
 
 
 def parse_date(val):
@@ -105,6 +106,11 @@ def check_org(meta, valid_slugs):
     if bad_slugs:
         issues.append(("concepts", f"Unknown concept slug(s): {bad_slugs}"))
 
+    # Rule 6: country not an ISO 3166-1 alpha-2 code
+    country = meta.get("country", "") or ""
+    if country and not ISO2_RE.match(country):
+        issues.append(("country", f"country: '{country}' is not a 2-letter ISO code (e.g. AU, GB, US)"))
+
     return issues
 
 
@@ -124,6 +130,7 @@ def main():
         "location": "Add location:\\n  latitude: XX.XXXX\\n  longitude: XX.XXXX\\n  name: City, Country",
         "concepts": "Fix the concept slug(s) to match filenames in docs/concepts/ (without .md).",
         "status": "Set status: to one of: active | inactive | deregistered",
+        "country": "Set country: to a 2-letter ISO 3166-1 alpha-2 code (AU, GB, US, DE…)",
     }
 
     pages_checked = pages_skipped = 0

--- a/util/lint_orgs.py
+++ b/util/lint_orgs.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+lint_orgs.py — Org page structural linter
+
+Checks for inconsistencies between frontmatter fields and the conventions
+documented in CLAUDE.md. Structural rules, not content accuracy — these checks
+are most useful regardless of last_checked age, but --days can filter output.
+
+Rules checked:
+  1. Active org with a Wayback Machine website: URL
+     (active orgs should have a live URL, not an archive link)
+
+  2. Inactive/deregistered org with a live (non-Wayback) website: URL
+     (defunct orgs should point to: https://web.archive.org/web/*/https://...)
+
+  3. Active org missing location: coordinates
+     (no location = doesn't appear on the interactive map)
+
+  4. Org page with concepts: slugs not found in docs/concepts/
+     (also caught by check_concepts.py — included here for a one-stop lint run)
+
+  5. Status values outside the allowed set: active | inactive | deregistered
+
+Filtering:
+  By default, all pages are checked (structural rules don't go stale).
+  Use --days N to suppress output for recently-verified pages.
+
+Usage:
+    python util/lint_orgs.py            # check all org pages
+    python util/lint_orgs.py --days 90  # suppress pages checked within 90 days
+    python util/lint_orgs.py --fix-hints  # print suggested frontmatter fixes
+
+Requirements: python-frontmatter (util/requirements.txt)
+"""
+
+import argparse
+import glob
+import os
+import sys
+from datetime import date, datetime
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
+SKIP_FILES = {"organisations.md"}
+WAYBACK_PREFIX = "https://web.archive.org"
+ALLOWED_STATUSES = {"active", "inactive", "deregistered"}
+
+
+def parse_date(val):
+    if val is None:
+        return None
+    if isinstance(val, (datetime, date)):
+        return val.date() if isinstance(val, datetime) else val
+    try:
+        return date.fromisoformat(str(val).strip('"'))
+    except ValueError:
+        return None
+
+
+def days_since(d):
+    return (date.today() - d).days if d else None
+
+
+def load_concept_slugs():
+    return {
+        os.path.basename(p)[:-3]
+        for p in glob.glob(os.path.join(CONCEPTS_DIR, "*.md"))
+        if os.path.basename(p) != "concepts.md"
+    }
+
+
+def check_org(meta, valid_slugs):
+    """Return list of (rule_id, message) violations."""
+    issues = []
+    status = meta.get("status", "")
+    website = meta.get("website", "") or ""
+    location = meta.get("location")
+    concepts = meta.get("concepts") or []
+
+    # Rule 5: invalid status
+    if status and status not in ALLOWED_STATUSES:
+        issues.append(("status", f"Unknown status '{status}' (allowed: {', '.join(sorted(ALLOWED_STATUSES))})"))
+
+    # Rule 1: active org with Wayback URL
+    if status == "active" and WAYBACK_PREFIX in website:
+        issues.append(("website-active", f"Active org has Wayback Machine URL: {website}"))
+
+    # Rule 2: inactive/deregistered with live URL
+    if status in ("inactive", "deregistered") and website and WAYBACK_PREFIX not in website:
+        issues.append(("website-inactive", f"Inactive org has live URL — should point to Wayback: {website}"))
+
+    # Rule 3: active org missing location
+    if status == "active" and not location:
+        issues.append(("location", "Active org is missing location: coordinates (won't appear on map)"))
+
+    # Rule 4: invalid concept slugs
+    bad_slugs = [s for s in concepts if s not in valid_slugs]
+    if bad_slugs:
+        issues.append(("concepts", f"Unknown concept slug(s): {bad_slugs}"))
+
+    return issues
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Lint org page frontmatter for structural issues")
+    parser.add_argument("--days", type=int, default=0,
+                        help="Suppress output for pages checked within N days (default: 0 = check all)")
+    parser.add_argument("--fix-hints", action="store_true",
+                        help="Print suggested fixes alongside issues")
+    args = parser.parse_args()
+
+    valid_slugs = load_concept_slugs()
+
+    FIX_HINTS = {
+        "website-active": "Change website: to the live URL of the site.",
+        "website-inactive": "Change website: to https://web.archive.org/web/*/https://originalurl.com/",
+        "location": "Add location:\\n  latitude: XX.XXXX\\n  longitude: XX.XXXX\\n  name: City, Country",
+        "concepts": "Fix the concept slug(s) to match filenames in docs/concepts/ (without .md).",
+        "status": "Set status: to one of: active | inactive | deregistered",
+    }
+
+    pages_checked = pages_skipped = 0
+    issues_found = 0
+
+    print(f"\n=== Org page linter  (suppressing pages checked within {args.days} days) ===\n")
+
+    for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        meta = post.metadata
+
+        # Apply --days filter
+        if args.days > 0:
+            lc = parse_date(meta.get("last_checked"))
+            age = days_since(lc)
+            if age is not None and age < args.days:
+                pages_skipped += 1
+                continue
+
+        issues = check_org(meta, valid_slugs)
+        pages_checked += 1
+
+        if issues:
+            lc = parse_date(meta.get("last_checked"))
+            lc_str = f"last_checked: {lc}" if lc else "never checked"
+            print(f"  {meta.get('title', os.path.basename(path))}")
+            print(f"    {os.path.relpath(path)}  ({lc_str})")
+            for rule_id, msg in issues:
+                print(f"    ✗ {msg}")
+                if args.fix_hints and rule_id in FIX_HINTS:
+                    print(f"      → {FIX_HINTS[rule_id]}")
+            print()
+            issues_found += len(issues)
+
+    if issues_found == 0:
+        print(f"  No structural issues found.")
+    print(f"Summary: {issues_found} issue(s) across {pages_checked} pages checked  |  {pages_skipped} skipped (recently verified)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/new_concept.py
+++ b/util/new_concept.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+new_concept.py — Interactive CLI to scaffold a new concept page
+
+Creates docs/concepts/<slug>.md with the standard discovery-aid structure.
+
+Convention (from CLAUDE.md): concept pages are brief orientations pointing
+to better sources — not authoritative explanations. Do not write extended
+prose from general knowledge. If depth is needed, link outward.
+
+Usage:
+    python util/new_concept.py
+
+Requirements: none (stdlib only)
+"""
+
+import glob
+import os
+import re
+import sys
+from datetime import date
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
+TODAY = date.today().isoformat()
+
+
+def load_concept_slugs():
+    slugs = set()
+    for path in glob.glob(os.path.join(CONCEPTS_DIR, "*.md")):
+        slug = os.path.basename(path)[:-3]
+        if slug != "concepts":
+            slugs.add(slug)
+    return slugs
+
+
+def slugify(text):
+    slug = text.lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug
+
+
+def ask(prompt, required=True):
+    suffix = " (required)" if required else " (optional, Enter to skip)"
+    while True:
+        val = input(f"  {prompt}{suffix}: ").strip()
+        if val or not required:
+            return val or None
+        print("    Required.")
+
+
+def main():
+    valid_slugs = load_concept_slugs()
+
+    print("\n── New concept page ──")
+    print("  Keep it as a discovery aid: brief orientation, link outward.")
+    print("  No extended explanations from general knowledge.\n")
+
+    title = ask("Title (e.g. Liquid Democracy)")
+    slug = slugify(title)
+
+    if os.path.isfile(os.path.join(CONCEPTS_DIR, f"{slug}.md")):
+        print(f"\n  Already exists: docs/concepts/{slug}.md")
+        return
+
+    summary = ask("One-line summary for search/metadata", required=False)
+
+    wiki_url = ask("Wikipedia URL (if one exists)", required=False)
+
+    print(f"\n  See Also — related concept slugs (comma-separated).")
+    print(f"  Enter ? to list all {len(valid_slugs)} known slugs, or Enter to skip.")
+    see_also = []
+    while True:
+        raw = input("  > ").strip()
+        if raw == "?":
+            for s in sorted(valid_slugs):
+                print(f"    {s}")
+            continue
+        if not raw:
+            break
+        candidates = [s.strip() for s in raw.split(",") if s.strip()]
+        unknown = [s for s in candidates if s not in valid_slugs]
+        if unknown:
+            print(f"  Warning: unknown slug(s): {unknown}")
+        see_also = candidates
+        break
+
+    # Build file
+    lines = ["---"]
+    lines.append(f"title: {title}")
+    if summary:
+        lines.append(f'summary: "{summary.replace(chr(34), chr(92)+chr(34))}"')
+    lines.append(f'last_checked: "{TODAY}"')
+    lines.append("---")
+    lines.append("")
+    lines.append(f"**{title}** is …")
+    lines.append("")
+    lines.append("## Further reading")
+    lines.append("")
+    if wiki_url:
+        lines.append(f"- Wikipedia: [{title}]({wiki_url})")
+    else:
+        wp_slug = title.replace(" ", "_")
+        lines.append(f"- Wikipedia: [{title}](https://en.wikipedia.org/wiki/{wp_slug})")
+    lines.append("")
+    if see_also:
+        lines.append("## See also")
+        lines.append("")
+        for s in see_also:
+            label = s.replace("-", " ").title()
+            lines.append(f"- [{label}]({s}.md)")
+
+    file_path = os.path.join(CONCEPTS_DIR, f"{slug}.md")
+    with open(file_path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"\n  Created: docs/concepts/{slug}.md  (slug: {slug})")
+    print(f"  Fill in the body — keep it to 1–2 paragraphs, then link outward.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/pre_commit_check.py
+++ b/util/pre_commit_check.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+pre_commit_check.py — Run all wiki quality checks in one pass
+
+Runs the three checker scripts in sequence, prints combined output, and
+exits non-zero if any hard check fails. Suitable as a git pre-commit hook
+or a manual pre-PR sanity pass.
+
+Hard failures (exit 1):
+  check_links   — broken internal .md links
+  check_concepts — invalid concept slugs on org pages
+
+Informational only (always shown, never blocks):
+  lint_orgs     — structural issues; 4 known Wayback exceptions always appear
+
+Usage:
+    python util/pre_commit_check.py
+    python util/pre_commit_check.py --fix-hints
+
+Install as git hook:
+    echo 'python util/pre_commit_check.py' > .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+
+Requirements: python-frontmatter (util/requirements.txt)
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+UTIL_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def run(script, *extra_args):
+    cmd = [sys.executable, os.path.join(UTIL_DIR, script)] + list(extra_args)
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def section(title):
+    print(f"\n── {title} " + "─" * max(0, 50 - len(title)))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run all wiki quality checks")
+    parser.add_argument("--fix-hints", action="store_true",
+                        help="Pass --fix-hints through to lint_orgs")
+    args = parser.parse_args()
+
+    W = 56
+    print(f"\n{'═' * W}")
+    print(f"  Pre-commit check  —  {__import__('datetime').date.today()}")
+    print(f"{'═' * W}")
+
+    failures = []
+
+    section("1/3  lint_orgs  (informational)")
+    print("     4 known Wayback exceptions will always appear here.\n")
+    lint_args = ["--fix-hints"] if args.fix_hints else []
+    run("lint_orgs.py", *lint_args)
+
+    section("2/3  check_concepts --all  (hard)")
+    rc = run("check_concepts.py", "--all")
+    if rc != 0:
+        failures.append("check_concepts: invalid concept slugs found")
+
+    section("3/3  check_links --all  (hard)")
+    rc = run("check_links.py", "--all")
+    if rc != 0:
+        failures.append("check_links: broken internal links found")
+
+    print(f"\n{'═' * W}")
+    if failures:
+        print("  FAILED:")
+        for f in failures:
+            print(f"    ✗  {f}")
+    else:
+        print("  All hard checks passed.")
+    print(f"{'═' * W}\n")
+
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/util/requirements.txt
+++ b/util/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.0.0
 python-frontmatter>=1.0.0
 python-dateutil>=2.8.0
+requests>=2.28.0

--- a/util/stamp.py
+++ b/util/stamp.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+stamp.py — Set last_checked: today on org (or concept) pages
+
+Updates the last_checked frontmatter field in-place without reordering any
+other keys. Accepts slugs (resolved against docs/organisations/ then
+docs/concepts/) or explicit file paths.
+
+Usage:
+    python util/stamp.py namfrel
+    python util/stamp.py docs/organisations/namfrel.md
+    python util/stamp.py namfrel flacso-cuba mysociety
+    python util/stamp.py --all-active     # all active orgs
+    python util/stamp.py --all            # all org pages
+
+Requirements: none (stdlib only)
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+from datetime import date
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
+SKIP_FILES = {"organisations.md", "concepts.md"}
+TODAY = date.today().isoformat()
+
+LC_RE = re.compile(r'^(last_checked:\s*).*$', re.MULTILINE)
+
+
+def resolve_target(target):
+    if os.path.isfile(target):
+        return os.path.abspath(target)
+    p = os.path.join(ORGS_DIR, f"{target}.md")
+    if os.path.isfile(p):
+        return p
+    p = os.path.join(CONCEPTS_DIR, f"{target}.md")
+    if os.path.isfile(p):
+        return p
+    return None
+
+
+def stamp_file(path):
+    """Update last_checked in-place. Returns (changed, note)."""
+    with open(path) as f:
+        content = f.read()
+
+    new_val = f'last_checked: "{TODAY}"'
+    match = LC_RE.search(content)
+
+    if match:
+        old_line = match.group(0)
+        if TODAY in old_line:
+            return False, "already current"
+        new_content = content[:match.start()] + new_val + content[match.end():]
+        old_note = old_line.split(":", 1)[1].strip().strip('"')
+    else:
+        # Insert before the closing --- of frontmatter
+        lines = content.splitlines(keepends=True)
+        if not lines or not lines[0].startswith("---"):
+            return False, "no frontmatter"
+        insert_at = None
+        for i, line in enumerate(lines[1:], 1):
+            if line.strip() == "---":
+                insert_at = i
+                break
+        if insert_at is None:
+            return False, "no closing frontmatter fence"
+        lines.insert(insert_at, f"{new_val}\n")
+        new_content = "".join(lines)
+        old_note = "unset"
+
+    with open(path, "w") as f:
+        f.write(new_content)
+    return True, old_note
+
+
+def org_status(path):
+    """Read status field without full frontmatter parse — fast grep."""
+    try:
+        with open(path) as f:
+            for line in f:
+                if line.startswith("status:"):
+                    return line.split(":", 1)[1].strip()
+                if line.strip() == "---" and f.tell() > 4:
+                    break
+    except Exception:
+        pass
+    return ""
+
+
+def all_org_paths(active_only=False):
+    paths = []
+    for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        if active_only and org_status(path) != "active":
+            continue
+        paths.append(path)
+    return paths
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stamp last_checked: today on pages")
+    parser.add_argument("targets", nargs="*", help="Slugs or file paths")
+    parser.add_argument("--all-active", action="store_true", help="Stamp all active org pages")
+    parser.add_argument("--all", action="store_true", help="Stamp all org pages")
+    args = parser.parse_args()
+
+    if not args.targets and not args.all_active and not args.all:
+        parser.print_help()
+        sys.exit(1)
+
+    paths = []
+    if args.all or args.all_active:
+        paths = all_org_paths(active_only=args.all_active)
+    else:
+        for t in args.targets:
+            p = resolve_target(t)
+            if p is None:
+                print(f"  ✗ Not found: {t}")
+            else:
+                paths.append(p)
+
+    changed = skipped = errors = 0
+    for path in paths:
+        try:
+            updated, note = stamp_file(path)
+            rel = os.path.relpath(path)
+            if updated:
+                print(f"  ✓ {rel}  ({note} → {TODAY})")
+                changed += 1
+            else:
+                skipped += 1
+        except Exception as e:
+            print(f"  ✗ {os.path.relpath(path)}: {e}")
+            errors += 1
+
+    print(f"\nDone: {changed} stamped, {skipped} already current, {errors} errors")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/stats.py
+++ b/util/stats.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+stats.py — Democracy Landscape snapshot
+
+Quick situational overview: org counts, geographic spread, type breakdown,
+last_checked freshness, and concept coverage. Run at the start of a
+maintenance session to understand the current state of the wiki.
+
+Usage:
+    python util/stats.py
+    python util/stats.py --concepts   # include orphaned concept list
+
+Requirements: python-frontmatter (util/requirements.txt)
+"""
+
+import argparse
+import glob
+import os
+import sys
+from collections import Counter
+from datetime import date, datetime
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
+SKIP_FILES = {"organisations.md", "concepts.md"}
+TODAY = date.today()
+
+
+def parse_date(val):
+    if val is None:
+        return None
+    if isinstance(val, (datetime, date)):
+        return val.date() if isinstance(val, datetime) else val
+    try:
+        return date.fromisoformat(str(val).strip('"'))
+    except ValueError:
+        return None
+
+
+def load_orgs():
+    orgs = []
+    for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        m = post.metadata
+        lc = parse_date(m.get("last_checked"))
+        orgs.append({
+            "title": m.get("title", os.path.basename(path)[:-3]),
+            "status": m.get("status", "unknown"),
+            "type": m.get("type", "unknown"),
+            "country": m.get("country", "??"),
+            "concepts": m.get("concepts") or [],
+            "last_checked": lc,
+            "age_days": (TODAY - lc).days if lc else None,
+        })
+    return orgs
+
+
+def load_concept_slugs():
+    slugs = set()
+    for path in glob.glob(os.path.join(CONCEPTS_DIR, "*.md")):
+        slug = os.path.basename(path)[:-3]
+        if slug != "concepts":
+            slugs.add(slug)
+    return slugs
+
+
+def bar(n, total, width=18):
+    if not total:
+        return "░" * width
+    filled = round(width * n / total)
+    return "█" * filled + "░" * (width - filled)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Democracy Landscape snapshot")
+    parser.add_argument("--concepts", action="store_true",
+                        help="List orphaned concept pages")
+    args = parser.parse_args()
+
+    orgs = load_orgs()
+    concept_slugs = load_concept_slugs()
+    total = len(orgs)
+
+    W = 56
+    print(f"\n{'═' * W}")
+    print(f"  Democracy Landscape  —  {TODAY}")
+    print(f"{'═' * W}\n")
+
+    # --- Status breakdown ---
+    status_counts = Counter(o["status"] for o in orgs)
+    print(f"Orgs  ({total} total)")
+    for s in ("active", "inactive", "deregistered", "unknown"):
+        n = status_counts.get(s, 0)
+        if n:
+            print(f"  {s:<14} {n:>4}  {bar(n, total)}")
+    print()
+
+    # --- Country breakdown (active) ---
+    active = [o for o in orgs if o["status"] == "active"]
+    country_counts = Counter(o["country"] for o in active)
+    print(f"Active orgs by country  ({len(active)} total)")
+    for country, n in country_counts.most_common(12):
+        print(f"  {country:<6} {n:>4}  {bar(n, len(active), 14)}")
+    print()
+
+    # --- Type breakdown (active) ---
+    type_counts = Counter(o["type"] for o in active)
+    print(f"Active orgs by type")
+    for t, n in type_counts.most_common():
+        print(f"  {t:<22} {n:>4}")
+    print()
+
+    # --- Freshness ---
+    checked = [o for o in orgs if o["age_days"] is not None]
+    never = [o for o in orgs if o["age_days"] is None]
+    active_never = [o for o in never if o["status"] == "active"]
+
+    print(f"Freshness  (last_checked)")
+    print(f"  Never checked:      {len(never):>4}  ({len(active_never)} active)")
+    if checked:
+        buckets = [
+            (0,   30,  "< 30 days"),
+            (30,  90,  "30–90 days"),
+            (90,  180, "90–180 days"),
+            (180, 365, "180–365 days"),
+            (365, None, "> 365 days"),
+        ]
+        for lo, hi, label in buckets:
+            if hi is None:
+                n = sum(1 for o in checked if o["age_days"] >= lo)
+            else:
+                n = sum(1 for o in checked if lo <= o["age_days"] < hi)
+            if n:
+                print(f"  {label:<16}  {n:>4}")
+    print()
+
+    # --- Concept coverage ---
+    all_referenced = set()
+    for o in orgs:
+        all_referenced.update(o["concepts"])
+    orphans = sorted(concept_slugs - all_referenced)
+
+    concept_ref_counts = Counter()
+    for o in orgs:
+        for c in o["concepts"]:
+            concept_ref_counts[c] += 1
+
+    orgs_with_concepts = sum(1 for o in orgs if o["concepts"])
+
+    print(f"Concepts  ({len(concept_slugs)} pages)")
+    print(f"  Referenced by ≥1 org:   {len(all_referenced & concept_slugs):>4}")
+    print(f"  Orphaned (no org ref):  {len(orphans):>4}")
+    print(f"  Orgs with concepts:     {orgs_with_concepts:>4} / {total}")
+    print()
+
+    print(f"Most referenced concepts  (top 10)")
+    for slug, n in concept_ref_counts.most_common(10):
+        print(f"  {slug:<36} {n:>4}")
+    print()
+
+    if args.concepts and orphans:
+        print(f"Orphaned concept pages  ({len(orphans)}):")
+        for slug in orphans:
+            print(f"  docs/concepts/{slug}.md")
+        print()
+
+    print(f"{'═' * W}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/suggest_tags.py
+++ b/util/suggest_tags.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+suggest_tags.py — Suggest concept tag additions to org pages
+
+Given a concept slug, finds org pages that don't have it tagged but mention
+related keywords in their body. Keywords are derived from the concept slug
+and its page title; extend with --keywords for better recall.
+
+Usage:
+    python util/suggest_tags.py deliberative-democracy
+    python util/suggest_tags.py citizens-assembly --keywords "mini-public" "citizen panel"
+    python util/suggest_tags.py e-government --threshold 2   # require 2+ hits
+    python util/suggest_tags.py sortition --all              # include already-tagged
+
+Requirements: python-frontmatter (util/requirements.txt)
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+CONCEPTS_DIR = os.path.join(DOCS_DIR, "concepts")
+SKIP_FILES = {"organisations.md"}
+STOP_WORDS = {
+    "a", "an", "the", "and", "or", "of", "for", "in", "to", "is", "are",
+    "was", "were", "that", "this", "it", "at", "by", "on", "with", "as",
+    "from", "what", "how", "which", "who", "be", "been", "have", "has",
+}
+
+
+def slug_keywords(slug):
+    return [w for w in slug.replace("-", " ").split()
+            if w not in STOP_WORDS and len(w) > 2]
+
+
+def concept_page_keywords(slug):
+    """Extract bolded terms from the first 600 chars of the concept body."""
+    path = os.path.join(CONCEPTS_DIR, f"{slug}.md")
+    if not os.path.isfile(path):
+        return []
+    post = frontmatter.load(path)
+    bold = re.findall(r'\*\*([^*]+)\*\*', post.content[:600])
+    extra = []
+    for term in bold:
+        words = [w.lower() for w in term.split()
+                 if w.lower() not in STOP_WORDS and len(w) > 2]
+        extra.extend(words)
+    return extra
+
+
+def matches_in_body(content, patterns):
+    hits = []
+    for i, line in enumerate(content.splitlines(), 1):
+        ll = line.lower()
+        for pat in patterns:
+            if pat.search(ll):
+                hits.append((i, line.strip()))
+                break
+    return hits
+
+
+def filter_ubiquitous(kws, org_paths, max_freq=0.4):
+    """Drop keywords that appear in more than max_freq of org bodies — too broad to discriminate."""
+    total = len(org_paths)
+    if not total:
+        return kws
+    kept = []
+    for kw in kws:
+        pat = re.compile(r'\b' + re.escape(kw) + r'\b')
+        hits = sum(1 for p in org_paths if _body_contains(p, pat))
+        freq = hits / total
+        if freq <= max_freq:
+            kept.append(kw)
+        else:
+            pass  # silently drop — too common
+    return kept
+
+
+def _body_contains(path, pat):
+    try:
+        post = frontmatter.load(path)
+        return bool(pat.search(post.content.lower()))
+    except Exception:
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Suggest concept tags for org pages based on keyword matches")
+    parser.add_argument("slug", help="Concept slug (e.g. deliberative-democracy)")
+    parser.add_argument("--keywords", nargs="+", metavar="TERM",
+                        help="Extra search keywords (phrases OK)")
+    parser.add_argument("--threshold", type=int, default=1,
+                        help="Min keyword hits to suggest tagging (default: 1)")
+    parser.add_argument("--all", action="store_true",
+                        help="Include orgs already tagged (for audit)")
+    args = parser.parse_args()
+
+    concept_path = os.path.join(CONCEPTS_DIR, f"{args.slug}.md")
+    if not os.path.isfile(concept_path):
+        print(f"Unknown concept slug: {args.slug}")
+        sys.exit(1)
+
+    # Build keyword list
+    kws = slug_keywords(args.slug) + concept_page_keywords(args.slug)
+    if args.keywords:
+        kws += [k.lower() for k in args.keywords]
+    # Deduplicate, preserve order
+    seen: set = set()
+    kws = [k for k in kws if not (k in seen or seen.add(k))]  # type: ignore[func-returns-value]
+
+    # Drop keywords that appear in >40% of org bodies — too broad to discriminate
+    all_org_paths = sorted(glob.glob(os.path.join(ORGS_DIR, "*.md")))
+    all_org_paths = [p for p in all_org_paths if os.path.basename(p) not in SKIP_FILES]
+    kws_filtered = filter_ubiquitous(kws, all_org_paths)
+    dropped = [k for k in kws if k not in kws_filtered]
+    if dropped:
+        print(f"    (Dropped overly common keywords: {', '.join(dropped)})")
+    kws = kws_filtered
+
+    if not kws:
+        print(f"All derived keywords were too common (>40% of orgs).")
+        print(f"Use --keywords to specify more distinctive terms.\n")
+        sys.exit(0)
+
+    patterns = [re.compile(r'\b' + re.escape(kw) + r'\b') for kw in kws]
+
+    print(f"\n=== Tag suggestions: {args.slug} ===")
+    print(f"    Keywords: {', '.join(kws)}\n")
+
+    suggestions = []
+    already_count = 0
+    no_match_count = 0
+
+    for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        m = post.metadata
+        title = m.get("title", os.path.basename(path)[:-3])
+        tagged = args.slug in (m.get("concepts") or [])
+
+        if tagged:
+            already_count += 1
+            if not args.all:
+                continue
+
+        hits = matches_in_body(post.content, patterns)
+
+        if len(hits) >= args.threshold:
+            suggestions.append({
+                "path": path, "title": title,
+                "tagged": tagged, "hits": hits,
+            })
+        elif not tagged:
+            no_match_count += 1
+
+    untagged_suggestions = [s for s in suggestions if not s["tagged"]]
+    tagged_suggestions = [s for s in suggestions if s["tagged"]]
+
+    if untagged_suggestions:
+        print(f"Untagged orgs to consider  ({len(untagged_suggestions)}):\n")
+        for s in untagged_suggestions:
+            print(f"  {s['title']}")
+            print(f"    {os.path.relpath(s['path'])}")
+            for lineno, line in s["hits"][:3]:
+                print(f"    {lineno:>4}: {line[:100]}")
+            if len(s["hits"]) > 3:
+                print(f"         … {len(s['hits']) - 3} more")
+            print()
+    else:
+        print("No untagged orgs found with matching keywords.\n")
+
+    if args.all and tagged_suggestions:
+        print(f"Already-tagged orgs with matches  ({len(tagged_suggestions)}):")
+        for s in tagged_suggestions:
+            print(f"  ✓ {s['title']}  ({len(s['hits'])} hit(s))")
+        print()
+
+    print(f"Already tagged: {already_count}  |  "
+          f"Suggested: {len(untagged_suggestions)}  |  "
+          f"No match: {no_match_count}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

A full maintenance toolkit for the Democracy Landscape wiki — covering the entire loop from orientation through scaffolding, tagging, verification, and pre-commit gating. Also adds `/llms.txt` for LLM-friendly site discovery, fixes 3 inactive org pages with wrong URLs, and fixes 2 non-ISO country codes.

---

## Scripts added / updated

| Script | Purpose |
|---|---|
| `stats.py` | Landscape snapshot: org counts, country/type spread, freshness, concept coverage |
| `find.py` | Full-text search across org/concept pages by keyword or regex |
| `add_org.py` | Scaffold new org page — validates ISO country, concept slugs, Wayback convention inline |
| `new_concept.py` | Scaffold new concept page with discovery-aid structure |
| `suggest_tags.py` | Find untagged orgs whose body mentions a concept's keywords; frequency filter drops overly common terms automatically |
| `stamp.py` | Set `last_checked: today` in-place (no key reordering), by slug or path |
| `check_orgs.py` | Staleness queue: active orgs sorted by oldest/missing `last_checked` |
| `check_concepts.py` | Invalid concept slugs on org pages; orphaned concept pages |
| `check_links.py` | Broken internal `.md` links (MkDocs `use_directory_urls`-aware) |
| `lint_orgs.py` | Structural rules: Wayback/live URL, missing map coords, invalid status, non-ISO country codes |
| `check_urls.py` | HTTP reachability sweep for `website:` fields; skips Wayback exceptions |
| `pre_commit_check.py` | Run all checks in one pass; exits non-zero on hard failures; git hook-ready |
| `createPost.py` | Overhauled: adds categories + link prompts, slug sanitisation, overwrite guard |
| `SOUL.md` | Intent document: why each script exists, conventions, known exceptions, workflows |

## Hook added

| Hook | Purpose |
|---|---|
| `hooks/llms_txt.py` | Generates `/llms.txt` at build time from org/concept frontmatter — compact index (~50k chars) covering all 108 orgs and 37 concepts so LLMs can find the right page without crawling the whole site |

---

## Org / data fixes

- `democracy-foundation`, `peoplecount`, `electoral-royal-commission`: `website:` pointed to live URLs for inactive orgs — corrected to Wayback Machine calendar URLs
- `conversations-at-the-crossroads`, `lismore-peoples-assembly`: `country: Australia` → `country: AU` (surfaced by `stats.py`)
- NAMFREL: added `last_checked`, noted domains exist but origin server is down (522)

---

## Typical maintenance workflow

```bash
python util/stats.py                        # orient — counts, freshness, concept coverage
python util/find.py "keyword"               # check for existing coverage before adding
python util/add_org.py                      # scaffold a new org page
python util/suggest_tags.py <concept-slug>  # find untagged orgs to back-tag
python util/check_orgs.py --active          # queue of pages due for re-verification
python util/stamp.py slug1 slug2            # mark verified pages
python util/pre_commit_check.py             # lint + concept + link checks before committing
```

---

## Test plan

- [ ] `python util/pre_commit_check.py` exits 0 — all hard checks pass
- [ ] `python util/stats.py` — AU shows as 27 (not split with `Australia`)
- [ ] `python util/find.py "deliberative"` returns relevant pages
- [ ] `python util/suggest_tags.py deliberative-democracy` returns focused suggestions
- [ ] `python util/stamp.py <slug>` updates `last_checked` in-place; idempotent on second run
- [ ] `mkdocs build` generates `site/llms.txt` with org index