### PR TITLE
llms.txt: add community/projects pointer to key pages

### DIFF
--- a/hooks/llms_txt.py
+++ b/hooks/llms_txt.py
@@ -144,6 +144,7 @@ def build_llms_txt(site_url):
         f"- Knowledge graph (org↔concept relationships): {site_url}/graph/",
         f"- Blog (event posts, meetup summaries): {site_url}/blog/",
         f"- About / philosophy: {site_url}/about/",
+        f"- DOD's own projects (wiki, tools, research): {site_url}/community/",
         "",
     ]
 


### PR DESCRIPTION
One-liner addition to the Key pages section of `llms.txt` so an LLM knows DOD's own projects exist and where to find them, without indexing every project page individually.

Before: Key pages listed org index, concept index, knowledge graph, blog, about.  
After: also includes `- DOD's own projects (wiki, tools, research): /community/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtEmEDUxow8frMecj28Wqy)_