### PR TITLE
knowledge-graph: org links, edge/colour fading, edge click-through

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ The invariants recorded there are not immutable. Any document in this repo — i
 - `location: {latitude, longitude, name}` — required for the org to appear on the interactive map. Only `status: active` orgs are shown on the map.
 - The `organisation.html` template is **auto-applied** to all org pages via `hooks/org_template.py` — no need to set `template:` in frontmatter unless overriding.
 - `rss_feed: <url>` — optional; the org's RSS or Atom feed URL. Populated by `util/check_rss.py`.
+- `related_orgs: [slug, slug]` — optional; list of org slugs with a direct relationship to this org. Rendered as orange edges in the knowledge graph. Declare on one side only — direction is normalised so duplicates are automatically suppressed.
 - `activity:` — optional dict of evidence sources, each keyed by method name. The build hook
   (`hooks/activity_selector.py`) picks the best entry for display using a priority order and
   per-source staleness thresholds.

--- a/docs/knowledge-graph.md
+++ b/docs/knowledge-graph.md
@@ -8,7 +8,8 @@ Explore the connections between concepts, organisations, and projects tracked on
 - **Concepts** (indigo) — governance and democracy ideas
 - **Organisations** (blue → grey) — groups in the democracy landscape; vivid blue = recently active, fading to grey = dormant or inactive. All orgs start as emoji-only when zoomed out; zoom in to reveal names progressively — most recently active orgs appear first. Emoji key: 🔬 research · 📢 advocacy · 💻 platform · ⚙️ civic tech · 🤝 practice · 🗳️ party/political · 🏛️ governance · ♻️ cooperative · 🌱 philanthropy · 🎓 education
 - **Projects** (green) — Designing Open Democracy's own work
-- **Solid edges** — organisation or project relates to a concept (`concepts:` frontmatter)
+- **Solid grey edges** — organisation or project relates to a concept (`concepts:` frontmatter)
+- **Solid orange edges** — direct org-to-org link (`related_orgs:` frontmatter)
 - **Dashed purple edges** — concept links to another concept (from *See also* sections)
 
 Click a node to see details; double-click to navigate to its page. Left-click drag to pan, scroll to zoom, or use middle/right-click drag to pan. Use the toolbar to filter by type, show only active entries, search by name, or zoom to fit.

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -149,7 +149,7 @@
       style: {
         'width':       1,
         'line-color':  '#90a4ae',
-        'opacity':     0.5,
+        'opacity':     ele => Math.max(0.08, 0.5 - ele.data('stale_rank') * 0.4),
         'curve-style': 'bezier',
       }
     },
