### PR TITLE
knowledge-graph: dormant orgs show emoji-only at wide zoom, reveal name on zoom-in

### DIFF
--- a/docs/knowledge-graph.md
+++ b/docs/knowledge-graph.md
@@ -6,7 +6,7 @@ template: knowledge-graph.html
 Explore the connections between concepts, organisations, and projects tracked on this site.
 
 - **Concepts** (indigo) — governance and democracy ideas
-- **Organisations** (blue → grey) — groups in the democracy landscape; colour and size indicate recency of activity: vivid blue = recently active, fading to grey = dormant or inactive. Emoji prefix shows org type (🔬 research · 📢 advocacy · 💻 platform · ⚙️ civic tech · 🤝 practice · 🗳️ party/political · 🏛️ governance · ♻️ cooperative · 🌱 philanthropy · 🎓 education)
+- **Organisations** (blue → grey) — groups in the democracy landscape; vivid blue = recently active, fading to grey = dormant or inactive. Dormant orgs show only their type emoji when zoomed out; zoom in to reveal names. Emoji key: 🔬 research · 📢 advocacy · 💻 platform · ⚙️ civic tech · 🤝 practice · 🗳️ party/political · 🏛️ governance · ♻️ cooperative · 🌱 philanthropy · 🎓 education
 - **Projects** (green) — Designing Open Democracy's own work
 - **Solid edges** — organisation or project relates to a concept (`concepts:` frontmatter)
 - **Dashed purple edges** — concept links to another concept (from *See also* sections)

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -197,8 +197,13 @@
         }
         var s = (data.type === 'organisation' || data.type === 'project')
           ? staleness(data.activity_date) : 0;
-        data.base_font    = data.type === 'concept' ? 11 : 9 - s * 2.5;
         data.stale_factor = s;
+        // Dormant orgs (stale ≥ ~6 months) show emoji-only when zoomed out
+        if (data.type === 'organisation' && s >= 0.5) {
+          data.full_label  = data.label;
+          data.short_label = TYPE_EMOJI[data.org_type] || '•';
+          data.label       = data.short_label;
+        }
         return { data: data };
       }),
       ...graphData.edges.map(function(e, i) {
@@ -255,15 +260,23 @@
         edge.addClass('hidden');
     });
 
-    cy.fit();
+    // Zoom-invariant font + label switching (dormant orgs: emoji at low zoom, name when zoomed in)
+    var LABEL_ZOOM = 0.6;
 
-    // Zoom-invariant font size (per-node base_font respects staleness scaling)
-    cy.on('zoom', function() {
+    function updateZoom() {
       var z = cy.zoom();
+      var showFull = z >= LABEL_ZOOM;
       cy.nodes().forEach(function(node) {
-        node.style('font-size', ((node.data('base_font') || 9) / z) + 'px');
+        var d = node.data();
+        node.style('font-size', ((d.type === 'concept' ? 11 : 9) / z) + 'px');
+        if (d.short_label) node.data('label', showFull ? d.full_label : d.short_label);
       });
-    });
+    }
+
+    cy.fit();
+    updateZoom();
+
+    cy.on('zoom', updateZoom);
 
     // Middle and right-click panning
     var _panning = false, _panAnchor = {x:0,y:0}, _panOrigin = {x:0,y:0};


### PR DESCRIPTION
Dormant organisations (last activity >~6 months ago, or no recorded activity) now display only their type emoji when the graph is zoomed out. Zooming past 0.6× reveals the full name.

## Changes

- `knowledge-graph.html`: dormant orgs (`stale_factor >= 0.5`) get a `short_label` (type emoji) and `full_label` (full name). A shared `updateZoom()` function handles both zoom-invariant font sizing and the emoji↔name switch, called on load and on every zoom event.
- `knowledge-graph.md`: updated legend to describe the zoom-reveal behaviour and emoji key.

## Visual behaviour

| Zoom level | Dormant org label | Active org label |
|---|---|---|
| Wide / default fit | 🔬 (emoji only) | Full name |
| Zoomed in ≥ 0.6× | Full name | Full name |

Colour still fades to grey for dormant orgs as a secondary cue. The `LABEL_ZOOM = 0.6` constant is easy to adjust if the reveal point needs tuning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQyGLcNV9ocX6VpkQrP7Ke)_