### PR TITLE
Standardize organisation type taxonomy and adjust table layout

### DIFF
--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -511,12 +511,12 @@
     background: rgba(128, 128, 128, 0.08);
 }
 
-.org-sortable-table th:nth-child(1) { width: 28%; }
-.org-sortable-table th:nth-child(2) { width: 12%; }
-.org-sortable-table th:nth-child(3) { width: 10%; }
-.org-sortable-table th:nth-child(4) { width: 10%; }
+.org-sortable-table th:nth-child(1) { width: 35%; }
+.org-sortable-table th:nth-child(2) { width: 9%; }
+.org-sortable-table th:nth-child(3) { width: 9%; }
+.org-sortable-table th:nth-child(4) { width: 9%; }
 .org-sortable-table th:nth-child(5) { width: 14%; }
-.org-sortable-table th:nth-child(6) { width: 26%; }
+.org-sortable-table th:nth-child(6) { width: 24%; }
 
 .sort-icon {
     opacity: 0.45;

--- a/docs/organisations/a-nous-la-democratie.md
+++ b/docs/organisations/a-nous-la-democratie.md
@@ -1,6 +1,6 @@
 ---
 title: À Nous La Démocratie!
-type: political_movement
+type: movement
 status: active
 country: FR
 website: https://anouslademocratie.fr/

--- a/docs/organisations/br-acc.md
+++ b/docs/organisations/br-acc.md
@@ -1,6 +1,6 @@
 ---
 title: br/acc (World Transparency Graph)
-type: civic_tech
+type: civic tech
 status: active
 country: BR
 website: https://github.com/brunoclz/br-acc

--- a/docs/organisations/build-a-ballot.md
+++ b/docs/organisations/build-a-ballot.md
@@ -1,6 +1,6 @@
 ---
 title: Build a Ballot
-type: civic_tech
+type: civic tech
 status: active
 country: AU
 website: https://www.buildaballot.org.au

--- a/docs/organisations/china-democratic-league.md
+++ b/docs/organisations/china-democratic-league.md
@@ -1,6 +1,6 @@
 ---
 title: China Democratic League (CDL)
-type: political_party
+type: party
 status: active
 country: CN
 website: https://www.mmzy.org.cn

--- a/docs/organisations/code-for-australia.md
+++ b/docs/organisations/code-for-australia.md
@@ -1,6 +1,6 @@
 ---
 title: Code for Australia
-type: civic_tech
+type: civic tech
 status: active
 country: AU
 website: https://www.codeforaustralia.org

--- a/docs/organisations/democracylab.md
+++ b/docs/organisations/democracylab.md
@@ -1,6 +1,6 @@
 ---
 title: DemocracyLab
-type: civic_tech
+type: civic tech
 status: active
 country: US
 website: https://www.democracylab.org

--- a/docs/organisations/diem25.md
+++ b/docs/organisations/diem25.md
@@ -1,6 +1,6 @@
 ---
 title: DiEM25
-type: political_movement
+type: movement
 status: active
 country: EU
 website: https://diem25.org

--- a/docs/organisations/flux-party.md
+++ b/docs/organisations/flux-party.md
@@ -1,6 +1,6 @@
 ---
 title: Flux Party
-type: political-party
+type: party
 status: deregistered
 country: AU
 website: https://web.archive.org/web/*/https://voteflux.org/

--- a/docs/organisations/g0v.md
+++ b/docs/organisations/g0v.md
@@ -1,6 +1,6 @@
 ---
 title: g0v (gov zero)
-type: civic_tech
+type: civic tech
 status: active
 country: TW
 website: https://g0v.tw

--- a/docs/organisations/janaagraha.md
+++ b/docs/organisations/janaagraha.md
@@ -1,6 +1,6 @@
 ---
 title: Janaagraha Centre for Citizenship and Democracy
-type: civic_tech
+type: civic tech
 status: active
 country: IN
 website: https://www.janaagraha.org

--- a/docs/organisations/liquid-democracy-ev.md
+++ b/docs/organisations/liquid-democracy-ev.md
@@ -1,6 +1,6 @@
 ---
 title: Liquid Democracy e.V.
-type: civic_tech
+type: civic tech
 status: active
 country: DE
 website: https://liqd.net/en/

--- a/docs/organisations/mysociety.md
+++ b/docs/organisations/mysociety.md
@@ -1,6 +1,6 @@
 ---
 title: mySociety
-type: civic_tech
+type: civic tech
 status: active
 country: GB
 website: https://www.mysociety.org

--- a/docs/organisations/open-australia-foundation.md
+++ b/docs/organisations/open-australia-foundation.md
@@ -1,6 +1,6 @@
 ---
 title: OpenAustralia Foundation
-type: civic_tech
+type: civic tech
 status: active
 country: AU
 website: https://www.openaustraliafoundation.org.au

--- a/docs/overrides/organisations.html
+++ b/docs/overrides/organisations.html
@@ -2,9 +2,9 @@
 {% set type_icons = {
   'research': '🔬', 'education': '🔬',
   'advocacy': '📢',
-  'platform': '💻', 'civic_tech': '💻',
+  'platform': '💻', 'civic tech': '💻',
   'practice': '🤝', 'philanthropy': '🤝', 'cooperative': '🤝',
-  'party': '🗳️', 'political_party': '🗳️', 'political-party': '🗳️', 'political_movement': '🗳️',
+  'party': '🗳️', 'movement': '🗳️',
   'governance': '⚖️', 'government': '⚖️'
 } %}
 {% block content %}


### PR DESCRIPTION
## Summary

This PR standardizes the organisation type taxonomy by consolidating variant spellings and naming conventions into a single canonical form for each type, and adjusts the sortable table column widths to better accommodate the updated content.

## Changes

**Organisation type taxonomy:**
- Consolidated `civic_tech` → `civic tech` (space instead of underscore)
- Consolidated `political_party`, `political-party`, `political_movement` → `party` and `movement` (simplified naming)
- Updated the type icon mapping in `organisations.html` to reflect the new canonical types
- Updated 13 organisation markdown files to use the new type values

**Table layout:**
- Adjusted `.org-sortable-table` column widths in `customizations.css`:
  - Column 1: 28% → 35% (wider for organisation names)
  - Columns 2–4: 12%, 10%, 10% → 9%, 9%, 9% (narrower, more balanced)
  - Column 6: 26% → 24% (slight reduction)

## Implementation Details

The type consolidation reduces cognitive overhead for curators and improves consistency across the organisation index. The table width adjustments provide better visual balance and accommodate longer organisation names without overflow.

https://claude.ai/code/session_01NydQ78toweVU1W32VmgkQn