@@ -159,7 +159,7 @@
     },
     {
       selector: 'edge[type = "org_link"]',
-      style: { 'line-color': '#e65100', 'width': 2, 'opacity': 0.75 }
+      style: { 'line-color': '#e65100', 'width': 2, 'opacity': ele => Math.max(0.1, 0.75 - ele.data('stale_rank') * 0.6) }
     },
     {
       selector: 'node.highlighted',
@@ -223,6 +223,17 @@
     orgEls.forEach(function(el, i) {
       var t = orgEls.length > 1 ? i / (orgEls.length - 1) : 0;
       el.data.reveal_zoom = 1.0 + t * 3.0;
+      el.data.stale_rank  = t;
+    });
+
+    // Propagate stale_rank to edges: use the stalest endpoint.
+    var nodeRank = {};
+    elements.forEach(function(el) {
+      if (el.data.stale_rank !== undefined) nodeRank[el.data.id] = el.data.stale_rank;
+    });
+    elements.forEach(function(el) {
+      if (el.data.source !== undefined)
+        el.data.stale_rank = Math.max(nodeRank[el.data.source] || 0, nodeRank[el.data.target] || 0);
     });
 
     var cy = cytoscape({

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -158,6 +158,10 @@
       style: { 'line-color': '#9c27b0', 'line-style': 'dashed', 'opacity': 0.4 }
     },
     {
+      selector: 'edge[type = "org_link"]',
+      style: { 'line-color': '#e65100', 'width': 2, 'opacity': 0.75 }
+    },
+    {
       selector: 'node.highlighted',
       style: { 'border-width': '3px', 'border-color': '#ffeb3b', 'z-index': 10 }
     },

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -340,8 +340,8 @@
       showInfo(node.data());
       cy.elements().addClass('faded').removeClass('highlighted');
       node.removeClass('faded').addClass('highlighted');
-      var neighbours = node.connectedEdges().connectedNodes();
-      neighbours.removeClass('faded');
+      var connectedEdges = node.connectedEdges().removeClass('faded');
+      var neighbours = connectedEdges.connectedNodes().removeClass('faded');
       // Pin selected node + neighbours so they always show full label
       cy.nodes().removeClass('pinned');
       node.addClass('pinned');

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -78,18 +78,10 @@
   }
 
   function bgColor(d) {
-    var base;
-    if (d.type === 'concept') return '#3949ab';
-    if (d.type === 'organisation') {
-      if (d.status === 'active')            base = '#1565c0';
-      else if (d.status === 'deregistered') base = '#78909c';
-      else                                  base = '#607d8b';
-    } else if (d.type === 'project') {
-      base = d.status === 'active' ? '#2e7d32' : '#66bb6a';
-    } else {
-      return '#9e9e9e';
-    }
-    return blendToGrey(base, (d.stale_factor || 0) * 0.6);
+    if (d.type === 'concept')      return '#3949ab';
+    if (d.type === 'organisation') return blendToGrey('#1565c0', (d.stale_rank || 0) * 0.8);
+    if (d.type === 'project')      return d.status === 'active' ? '#2e7d32' : '#66bb6a';
+    return '#9e9e9e';
   }
 
   var TYPE_EMOJI = {

--- a/docs/overrides/knowledge-graph.html
+++ b/docs/overrides/knowledge-graph.html
@@ -151,6 +151,7 @@
         'line-color':  '#90a4ae',
         'opacity':     ele => Math.max(0.08, 0.5 - ele.data('stale_rank') * 0.4),
         'curve-style': 'bezier',
+        'events':      'no',
       }
     },
     {

--- a/hooks/graph_builder.py
+++ b/hooks/graph_builder.py
@@ -97,6 +97,9 @@ def on_page_context(context, *, page, config, nav):
         }
         for c in (page.meta.get('concepts') or []):
             _edges.append({'source': node_id, 'target': f'concept:{c}', 'type': 'relates_to'})
+        for r in (page.meta.get('related_orgs') or []):
+            a, b = sorted([node_id, f'org:{r}'])
+            _edges.append({'source': a, 'target': b, 'type': 'org_link'})
 
     elif url.startswith('projects/') and url not in ('projects/', 'projects/projects/'):
         slug = url.replace('projects/', '').rstrip('/')


### PR DESCRIPTION
Five commits:

**Restore edge visibility on selection** — edges connecting a selected node were accidentally faded in a prior refactor; fixed by un-fading `connectedEdges()` before traversing to neighbour nodes.

**Org-to-org links via `related_orgs` frontmatter** — add `related_orgs: [slug, slug]` to any org page to declare a direct relationship. `graph_builder.py` emits these as `org_link` edges (direction normalised so declaring on one side is enough). Rendered as thick orange edges. Documented in CLAUDE.md and the graph legend.

**Fade edges by activity rank** — each edge gets `stale_rank = max(source_rank, target_rank)`. Concept edges fade from opacity 0.5 → 0.08; org-link edges from 0.75 → 0.10. Concept–concept (see-also) edges keep a fixed 0.4.

**Disable edge pointer events** — `events: no` on the edge base style so clicks and drags on edges pass through to the canvas, fixing panning interference.

**Continuous org colour fade** — `bgColor` now uses a single `#1565c0` base for all orgs and blends toward grey by `stale_rank` (0→80%). Removes the two-state active/inactive colour split.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQyGLcNV9ocX6VpkQrP7Ke)_