### PR TITLE
Add activity.*.checked field — track last probe date per source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,25 +63,30 @@ The invariants recorded there are not immutable. Any document in this repo — i
       date: 2026-03-04
       note: "Latest post: Final report on Community Consultation"
       url: https://...
+      checked: 2026-06-07       # last probe date (written automatically by check_rss.py)
     scrape:
       date: 2026-05-10
       note: "Latest post: Democracy Forum 2026 announced"
       url: https://example.org/news
+      checked: 2026-06-07
     sitemap:
       date: 2026-06-04
       note: "Page last modified (from sitemap)"
       url: https://...
+      checked: 2026-06-07
     manual:
       date: 2026-05-01
       note: "Visited site, confirmed active"
+      checked: 2026-05-01       # same as date for manual reviews
   ```
   - `method` keys: `manual` | `rss` | `scrape` | `sitemap` | `dod` | `social`
+  - `checked:` — optional; the date the source was last probed, regardless of whether new content was found. Written automatically by `check_rss.py`, `scrape_news.py`, and `review_orgs.py`. Entries with no `date` but a `checked` date mean the source was probed but found nothing.
   - Priority order (highest first): `manual` > `dod` > `social` > `rss` > `scrape` > `sitemap`
   - Staleness thresholds: `manual`/`dod` 730 d · `social`/`rss`/`scrape` 365 d · `sitemap` 180 d
   - A source is skipped if older than its threshold; the next-priority fresh source wins
   - If all sources are stale, the most recent entry is shown regardless
-  - `util/check_rss.py --update-activity` populates `rss` and `sitemap` entries automatically
-  - `util/scrape_news.py` populates `scrape` entries for orgs with `news_page:` set
+  - `util/check_rss.py --update-activity` populates `rss` and `sitemap` entries automatically; re-runs skip orgs checked within 7 days (use `--force` to override)
+  - `util/scrape_news.py` populates `scrape` entries for orgs with `news_page:` set; same skip behaviour
 - **Key people** is an optional section. Add it only when named individuals are central to understanding the org's story (founders, government champions, notable critics) and the information is sourced. Link names to Wikipedia where a confirmed article exists. Do not add it just to fill the template — most orgs are better served by institutional description.
 
 ### Blog posts (`docs/blog/posts/`)

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -11,6 +11,7 @@ Read **CLAUDE.md** first for site conventions and curation standards.
 
 ```bash
 # 1. automated data collection (no input needed)
+# re-runs skip orgs checked within 7 days; add --force to probe everything
 python util/check_rss.py --update-activity
 python util/scrape_news.py
 python util/check_urls.py
