### PR TITLE
Add interactive org review tool and human maintenance guide

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -7,6 +7,29 @@ Read **CLAUDE.md** first for site conventions and curation standards.
 
 ---
 
+## Quick start (copy-paste sequence)
+
+```bash
+# 1. automated data collection (no input needed)
+python util/check_rss.py --update-activity
+python util/scrape_news.py
+python util/check_urls.py
+
+# 2. manual review pass (interactive — opens each site in browser)
+python util/review_orgs.py
+
+# 3. lint check
+python util/pre_commit_check.py
+
+# 4. commit
+git add docs/organisations/
+git commit -m "Maintenance pass — YYYY-MM: N orgs verified"
+```
+
+Read the detail sections below if anything looks unfamiliar.
+
+---
+
 ## Setup
 
 ```bash

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,151 @@
+# Human Maintenance Guide
+
+A step-by-step pass for a human contributor to keep org data fresh.
+Run this whenever you have an hour or two — quarterly is a reasonable cadence.
+
+Read **CLAUDE.md** first for site conventions and curation standards.
+
+---
+
+## Setup
+
+```bash
+pip install -r util/requirements.txt
+```
+
+---
+
+## The sequence
+
+### 1. Orient
+
+```bash
+python util/stats.py
+```
+
+Gives you a snapshot: org counts, freshness distribution, concept coverage.
+Take note of how many orgs have no recent activity signal — that's your backlog.
+
+---
+
+### 2. Automated data collection
+
+Run these in order. They write `activity.*` entries to frontmatter automatically
+and do not require any manual input.
+
+**Probe RSS feeds and sitemaps:**
+
+```bash
+python util/check_rss.py --update-activity
+```
+
+Tries 23 common feed paths per site. Writes `activity.rss` with the latest
+post date and title, or `activity.sitemap` as a fallback (confirms the site
+is alive but carries less weight). Takes a few minutes for the full set.
+
+**Scrape news pages** (orgs that have `news_page:` set):
+
+```bash
+python util/scrape_news.py
+```
+
+Extracts dates from JSON-LD, OpenGraph, and `<time>` elements only.
+Writes `activity.scrape`. Respects robots.txt.
+
+**Check for dead websites:**
+
+```bash
+python util/check_urls.py
+```
+
+Reports which org websites return errors or have gone offline. Any
+`CLIENT_ERROR` or `CONNECTION_ERROR` result warrants a manual check —
+the org may have moved, gone inactive, or shut down.
+
+---
+
+### 3. Manual review pass
+
+This is the highest-value step. `activity.manual` carries the most weight in
+the activity ranking and stays fresh for two years.
+
+```bash
+python util/review_orgs.py
+```
+
+At startup it asks which scope to review:
+
+```
+Which orgs do you want to review?
+  [1] All active orgs
+  [2] Never manually reviewed
+  [3] Stale manual review (>1 year old)
+  [4] No or stale manual review (>2 years)
+```
+
+For each org it shows the current status and best existing activity date, then
+opens the website in your browser. You confirm:
+
+```
+[a] Active      [i] Inactive    [d] Deregistered
+[s] Skip        [q] Quit
+```
+
+Choosing `a`, `i`, or `d` writes `activity.manual` with today's date and updates
+the `status:` field if it changed. You can add a note (e.g. "blog last updated
+Jan 2025, looks dormant") or press Enter for the default.
+
+Press `q` at any time to quit — progress is saved org by org as you go.
+
+**If you find an org has shut down or gone inactive:**
+- Set status to `inactive` or `deregistered` via the prompt
+- Manually update `website:` to the Wayback Machine calendar URL:
+  `https://web.archive.org/web/*/https://originalurl.com/`
+- Update the summary if it refers to the org in present tense
+
+**Useful flags:**
+
+```bash
+python util/review_orgs.py --only-stale   # skip the scope prompt; review >2yr orgs
+python util/review_orgs.py --all          # include inactive/deregistered orgs
+python util/review_orgs.py --slug loomio  # single org
+```
+
+---
+
+### 4. Structural check
+
+```bash
+python util/pre_commit_check.py
+```
+
+Catches broken internal links and invalid concept slugs. Fix any hard failures
+before committing. The four known lint exceptions (FLACSO-Cuba, Kongra Star,
+Memorial, NAMFREL) are expected — see `util/SOUL.md`.
+
+---
+
+### 5. Commit and open a PR
+
+Stage and commit your changes:
+
+```bash
+git add docs/organisations/
+git commit -m "Maintenance pass — YYYY-MM: N orgs verified, M status updates"
+```
+
+Open a PR. In the body, include the `stats.py` before/after snapshot and a
+brief note on anything notable you found (orgs gone inactive, websites moved,
+new RSS feeds discovered, etc.).
+
+---
+
+## What counts as a good pass
+
+You don't need to review every org in one sitting. A focused pass on options
+`[2]` or `[4]` — orgs that have never been manually reviewed or are overdue —
+is more valuable than a shallow pass over everything. Work at whatever pace
+lets you actually look at each site rather than clicking through.
+
+The automated tools (step 2) run fast and are worth doing every time even
+if you don't have time for the full manual review.

