### PR TITLE
Fix /llms.txt 404 — add python-frontmatter to site build deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-material-extensions==1.3.1
 mkdocs-literate-nav==0.6.3
 mkdocs-ezlinks-plugin==0.1.14
 mkdocs-rss-plugin==1.19.0
+python-frontmatter>=1.0.0


### PR DESCRIPTION
## Problem

`https://www.designingopendemocracy.com/llms.txt` returns 404.

The `hooks/llms_txt.py` build hook has a graceful degradation path — if `python-frontmatter` isn't installed it silently does nothing. In CI, only `requirements.txt` is installed, and `python-frontmatter` was only in `util/requirements.txt`. So the hook was a no-op in CI and `docs/llms.txt` was never generated, so `site/llms.txt` never existed.

## Fix

Add `python-frontmatter>=1.0.0` to `requirements.txt`.

## Test plan

- [ ] After merge and CI redeploy, `https://www.designingopendemocracy.com/llms.txt` serves the org/concept index

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_