@@ -107,8 +108,9 @@ python util/check_rss.py --update-activity
 ```
 
 Tries 23 common feed paths per site. Writes `activity.rss` with the latest
-post date and title, or `activity.sitemap` as a fallback (confirms the site
-is alive but carries less weight). Takes a few minutes for the full set.
+post date and title, or `activity.sitemap` as a fallback. Also writes
+`activity.*.checked` with today's date on every org probed — re-runs within
+7 days skip those orgs automatically. Use `--force` to probe everything.
 
 **Scrape news pages** (orgs that have `news_page:` set):
 

--- a/util/check_rss.py
+++ b/util/check_rss.py
@@ -277,6 +277,7 @@ def update_activity_source(path, date_str, note, feed_url, post_url=None, method
         f"    date: {date_str}",
         f"    note: {json.dumps(note, ensure_ascii=False)}",
         f"    url: {url_field}",
+        f"    checked: {TODAY}",
     ]
 
     if meta.get("activity"):
@@ -339,6 +340,103 @@ def update_activity_source(path, date_str, note, feed_url, post_url=None, method
     return True
 
 
+def write_checked_only(path, method, note=None):
+    """Add/update checked: <TODAY> on an activity source entry.
+
+    If the source entry doesn't exist, creates a minimal entry with note and
+    checked (no date/url).  If it exists, adds/updates only the checked: field
+    without touching date, note, or url.
+    """
+    import yaml as _yaml
+
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    parts = content.split("---", 2)
+    if len(parts) < 3 or parts[0] != "":
+        return False
+    yaml_block, rest = parts[1], parts[2]
+    meta = _yaml.safe_load(yaml_block) or {}
+    activity = meta.get("activity") or {}
+
+    minimal = [f"  {method}:"]
+    if note:
+        minimal.append(f"    note: {json.dumps(note, ensure_ascii=False)}")
+    minimal.append(f"    checked: {TODAY}")
+
+    if not activity:
+        yaml_block = yaml_block.rstrip("\n") + "\nactivity:\n" + "\n".join(minimal) + "\n"
+
+    elif method not in activity:
+        # Append minimal entry into existing activity: block
+        lines = yaml_block.split("\n")
+        new_lines = []
+        in_activity = False
+        inserted = False
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if re.match(r"^activity\s*:", line):
+                in_activity = True
+                new_lines.append(line)
+                i += 1
+                continue
+            if in_activity and line and not line.startswith(" "):
+                if not inserted:
+                    new_lines.extend(minimal)
+                    inserted = True
+                in_activity = False
+                new_lines.append(line)
+                i += 1
+                continue
+            new_lines.append(line)
+            i += 1
+        if in_activity and not inserted:
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
+            new_lines.extend(minimal)
+        yaml_block = "\n".join(new_lines)
+
+    else:
+        # Source exists — update or insert the checked: line in its sub-block
+        lines = yaml_block.split("\n")
+        new_lines = []
+        in_this_source = False
+        checked_written = False
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if re.match(rf"^  {method}\s*:", line):
+                in_this_source = True
+                new_lines.append(line)
+                i += 1
+                continue
+            if in_this_source:
+                # Another source block or top-level key ends this sub-block
+                if re.match(r"^  \w", line) or (line and not line.startswith("    ")):
+                    if not checked_written:
+                        new_lines.append(f"    checked: {TODAY}")
+                        checked_written = True
+                    in_this_source = False
+                elif re.match(r"^    checked\s*:", line):
+                    new_lines.append(f"    checked: {TODAY}")
+                    checked_written = True
+                    i += 1
+                    continue
+            new_lines.append(line)
+            i += 1
+        if in_this_source and not checked_written:
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
+            new_lines.append(f"    checked: {TODAY}")
+        yaml_block = "\n".join(new_lines)
+
+    if not yaml_block.endswith("\n"):
+        yaml_block += "\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---" + yaml_block + "---" + rest)
+    return True
+
+
 def load_orgs(slug_filter=None, include_inactive=False):
     orgs = []
     for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
@@ -362,6 +460,7 @@ def load_orgs(slug_filter=None, include_inactive=False):
             "status": status,
             "rss_feed": meta.get("rss_feed") or "",
             "path": path,
+            "activity": meta.get("activity") or {},
         })
     return orgs
 
@@ -375,6 +474,8 @@ def main():
     parser.add_argument("--skip-existing", action="store_true", help="Skip orgs that already have rss_feed:")
     parser.add_argument("--update-activity", action="store_true",
                         help="Fetch each discovered (or existing) feed and update last_activity with latest post date/title")
+    parser.add_argument("--force", action="store_true",
+                        help="Probe all orgs even if recently checked (ignores activity.*.checked)")
     args = parser.parse_args()
 
     orgs = load_orgs(slug_filter=args.slug, include_inactive=args.all)
@@ -399,6 +500,24 @@ def main():
             print(f"  [{i:3d}/{len(orgs)}] SKIP  {slug} (already has rss_feed)")
             continue
 
+        # Skip orgs checked recently unless --force
+        if not args.force and args.update_activity:
+            activity = org.get("activity", {})
+            recent_age = None
+            for chk_method in ("rss", "sitemap"):
+                entry = activity.get(chk_method) or {}
+                chk_date = parse_date(str(entry.get("checked", "") or ""))
+                if chk_date:
+                    age = (datetime.today().date() - chk_date).days
+                    if age <= 7:
+                        recent_age = age
+                        break
+            if recent_age is not None:
+                print(f"  [{i:3d}/{len(orgs)}] {slug} … SKIPPED (checked {recent_age}d ago)")
+                skipped.append(org)
+                results.append({**org, "feed_url": None, "skipped_checked": True})
+                continue
+
         # Use existing rss_feed if present, otherwise probe
         feed_url = org["rss_feed"] or probe_feeds(org["website"], timeout=args.timeout, session=session)
 
@@ -416,6 +535,7 @@ def main():
                         print(f"SITEMAP  {d}")
                         result["latest_date"] = d.isoformat()
                     else:
+                        write_checked_only(org["path"], "sitemap", "Sitemap found, no lastmod")
                         print(f"SITEMAP (no lastmod)  {feed_url}")
                 else:
                     d, title, link, http_ok = latest_from_feed(feed_url, timeout=args.timeout, session=session)
@@ -438,6 +558,8 @@ def main():
                 print(f"FOUND  {feed_url}")
             found.append(result)
         else:
+            if args.update_activity:
+                write_checked_only(org["path"], "rss", "No feed found")
             print("not found")
             not_found.append(result)
 

--- a/util/review_orgs.py
+++ b/util/review_orgs.py
@@ -124,6 +124,7 @@ def write_manual_activity(path, date_str, note):
         "  manual:",
         f"    date: {date_str}",
         f"    note: {json.dumps(note, ensure_ascii=False)}",
+        f"    checked: {date_str}",
     ]
 
     if meta.get("activity"):

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -244,6 +244,7 @@ def update_activity_source(path, date_str, note, url, method="scrape"):
         f"    date: {date_str}",
         f"    note: {json.dumps(note, ensure_ascii=False)}",
         f"    url: {url}",
+        f"    checked: {TODAY}",
     ]
 
     if meta.get("activity"):
@@ -295,6 +296,93 @@ def update_activity_source(path, date_str, note, url, method="scrape"):
 # Org loader
 # ---------------------------------------------------------------------------
 
+def write_checked_only(path, method, note=None):
+    """Add/update checked: <TODAY> on an activity source entry (no date/url change)."""
+    import yaml as _yaml
+
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    parts = content.split("---", 2)
+    if len(parts) < 3 or parts[0] != "":
+        return False
+    yaml_block, rest = parts[1], parts[2]
+    meta = _yaml.safe_load(yaml_block) or {}
+    activity = meta.get("activity") or {}
+
+    minimal = [f"  {method}:"]
+    if note:
+        minimal.append(f"    note: {json.dumps(note, ensure_ascii=False)}")
+    minimal.append(f"    checked: {TODAY}")
+
+    if not activity:
+        yaml_block = yaml_block.rstrip("\n") + "\nactivity:\n" + "\n".join(minimal) + "\n"
+    elif method not in activity:
+        lines = yaml_block.split("\n")
+        new_lines = []
+        in_activity = False
+        inserted = False
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if re.match(r"^activity\s*:", line):
+                in_activity = True
+                new_lines.append(line)
+                i += 1
+                continue
+            if in_activity and line and not line.startswith(" "):
+                if not inserted:
+                    new_lines.extend(minimal)
+                    inserted = True
+                in_activity = False
+                new_lines.append(line)
+                i += 1
+                continue
+            new_lines.append(line)
+            i += 1
+        if in_activity and not inserted:
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
+            new_lines.extend(minimal)
+        yaml_block = "\n".join(new_lines)
+    else:
+        lines = yaml_block.split("\n")
+        new_lines = []
+        in_this_source = False
+        checked_written = False
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if re.match(rf"^  {method}\s*:", line):
+                in_this_source = True
+                new_lines.append(line)
+                i += 1
+                continue
+            if in_this_source:
+                if re.match(r"^  \w", line) or (line and not line.startswith("    ")):
+                    if not checked_written:
+                        new_lines.append(f"    checked: {TODAY}")
+                        checked_written = True
+                    in_this_source = False
+                elif re.match(r"^    checked\s*:", line):
+                    new_lines.append(f"    checked: {TODAY}")
+                    checked_written = True
+                    i += 1
+                    continue
+            new_lines.append(line)
+            i += 1
+        if in_this_source and not checked_written:
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
+            new_lines.append(f"    checked: {TODAY}")
+        yaml_block = "\n".join(new_lines)
+
+    if not yaml_block.endswith("\n"):
+        yaml_block += "\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---" + yaml_block + "---" + rest)
+    return True
+
+
 def load_orgs(slug_filter=None, include_inactive=False):
     orgs = []
     for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
@@ -320,6 +408,7 @@ def load_orgs(slug_filter=None, include_inactive=False):
             "status": status,
             "news_page": news_page,
             "path": path,
+            "activity": meta.get("activity") or {},
         })
     return orgs
 
@@ -334,6 +423,8 @@ def main():
     parser.add_argument("--slug", metavar="SLUG", help="Scrape a single org by slug")
     parser.add_argument("--timeout", type=int, default=10, metavar="N", help="Per-request timeout in seconds (default: 10)")
     parser.add_argument("--dry-run", action="store_true", help="Print results without writing frontmatter")
+    parser.add_argument("--force", action="store_true",
+                        help="Scrape all orgs even if recently checked (ignores activity.scrape.checked)")
     args = parser.parse_args()
 
     orgs = load_orgs(slug_filter=args.slug, include_inactive=args.all)
@@ -352,6 +443,16 @@ def main():
         url = org["news_page"]
         print(f"  [{i:3d}/{len(orgs)}] {slug} … ", end="", flush=True)
 
+        # Skip recently-checked orgs unless --force
+        if not args.force:
+            entry = (org.get("activity") or {}).get("scrape") or {}
+            chk_date = parse_date(str(entry.get("checked", "") or ""))
+            if chk_date:
+                age = (datetime.strptime(TODAY, "%Y-%m-%d").date() - chk_date).days
+                if age <= 7:
+                    print(f"SKIPPED (checked {age}d ago)")
+                    continue
+
         if not robots_allowed(url, timeout=args.timeout, session=session):
             print(f"ROBOTS_DISALLOWED  {url}")
             time.sleep(1.0)
@@ -362,6 +463,8 @@ def main():
         if not ok:
             print(f"UNREACHABLE  {url}")
         elif d is None:
+            if not args.dry_run:
+                write_checked_only(org["path"], "scrape", "News page found, no machine-readable date")
             print(f"NO_DATE_FOUND  {url}")
         else:
             note = f"Latest post: {title[:80]}" if title else "Latest news page scraped"


### PR DESCRIPTION
## Summary

- Each activity source entry gains an optional `checked:` field recording when it was last probed, independent of when new content was found
- Re-runs of `check_rss.py` and `scrape_news.py` skip recently-probed orgs (within 7 days) — use `--force` to probe everything
- "No result" outcomes (not found, no lastmod, no machine-readable date) now write a minimal `checked` entry so the skip fires on re-run

## Schema

```yaml
activity:
  rss:
    date: 2026-03-04        # latest content date (unchanged if nothing new)
    note: "Latest post: …"
    url: https://…
    checked: 2026-06-07     # last probe date — always updated on probe
  rss:                      # probe found nothing — checked only, no date
    checked: 2026-06-07
    note: "No feed found"
```

`date` still drives all display and staleness logic — nothing changed there. `checked` is purely for probe skip logic and "we looked but found nothing" transparency.

## Changes

| File | What changed |
|---|---|
| `util/check_rss.py` | `update_activity_source` writes `checked`; new `write_checked_only` for no-result cases; skip logic + `--force` flag |
| `util/scrape_news.py` | Same pattern — `checked` on write, skip on re-run, `write_checked_only` for `NO_DATE_FOUND` |
| `util/review_orgs.py` | Manual entries write `checked = date` |
| `CLAUDE.md` | Schema docs updated with `checked` field |
| `MAINTENANCE.md` | `--force` note added to quick-start |

## Test plan

- [ ] Run `check_rss.py --update-activity` — confirm `checked:` appears in written entries
- [ ] Re-run immediately — confirm orgs print `SKIPPED (checked 0d ago)`
- [ ] Re-run with `--force` — confirm all orgs are probed again
- [ ] Check an org with no feed — confirm minimal `rss: checked:` entry written
- [ ] Run `review_orgs.py --slug loomio` — confirm `checked` = `date` in written manual entry

---
_Generated by [Claude Code](https://claude.ai/code/session_016w7k1x8WJnnWiVZosbXzxA)_