--- a/util/review_orgs.py
+++ b/util/review_orgs.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+review_orgs.py — Interactive CLI for manual org status review.
+
+Opens each org's website in your browser and prompts for a status confirmation.
+Writes activity.manual entries (highest-priority evidence source) to frontmatter.
+Optionally updates the org's status field if you find it has changed.
+
+Usage:
+    python util/review_orgs.py              # interactive scope selection
+    python util/review_orgs.py --only-stale # skip prompt; review orgs with no/stale manual review
+    python util/review_orgs.py --all        # include inactive/deregistered orgs
+    python util/review_orgs.py --slug loomio  # single org
+
+Requirements: python-frontmatter, pyyaml (util/requirements.txt)
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+import webbrowser
+from datetime import date, datetime
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+try:
+    import yaml as _yaml
+except ImportError:
+    print("Missing dependency: pip install pyyaml")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+SKIP_FILES = {"organisations.md"}
+WAYBACK_PREFIX = "https://web.archive.org"
+TODAY = date.today().isoformat()
+
+PRIORITY_ORDER = ["manual", "dod", "social", "rss", "scrape", "sitemap"]
+STALENESS_DAYS = {"manual": 730, "dod": 730, "social": 365, "rss": 365, "scrape": 365, "sitemap": 180}
+MANUAL_STALE_DAYS = 730
+
+
+def parse_date(s):
+    if not s:
+        return None
+    try:
+        return datetime.strptime(str(s).strip()[:10], "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def best_activity(activity_dict):
+    """Return (source, date, note) for the best non-stale entry, falling back to most recent."""
+    if not activity_dict:
+        return None
+    today = date.today()
+    for source in PRIORITY_ORDER:
+        entry = activity_dict.get(source)
+        if not entry:
+            continue
+        d = parse_date(entry.get("date"))
+        if d and (today - d).days <= STALENESS_DAYS[source]:
+            return source, d, entry.get("note", "")
+    # All stale — return most recent regardless
+    best = None
+    for source, entry in activity_dict.items():
+        d = parse_date(entry.get("date"))
+        if d and (best is None or d > best[1]):
+            best = source, d, entry.get("note", "")
+    return best
+
+
+def manual_age_days(activity_dict):
+    """Days since last manual review, or None if never reviewed."""
+    entry = (activity_dict or {}).get("manual")
+    if not entry:
+        return None
+    d = parse_date(entry.get("date"))
+    return (date.today() - d).days if d else None
+
+
+def load_orgs(slug_filter=None, include_inactive=False):
+    orgs = []
+    for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
+        if os.path.basename(path) in SKIP_FILES:
+            continue
+        post = frontmatter.load(path)
+        meta = post.metadata
+        slug = os.path.basename(path)[:-3]
+        if slug_filter and slug != slug_filter:
+            continue
+        status = meta.get("status", "")
+        if not include_inactive and status not in ("active",):
+            continue
+        orgs.append({
+            "slug": slug,
+            "path": path,
+            "title": meta.get("title", slug),
+            "status": status,
+            "website": meta.get("website", "") or "",
+            "activity": meta.get("activity") or {},
+        })
+    return orgs
+
+
+def write_manual_activity(path, date_str, note):
+    """Write or update activity.manual in org frontmatter using raw text edit."""
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    parts = content.split("---", 2)
+    if len(parts) < 3 or parts[0] != "":
+        return False
+    yaml_block, rest = parts[1], parts[2]
+
+    meta = _yaml.safe_load(yaml_block) or {}
+    source_lines = [
+        "  manual:",
+        f"    date: {date_str}",
+        f"    note: {json.dumps(note, ensure_ascii=False)}",
+    ]
+
+    if meta.get("activity"):
+        lines = yaml_block.split("\n")
+        new_lines = []
+        in_activity = False
+        in_this_source = False
+        inserted = False
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if re.match(r"^activity\s*:", line):
+                in_activity = True
+                new_lines.append(line)
+                i += 1
+                continue
+            if in_activity:
+                # Top-level key ends the activity block
+                if line and not line.startswith(" "):
+                    if in_this_source and not inserted:
+                        new_lines.extend(source_lines)
+                        inserted = True
+                    in_activity = False
+                    in_this_source = False
+                    new_lines.append(line)
+                    i += 1
+                    continue
+                # Found the manual sub-block — replace it
+                if re.match(r"^  manual\s*:", line):
+                    in_this_source = True
+                    i += 1
+                    while i < len(lines) and lines[i].startswith("    "):
+                        i += 1
+                    new_lines.extend(source_lines)
+                    inserted = True
+                    continue
+                # Another source sub-block begins — clear the source flag
+                if in_this_source and re.match(r"^  \w", line):
+                    in_this_source = False
+            new_lines.append(line)
+            i += 1
+        # activity block ran to EOF without a closing top-level key
+        if in_activity and not inserted:
+            # strip trailing blank lines so the new entry lands flush after the last entry
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
+            new_lines.extend(source_lines)
+        yaml_block = "\n".join(new_lines)
+        if not yaml_block.endswith("\n"):
+            yaml_block += "\n"
+    else:
+        new_block = ["activity:"] + source_lines
+        yaml_block = yaml_block.rstrip("\n") + "\n" + "\n".join(new_block) + "\n"
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---" + yaml_block + "---" + rest)
+    return True
+
+
+def update_status_field(path, new_status):
+    """Update the status: line in org frontmatter using raw text substitution."""
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    parts = content.split("---", 2)
+    if len(parts) < 3 or parts[0] != "":
+        return False
+    yaml_block, rest = parts[1], parts[2]
+    yaml_block = re.sub(
+        r"^(status\s*:\s*)\S+",
+        rf"\g<1>{new_status}",
+        yaml_block,
+        flags=re.MULTILINE,
+    )
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---" + yaml_block + "---" + rest)
+    return True
+
+
+def prompt_scope(orgs):
+    """Ask the user which orgs to review; return the filtered list."""
+    never = [o for o in orgs if not (o["activity"] or {}).get("manual")]
+    stale_1yr = [
+        o for o in orgs
+        if manual_age_days(o["activity"]) is not None
+        and manual_age_days(o["activity"]) > 365
+    ]
+    stale_2yr = [
+        o for o in orgs
+        if manual_age_days(o["activity"]) is None
+        or manual_age_days(o["activity"]) > MANUAL_STALE_DAYS
+    ]
+
+    print()
+    print("Which orgs do you want to review?")
+    print(f"  [1] All loaded orgs                          ({len(orgs)} orgs)")
+    print(f"  [2] Never manually reviewed                  ({len(never)} orgs)")
+    print(f"  [3] Stale manual review (>1 year old)        ({len(stale_1yr)} orgs)")
+    print(f"  [4] No or stale manual review (>2 years)     ({len(stale_2yr)} orgs)")
+    print()
+    while True:
+        choice = input("Choice [1-4]: ").strip()
+        if choice == "1":
+            return orgs
+        if choice == "2":
+            return never
+        if choice == "3":
+            return stale_1yr
+        if choice == "4":
+            return stale_2yr
+        print("Please enter 1, 2, 3, or 4.")
+
+
+def review_org(org, index, total):
+    """Interactively review one org. Returns True to continue, False to quit."""
+    print()
+    print("=" * 62)
+    print(f"[{index}/{total}]  {org['title']}  ({org['slug']})")
+    print(f"  Status:   {org['status']}")
+    print(f"  Website:  {org['website'] or '(none)'}")
+
+    activity = org["activity"]
+    best = best_activity(activity)
+    if best:
+        src, d, note = best
+        print(f"  Activity: {src} {d}  —  {note or '(no note)'}")
+    else:
+        print("  Activity: none recorded")
+
+    manual_entry = activity.get("manual")
+    if manual_entry:
+        age = manual_age_days(activity)
+        print(f"  Manual:   {manual_entry.get('date')} ({age}d ago)  —  {manual_entry.get('note', '')}")
+    else:
+        print("  Manual:   never reviewed")
+
+    website = org["website"]
+    if website and WAYBACK_PREFIX not in website:
+        input(f"\n  Press Enter to open website in browser... ")
+        webbrowser.open(website)
+    else:
+        print("\n  (No live website — skipping browser open)")
+
+    print()
+    print("  [a] Active      [i] Inactive    [d] Deregistered")
+    print("  [s] Skip        [q] Quit")
+    print()
+
+    while True:
+        choice = input("  > ").strip().lower()
+        if choice == "q":
+            return False
+        if choice == "s":
+            print("  Skipped.")
+            return True
+        if choice in ("a", "i", "d"):
+            new_status = {"a": "active", "i": "inactive", "d": "deregistered"}[choice]
+            note = input("  Note (Enter to use default): ").strip()
+            if not note:
+                note = f"Visited site, confirmed {new_status}"
+
+            write_manual_activity(org["path"], TODAY, note)
+            print(f"  ✓ Wrote activity.manual: {TODAY}")
+
+            if new_status != org["status"]:
+                update_status_field(org["path"], new_status)
+                print(f"  ✓ Status updated: {org['status']} → {new_status}")
+
+            return True
+        print("  Invalid choice. Enter a, i, d, s, or q.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Interactive org status review — opens each org's website and records a manual activity entry."
+    )
+    parser.add_argument("--slug", help="Review a single org by slug")
+    parser.add_argument(
+        "--all", action="store_true", dest="include_all",
+        help="Include inactive/deregistered orgs (default: active only)",
+    )
+    parser.add_argument(
+        "--only-stale", action="store_true",
+        help="Skip scope prompt; only review orgs with no or stale (>2yr) manual review",
+    )
+    args = parser.parse_args()
+
+    orgs = load_orgs(slug_filter=args.slug, include_inactive=args.include_all)
+    if not orgs:
+        print("No orgs found matching criteria.")
+        sys.exit(0)
+
+    if args.slug:
+        to_review = orgs
+    elif args.only_stale:
+        to_review = [
+            o for o in orgs
+            if manual_age_days(o["activity"]) is None
+            or manual_age_days(o["activity"]) > MANUAL_STALE_DAYS
+        ]
+        print(f"Reviewing {len(to_review)} orgs with no or stale manual review (>{MANUAL_STALE_DAYS}d).")
+    else:
+        to_review = prompt_scope(orgs)
+
+    if not to_review:
+        print("No orgs to review in selected scope.")
+        sys.exit(0)
+
+    total = len(to_review)
+    print(f"\nStarting review of {total} org(s). Press q at any time to quit.")
+
+    for i, org in enumerate(to_review, 1):
+        if not review_org(org, i, total):
+            print(f"\nQuit after {i - 1}/{total} orgs reviewed.")
+            break
+    else:
+        print(f"\nDone — reviewed all {total} orgs.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`util/review_orgs.py`** — interactive CLI for human org status review. Opens each org's website in the browser, shows current status and activity data, prompts for confirmation (`active` / `inactive` / `deregistered` / `skip` / `quit`), and writes `activity.manual` entries directly to frontmatter. Also updates the `status:` field if it changed. Progress is saved org by org so quitting mid-session loses nothing.
- **`MAINTENANCE.md`** — human contributor maintenance guide covering the full quarterly review sequence, with a copy-paste quick-start block at the top.

## How `review_orgs.py` works

At startup (without flags) it asks which scope to review:

```
Which orgs do you want to review?
  [1] All active orgs                          (92 orgs)
  [2] Never manually reviewed                  (87 orgs)
  [3] Stale manual review (>1 year old)        (0 orgs)
  [4] No or stale manual review (>2 years)     (87 orgs)
```

For each org it shows name, status, best existing activity date, and last manual review age, then opens the website before prompting. Writes `activity.manual` with today's date — the highest-priority evidence source, valid for 2 years per the activity staleness rules.

Flags: `--only-stale` (skip prompt, review >2yr orgs), `--all` (include inactive), `--slug <slug>` (single org).

## Test plan

- [ ] `python util/review_orgs.py --slug loomio` — single org flow, confirm `activity.manual` written to frontmatter
- [ ] `python util/review_orgs.py --only-stale` — skips scope prompt, loads correct subset
- [ ] Status change (choose `i` for an active org) — confirm `status:` field updated in file
- [ ] Press `q` mid-session — confirm previously reviewed orgs are already saved

---
_Generated by [Claude Code](https://claude.ai/code/session_016w7k1x8WJnnWiVZosbXzxA)_