### PR TITLE
fix: extract activity dates from manual review notes; add date+url prompts to review_orgs

### DIFF
--- a/docs/organisations/adr-india.md
+++ b/docs/organisations/adr-india.md
@@ -18,7 +18,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-05
     note: "website is present and loaded. Last report released by them is at 5 June, 2026"
     checked: 2026-06-07
 ---

--- a/docs/organisations/australian-democracy-network.md
+++ b/docs/organisations/australian-democracy-network.md
@@ -19,7 +19,7 @@ activity:
     note: "Server still up (sitemap detected)"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-04-15
     note: "Website is up and they got a new post. 15 Apr 2026 Take the Pledge: Integrity Organisations call on Victorian Political Parties to Commit Now to Donation Transparency"
     checked: 2026-06-07
 ---

--- a/docs/organisations/cdd-west-africa.md
+++ b/docs/organisations/cdd-west-africa.md
@@ -4,6 +4,7 @@ type: research
 status: active
 country: NG
 website: https://www.cddwestafrica.org
+news_page: https://www.cddwestafrica.org/blog/
 summary: "An Abuja-based independent research and advocacy organisation focused on democratic governance and human security in West Africa — founded in 1997 to support Nigeria's democratic transition, now a regional hub for policy analysis, electoral integrity, and civil society capacity-building."
 location:
   latitude: 9.0579

--- a/docs/organisations/cdd-west-africa.md
+++ b/docs/organisations/cdd-west-africa.md
@@ -21,6 +21,7 @@ activity:
   manual:
     date: 2026-06-04
     note: "They got a blog at https://www.cddwestafrica.org/blog/ which has a post on 4 June 2026 : Reconciliation Is Not Deradicalisation: Rethinking the Role of Faith Community Leaders in Operation Safe Corridor"
+    url: https://www.cddwestafrica.org/blog/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/cdd-west-africa.md
+++ b/docs/organisations/cdd-west-africa.md
@@ -24,6 +24,9 @@ activity:
     note: "They got a blog at https://www.cddwestafrica.org/blog/ which has a post on 4 June 2026 : Reconciliation Is Not Deradicalisation: Rethinking the Role of Faith Community Leaders in Operation Safe Corridor"
     url: https://www.cddwestafrica.org/blog/
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 The Centre for Democracy and Development (CDD West Africa) is an independent, non-profit research and advocacy organisation founded in 1997 (and registered in Nigeria in 1999) to support democratic governance and people-centred development across West Africa. It was established during Nigeria's transition from military to civilian rule and has since grown into a regional institution.

--- a/docs/organisations/cdd-west-africa.md
+++ b/docs/organisations/cdd-west-africa.md
@@ -19,7 +19,7 @@ activity:
     note: "Server still up (sitemap detected)"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-04
     note: "They got a blog at https://www.cddwestafrica.org/blog/ which has a post on 4 June 2026 : Reconciliation Is Not Deradicalisation: Rethinking the Role of Faith Community Leaders in Operation Safe Corridor"
     checked: 2026-06-07
 ---

--- a/docs/organisations/china-democratic-league.md
+++ b/docs/organisations/china-democratic-league.md
@@ -17,7 +17,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-04-08
     note: "https://www.mmzy.org.cn/mmyw/default.aspx is it's news section. 8th April 2026 ' NLD \"political participation for the public, practical for the people\" theme education start-up meeting held'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/china-democratic-league.md
+++ b/docs/organisations/china-democratic-league.md
@@ -19,6 +19,7 @@ activity:
   manual:
     date: 2026-04-08
     note: "https://www.mmzy.org.cn/mmyw/default.aspx is it's news section. 8th April 2026 ' NLD \"political participation for the public, practical for the people\" theme education start-up meeting held'"
+    url: https://www.mmzy.org.cn/mmyw/default.aspx
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/citizens-foundation.md
+++ b/docs/organisations/citizens-foundation.md
@@ -24,6 +24,7 @@ activity:
   manual:
     date: 2026-06-07
     note: "Unsure how to read the blog section for year last posted. However https://github.com/CitizensFoundation/your-priorities-app has activity 3 weeks ago."
+    url: https://github.com/CitizensFoundation/your-priorities-app
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/conaie.md
+++ b/docs/organisations/conaie.md
@@ -17,7 +17,7 @@ activity:
     note: "Page last modified (from sitemap)"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2025-04-04
     note: "website loaded. Last news at april 4 2025 \"Esmeraldas derramada: una historia de Las Piedras\""
     checked: 2026-06-07
 ---

--- a/docs/organisations/conversations-at-the-crossroads.md
+++ b/docs/organisations/conversations-at-the-crossroads.md
@@ -21,6 +21,7 @@ activity:
   manual:
     date: 2026-06-07
     note: "Website loaded. https://www.crossroadsconversation.com.au/events says next event is at  Tuesday 30 June 2026  'The decline of democracy and the rise of the far-right'"
+    url: https://www.crossroadsconversation.com.au/events
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/conversations-at-the-crossroads.md
+++ b/docs/organisations/conversations-at-the-crossroads.md
@@ -24,6 +24,12 @@ activity:
     note: "Website loaded. https://www.crossroadsconversation.com.au/events says next event is at  Tuesday 30 June 2026  'The decline of democracy and the rise of the far-right'"
     url: https://www.crossroadsconversation.com.au/events
     checked: 2026-06-07
+
+  scrape:
+    date: 2026-06-30
+    note: "Latest news page scraped"
+    url: https://www.crossroadsconversation.com.au/events
+    checked: 2026-06-07
 ---
 
 Conversations at the Crossroads is an independent Australian civic network focused on democratic renewal through thoughtful, informed conversation. Founded around 2020 by Professor Joseph Camilleri (Professor Emeritus, La Trobe University) and colleagues, the network runs public events, citizens assemblies, educational series, and podcasts aimed at connecting progressive social movements and scaling deliberative participation.

--- a/docs/organisations/conversations-at-the-crossroads.md
+++ b/docs/organisations/conversations-at-the-crossroads.md
@@ -4,6 +4,7 @@ type: advocacy
 status: active
 country: AU
 website: https://www.crossroadsconversation.com.au
+news_page: https://www.crossroadsconversation.com.au/events
 summary: "An independent Melbourne-based civic network running deliberative democracy initiatives, including large-scale citizens assemblies and a national program to scale deliberative participation."
 concepts:
   - citizens-assembly

--- a/docs/organisations/cppcc.md
+++ b/docs/organisations/cppcc.md
@@ -17,7 +17,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-02
     note: "Website loaded. Latest news is 2026-06-02 'Xi encourages Chinese children to strive for better future'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/darkenu.md
+++ b/docs/organisations/darkenu.md
@@ -18,7 +18,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2025-12-02
     note: "website loaded. It mentioned that it was in the news פורסם: 17.11.25, 15:30 | עודכן: 02.12.25, 15:50 'חנוכה 2025: כל מה שאפשר לעשות עם הילדים בחג'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/democracy-next.md
+++ b/docs/organisations/democracy-next.md
@@ -21,6 +21,7 @@ activity:
   manual:
     date: 2026-01-02
     note: "website loaded. https://www.demnext.org/news mentions www.theartnewspaper.com/2026/01/02/uk-museums-embrace-citizens-assemblies-to-frame-their-futures 2 January 2026 'How UK museums are embracing citizens’ assemblies to help frame their futures'"
+    url: https://www.demnext.org/news
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/democracy-next.md
+++ b/docs/organisations/democracy-next.md
@@ -19,7 +19,7 @@ activity:
     date: 2026-06-04
     note: Page last modified (from sitemap)
   manual:
-    date: 2026-06-07
+    date: 2026-01-02
     note: "website loaded. https://www.demnext.org/news mentions www.theartnewspaper.com/2026/01/02/uk-museums-embrace-citizens-assemblies-to-frame-their-futures 2 January 2026 'How UK museums are embracing citizens’ assemblies to help frame their futures'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/democracy-next.md
+++ b/docs/organisations/democracy-next.md
@@ -24,6 +24,12 @@ activity:
     note: "website loaded. https://www.demnext.org/news mentions www.theartnewspaper.com/2026/01/02/uk-museums-embrace-citizens-assemblies-to-frame-their-futures 2 January 2026 'How UK museums are embracing citizens’ assemblies to help frame their futures'"
     url: https://www.demnext.org/news
     checked: 2026-06-07
+
+  scrape:
+    date: 2026-03-27
+    note: "Latest news page scraped"
+    url: https://www.demnext.org/news
+    checked: 2026-06-07
 ---
 
 DemocracyNext (demnext.org) is a research institute whose position is that sortition should *replace* elections as the central mechanism of democratic governance — not merely complement them. This distinguishes it from organisations that treat citizens' assemblies as an add-on to existing representative systems.

--- a/docs/organisations/democracy-next.md
+++ b/docs/organisations/democracy-next.md
@@ -4,6 +4,7 @@ type: research
 status: active
 country: EU
 website: https://www.demnext.org
+news_page: https://www.demnext.org/news
 summary: "An international research institute focused on the theory and practice of sortition-based democracy — replacing elections with randomly selected assemblies as the primary decision-making mechanism."
 location:
   latitude: 55.6761

--- a/docs/organisations/democracy-technologies.md
+++ b/docs/organisations/democracy-technologies.md
@@ -20,7 +20,7 @@ activity:
     date: 2025-09-03
     note: Page last modified (from sitemap)
   manual:
-    date: 2026-06-07
+    date: 2024-09-04
     note: "website loaded. Last article at September 4, 2024 AI-Washing Is an Opportunity"
     checked: 2026-06-07
 ---

--- a/docs/organisations/democracylab.md
+++ b/docs/organisations/democracylab.md
@@ -19,7 +19,7 @@ activity:
     url: https://www.democracylab.org/sitemap.xml
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2025-09-10
     note: "website loaded. Last blog post is at https://blog.democracylab.org/10-000-volunteers-and-counting/  10 Sep 2025 '10,000 Volunteers and Counting!'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/democracylab.md
+++ b/docs/organisations/democracylab.md
@@ -21,6 +21,7 @@ activity:
   manual:
     date: 2025-09-10
     note: "website loaded. Last blog post is at https://blog.democracylab.org/10-000-volunteers-and-counting/  10 Sep 2025 '10,000 Volunteers and Counting!'"
+    url: https://blog.democracylab.org/10-000-volunteers-and-counting/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/fbk.md
+++ b/docs/organisations/fbk.md
@@ -20,6 +20,7 @@ activity:
   manual:
     date: 2026-06-04
     note: "website up. News at https://fbk.info/en/news/ latest article https://fbk.info/en/news/navalny-archive 4 June 2026 'We are launching the Alexei Navalny Archive'"
+    url: https://fbk.info/en/news/navalny-archive
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/fbk.md
+++ b/docs/organisations/fbk.md
@@ -23,6 +23,9 @@ activity:
     note: "website up. News at https://fbk.info/en/news/ latest article https://fbk.info/en/news/navalny-archive 4 June 2026 'We are launching the Alexei Navalny Archive'"
     url: https://fbk.info/en/news/navalny-archive
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 The Anti-Corruption Foundation (Фонд борьбы с коррупцией, FBK) was founded by Alexei Navalny and became Russia's most prominent anti-corruption investigative and advocacy organisation. Its video investigations into the wealth of senior Russian officials — including widely-viewed exposés on Prime Minister Medvedev and others — reached tens of millions of viewers inside Russia.

--- a/docs/organisations/fbk.md
+++ b/docs/organisations/fbk.md
@@ -18,7 +18,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-04
     note: "website up. News at https://fbk.info/en/news/ latest article https://fbk.info/en/news/navalny-archive 4 June 2026 'We are launching the Alexei Navalny Archive'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/fbk.md
+++ b/docs/organisations/fbk.md
@@ -4,6 +4,7 @@ type: advocacy
 status: active
 country: RU
 website: https://fbk.info/en
+news_page: https://fbk.info/en/news/
 summary: "An anti-corruption and pro-democracy organisation founded by Alexei Navalny — producing high-profile investigations of Kremlin-linked corruption, now operating in exile after being designated 'extremist' (2021) and 'terrorist' (November 2025) by Russian authorities. Led by Yulia Navalnaya following Navalny's death in prison in February 2024."
 location:
   latitude: 55.7558

--- a/docs/organisations/flacso-cuba.md
+++ b/docs/organisations/flacso-cuba.md
@@ -19,7 +19,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-04
     note: "website loaded. news in main page. Latest is 4 Jun 2026 'Communiqué for the death of Dr. Raúl Vega-Pacheco Researcher and teacher of FLACSO Mexico'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/g0v.md
+++ b/docs/organisations/g0v.md
@@ -4,6 +4,7 @@ type: civic tech
 status: active
 country: TW
 website: https://g0v.tw
+news_page: https://g0v.tw/intl/en/event/
 last_checked: "2026-05-30"
 summary: "A Taiwanese civic tech community that forks government websites and services to make them more open, usable, and participatory — best known internationally for co-developing the vTaiwan deliberation platform."
 location:

--- a/docs/organisations/g0v.md
+++ b/docs/organisations/g0v.md
@@ -24,6 +24,9 @@ activity:
     note: "website loaded. FYI they have an english version at https://g0v.tw/intl/en/ . In https://g0v.tw/intl/en/event/ there is a calendar where there appears to be various events."
     url: https://g0v.tw/intl/en/event/
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 g0v (pronounced "gov zero") is a decentralised, volunteer-driven civic tech community founded in Taiwan in 2012. The name is a pun: replacing the "o" in "gov" with "0" (zero) to create an alternative domain — `g0v.tw` versus `gov.tw` — signalling a parallel, open, citizen-built version of government infrastructure.

--- a/docs/organisations/g0v.md
+++ b/docs/organisations/g0v.md
@@ -21,6 +21,7 @@ activity:
   manual:
     date: 2026-06-07
     note: "website loaded. FYI they have an english version at https://g0v.tw/intl/en/ . In https://g0v.tw/intl/en/event/ there is a calendar where there appears to be various events."
+    url: https://g0v.tw/intl/en/event/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/g1000.md
+++ b/docs/organisations/g1000.md
@@ -22,7 +22,7 @@ activity:
     note: "Latest post: Future Forum Zoet Water"
     url: "https://www.g1000.org/en/cases/future-forum-zoet-water"
   manual:
-    date: 2026-06-07
+    date: 2026-05-11
     note: "website loaded. They got a news section at https://www.g1000.org/en/news where latest is 11.05.2026 'Your Voice Deserves a Seat: Launching Our Campaign for a permanent Citizens’ Assembly'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/g1000.md
+++ b/docs/organisations/g1000.md
@@ -24,6 +24,7 @@ activity:
   manual:
     date: 2026-05-11
     note: "website loaded. They got a news section at https://www.g1000.org/en/news where latest is 11.05.2026 'Your Voice Deserves a Seat: Launching Our Campaign for a permanent Citizens’ Assembly'"
+    url: https://www.g1000.org/en/news
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/hkdc.md
+++ b/docs/organisations/hkdc.md
@@ -4,6 +4,7 @@ type: advocacy
 status: active
 country: CN
 website: https://www.hkdc.us
+news_page: https://www.hkdc.us/news
 summary: "A Washington DC-based organisation advocating for the restoration of democratic governance in Hong Kong — specifically the election-based accountability system promised under One Country, Two Systems, which was effectively dismantled following the 2020 National Security Law."
 location:
   latitude: 22.3193

--- a/docs/organisations/hkdc.md
+++ b/docs/organisations/hkdc.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2026-02-10
     note: "website loaded. News is https://www.hkdc.us/news where latest is February 10, 2026 'Crossing a New Line: The Conviction of Anna Kwok’s Father'"
+    url: https://www.hkdc.us/news
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/hkdc.md
+++ b/docs/organisations/hkdc.md
@@ -20,7 +20,7 @@ activity:
     url: https://www.hkdc.us/sitemap.xml
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-02-10
     note: "website loaded. News is https://www.hkdc.us/news where latest is February 10, 2026 'Crossing a New Line: The Conviction of Anna Kwok’s Father'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/hkdc.md
+++ b/docs/organisations/hkdc.md
@@ -25,6 +25,9 @@ activity:
     note: "website loaded. News is https://www.hkdc.us/news where latest is February 10, 2026 'Crossing a New Line: The Conviction of Anna Kwok’s Father'"
     url: https://www.hkdc.us/news
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 > **Note:** HKDC operates from diaspora in Washington DC. It is included here because its work is specifically about a particular governance system — the accountability structures promised to Hong Kong under One Country, Two Systems — rather than general human rights documentation.

--- a/docs/organisations/israel-democracy-institute.md
+++ b/docs/organisations/israel-democracy-institute.md
@@ -20,7 +20,7 @@ activity:
     url: https://en.idi.org.il/sitemap.xml
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-03
     note: "Website loaded. News in mainpage. https://en.idi.org.il/hurvitz/2026/ June 2-3, 2026 which points to https://www.youtube.com/watch?v=bkYhEo0j54w ' The Israel Democracy Institute's annual Eli Hurvitz Conference on Economy and Society 2026 | Recap '"
     checked: 2026-06-07
 ---

--- a/docs/organisations/israel-democracy-institute.md
+++ b/docs/organisations/israel-democracy-institute.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2026-06-03
     note: "Website loaded. News in mainpage. https://en.idi.org.il/hurvitz/2026/ June 2-3, 2026 which points to https://www.youtube.com/watch?v=bkYhEo0j54w ' The Israel Democracy Institute's annual Eli Hurvitz Conference on Economy and Society 2026 | Recap '"
+    url: https://en.idi.org.il/hurvitz/2026/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/luminate.md
+++ b/docs/organisations/luminate.md
@@ -21,6 +21,7 @@ activity:
   manual:
     date: 2025-07-22
     note: "website loaded. Has a news page at https://luminategroup.com/news-and-insights . Latest seems to be 22 July 2025 'How storytelling can bring us closer to tech justice'"
+    url: https://luminategroup.com/news-and-insights
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/luminate.md
+++ b/docs/organisations/luminate.md
@@ -19,7 +19,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2025-07-22
     note: "website loaded. Has a news page at https://luminategroup.com/news-and-insights . Latest seems to be 22 July 2025 'How storytelling can bring us closer to tech justice'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/luminate.md
+++ b/docs/organisations/luminate.md
@@ -4,6 +4,7 @@ type: philanthropy
 status: active
 country: GB
 website: https://www.luminategroup.com
+news_page: https://luminategroup.com/news-and-insights
 summary: "A global philanthropic organisation funding civic technology, digital rights, independent media, and government transparency — spun out of the Omidyar Network in 2018 with a focus on open and accountable governance."
 concepts:
   - democracy

--- a/docs/organisations/luminate.md
+++ b/docs/organisations/luminate.md
@@ -24,6 +24,9 @@ activity:
     note: "website loaded. Has a news page at https://luminategroup.com/news-and-insights . Latest seems to be 22 July 2025 'How storytelling can bring us closer to tech justice'"
     url: https://luminategroup.com/news-and-insights
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 Luminate is a global philanthropic organisation established in 2018, spun out from the Omidyar Network (founded by eBay co-founder Pierre Omidyar) to focus specifically on civic empowerment and open governance. It operates globally with offices in London, Washington DC, Nairobi, São Paulo, and other cities.

--- a/docs/organisations/mass-lbp.md
+++ b/docs/organisations/mass-lbp.md
@@ -23,7 +23,7 @@ activity:
     date: 2026-05-22
     note: Page last modified (from sitemap)
   manual:
-    date: 2026-06-07
+    date: 2023-08-14
     note: "website loaded. Uncertain if active. Last social media post at Aug 14, 2023 'We’re aiming to expand our team this fall by adding a new Coordinator at MASS. We are looking for a candidate with the right mix of qualities, skills and experience to help us build our practice and raise our game.'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/memo98.md
+++ b/docs/organisations/memo98.md
@@ -18,7 +18,7 @@ activity:
     date: 2025-12-15
     note: Page last modified (from sitemap)
   manual:
-    date: 2026-06-07
+    date: 2025-12-20
     note: "website loaded. Blog at https://memo98.sk/articles/blog  20. December 2025 ' Moldova Story: How a Small Republic Resisted Hybrid War '"
     checked: 2026-06-07
 ---

--- a/docs/organisations/memo98.md
+++ b/docs/organisations/memo98.md
@@ -20,6 +20,7 @@ activity:
   manual:
     date: 2025-12-20
     note: "website loaded. Blog at https://memo98.sk/articles/blog  20. December 2025 ' Moldova Story: How a Small Republic Resisted Hybrid War '"
+    url: https://memo98.sk/articles/blog
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/memo98.md
+++ b/docs/organisations/memo98.md
@@ -23,6 +23,12 @@ activity:
     note: "website loaded. Blog at https://memo98.sk/articles/blog  20. December 2025 ' Moldova Story: How a Small Republic Resisted Hybrid War '"
     url: https://memo98.sk/articles/blog
     checked: 2026-06-07
+
+  scrape:
+    date: 2025-12-20
+    note: "Latest news page scraped"
+    url: https://memo98.sk/articles/blog
+    checked: 2026-06-07
 ---
 
 MEMO 98 is a Slovak organisation founded in 1998 focused on media integrity and democratic civic engagement. It is best known for its election media monitoring work — assessing whether voters have access to quality, balanced information during electoral periods — and has applied this methodology across multiple countries.

--- a/docs/organisations/memo98.md
+++ b/docs/organisations/memo98.md
@@ -4,6 +4,7 @@ type: research
 status: active
 country: SK
 website: https://memo98.sk
+news_page: https://memo98.sk/articles/blog
 summary: "A Bratislava-based media monitoring and democratic civic engagement organisation with 25+ years of experience — monitoring media integrity during elections, researching disinformation, and supporting democratic consolidation in post-authoritarian contexts."
 location:
   latitude: 48.1486

--- a/docs/organisations/memorial.md
+++ b/docs/organisations/memorial.md
@@ -20,7 +20,7 @@ activity:
     note: Server still up (sitemap detected)
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-04
     note: "website loaded. It's german... but this looks like news https://www.memorial.de/nachrichten wehere latest news is 04.06.2026 'Asat Miftachov wird im Lager gefoltert'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/memorial.md
+++ b/docs/organisations/memorial.md
@@ -25,6 +25,12 @@ activity:
     note: "website loaded. It's german... but this looks like news https://www.memorial.de/nachrichten wehere latest news is 04.06.2026 'Asat Miftachov wird im Lager gefoltert'"
     url: https://www.memorial.de/nachrichten
     checked: 2026-06-07
+
+  scrape:
+    date: 2026-06-04
+    note: "Latest news page scraped"
+    url: https://www.memorial.de/nachrichten
+    checked: 2026-06-07
 ---
 
 Memorial (Мемориал) was founded in the late 1980s during the Glasnost era to document and preserve memory of Soviet political repression — labour camps, executions, and mass deportations. It became one of Russia's most prominent civil society organisations, documenting abuses in Chechnya and other conflict zones, maintaining databases of political prisoners, and providing legal support to victims of state violence.

--- a/docs/organisations/memorial.md
+++ b/docs/organisations/memorial.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2026-06-04
     note: "website loaded. It's german... but this looks like news https://www.memorial.de/nachrichten wehere latest news is 04.06.2026 'Asat Miftachov wird im Lager gefoltert'"
+    url: https://www.memorial.de/nachrichten
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/memorial.md
+++ b/docs/organisations/memorial.md
@@ -4,6 +4,7 @@ type: research
 status: active
 country: RU
 website: https://www.memorial.de
+news_page: https://www.memorial.de/nachrichten
 summary: "Russia's best-known human rights and historical memory organisation — documenting Soviet-era repression and ongoing abuses for 35 years. Liquidated by Russian courts in December 2021 and designated 'extremist' in April 2026; continues operating in exile through its international chapters, including Germany."
 last_checked: "2026-06-02"
 location:

--- a/docs/organisations/mosaiclab.md
+++ b/docs/organisations/mosaiclab.md
@@ -18,7 +18,7 @@ activity:
     date: 2026-06-03
     note: Page last modified (from sitemap)
   manual:
-    date: 2026-06-07
+    date: 2025-12-08
     note: "website loaded. Latest blog post is on December 8, 2025 'SHIFTS SHAPING ENGAGEMENT NEXT YEAR'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/newvote.md
+++ b/docs/organisations/newvote.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2020-05-16
     note: "website loaded. But social media is last noted in twitter May 16, 2020 https://x.com/newvote/status/1261440493004615681 . So uncertain on newvote status"
+    url: https://x.com/newvote/status/1261440493004615681
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/newvote.md
+++ b/docs/organisations/newvote.md
@@ -20,7 +20,7 @@ activity:
     note: "Latest post: How's SpeakUp @ the University of Queensland going?"
     url: "https://newvote.org/blog/2019/11/10/hows-speakup-the-university-of-queensland-going"
   manual:
-    date: 2026-06-07
+    date: 2020-05-16
     note: "website loaded. But social media is last noted in twitter May 16, 2020 https://x.com/newvote/status/1261440493004615681 . So uncertain on newvote status"
     checked: 2026-06-07
 ---

--- a/docs/organisations/nota-canada.md
+++ b/docs/organisations/nota-canada.md
@@ -20,7 +20,7 @@ activity:
     note: "Latest post: None of the Above Party Calls for Referendum on Trump Tariffs, Strategic Voting "
     url: "https://nota.ca/none-of-the-above-party-calls-for-referendum-on-trump-tariffs/"
   manual:
-    date: 2026-06-07
+    date: 2025-01-27
     note: "website loaded. https://nota.ca/news/ has January 27, 2025 'None of the Above Party Calls for Referendum on Trump Tariffs, Strategic Voting to Defeat Ford Government in Election'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/nota-canada.md
+++ b/docs/organisations/nota-canada.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2025-01-27
     note: "website loaded. https://nota.ca/news/ has January 27, 2025 'None of the Above Party Calls for Referendum on Trump Tariffs, Strategic Voting to Defeat Ford Government in Election'"
+    url: https://nota.ca/news/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/open-society-foundations.md
+++ b/docs/organisations/open-society-foundations.md
@@ -24,6 +24,9 @@ activity:
     note: "website loaded. https://www.opensocietyfoundations.org/newsroom has  May 20, 2026 'Open Society Foundations Launch $300 Million Initiative to Advance Economic Security and Defend Civil Liberties in the United States'"
     url: https://www.opensocietyfoundations.org/newsroom
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 The Open Society Foundations (OSF) are a global network of foundations founded by George Soros in 1979. Beginning with scholarships for Black South African students and support for East European dissidents, OSF grew into the world's largest private funder of independent civil society organisations working on democracy, human rights, justice, and equity.

--- a/docs/organisations/open-society-foundations.md
+++ b/docs/organisations/open-society-foundations.md
@@ -19,7 +19,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-05-20
     note: "website loaded. https://www.opensocietyfoundations.org/newsroom has  May 20, 2026 'Open Society Foundations Launch $300 Million Initiative to Advance Economic Security and Defend Civil Liberties in the United States'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/open-society-foundations.md
+++ b/docs/organisations/open-society-foundations.md
@@ -21,6 +21,7 @@ activity:
   manual:
     date: 2026-05-20
     note: "website loaded. https://www.opensocietyfoundations.org/newsroom has  May 20, 2026 'Open Society Foundations Launch $300 Million Initiative to Advance Economic Security and Defend Civil Liberties in the United States'"
+    url: https://www.opensocietyfoundations.org/newsroom
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/open-society-foundations.md
+++ b/docs/organisations/open-society-foundations.md
@@ -4,6 +4,7 @@ type: philanthropy
 status: active
 country: US
 website: https://www.opensocietyfoundations.org
+news_page: https://www.opensocietyfoundations.org/newsroom
 summary: "The world's largest private funder of independent groups working for rights, equity, and justice — founded by George Soros in 1979, with grants, fellowships, and national foundations active across 100+ countries."
 concepts:
   - democracy

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -20,6 +20,7 @@ activity:
   manual:
     date: 2026-05-20
     note: "website loaded. https://oporaua.org/en/announce has  May 20, 2026 'REPORT. Dialogue with the Ukrainian Community in Ireland'"
+    url: https://oporaua.org/en/announce
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -18,7 +18,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-05-20
     note: "website loaded. https://oporaua.org/en/announce has  May 20, 2026 'REPORT. Dialogue with the Ukrainian Community in Ireland'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -23,6 +23,9 @@ activity:
     note: "website loaded. https://oporaua.org/en/announce has  May 20, 2026 'REPORT. Dialogue with the Ukrainian Community in Ireland'"
     url: https://oporaua.org/en/announce
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 Civil Network OPORA is Ukraine's primary independent election observation and civic oversight organisation, founded in 2006. It conducts comprehensive long-term and short-term election observation for presidential, parliamentary, and local elections, and publishes detailed analytical reports on each electoral cycle.

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -4,6 +4,7 @@ type: advocacy
 status: active
 country: UA
 website: https://oporaua.org/en
+news_page: https://oporaua.org/en/announce
 summary: "Ukraine's leading non-partisan election observation organisation — monitoring elections since 2006, conducting parliamentary oversight, and co-founding the European Platform for Democratic Elections (EPDE)."
 location:
   latitude: 50.4501

--- a/docs/organisations/participedia.md
+++ b/docs/organisations/participedia.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2026-01-06
     note: "website loaded. News page points to https://participediaproject.medium.com/ where latest is Jan 6, 2026 'Participedia Schools 2025 Summary Reports'"
+    url: https://participediaproject.medium.com/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/participedia.md
+++ b/docs/organisations/participedia.md
@@ -4,6 +4,7 @@ type: research
 status: active
 country: CA
 website: https://participedia.net
+news_page: https://participediaproject.medium.com/
 summary: "A global open-access database and research platform cataloguing thousands of participatory democracy cases, methods, and organisations from around the world."
 location:
   latitude: 49.2827

--- a/docs/organisations/participedia.md
+++ b/docs/organisations/participedia.md
@@ -20,7 +20,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-01-06
     note: "website loaded. News page points to https://participediaproject.medium.com/ where latest is Jan 6, 2026 'Participedia Schools 2025 Summary Reports'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/prediki.md
+++ b/docs/organisations/prediki.md
@@ -4,6 +4,7 @@ type: platform
 status: active
 country: AT
 website: https://www.prediki.com
+news_page: https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/
 summary: "An Austrian prediction market platform that aggregates collective intelligence on political and policy questions — users make structured predictions with reasons, and the system surfaces the informed consensus."
 location:
   latitude: 48.2082

--- a/docs/organisations/prediki.md
+++ b/docs/organisations/prediki.md
@@ -18,7 +18,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2022-09-30
     note: "website active. News link https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/ . Last is at  Vienna, 30 September 2022 'Renewed Controversy About Election Polls'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/prediki.md
+++ b/docs/organisations/prediki.md
@@ -20,6 +20,7 @@ activity:
   manual:
     date: 2022-09-30
     note: "website active. News link https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/ . Last is at  Vienna, 30 September 2022 'Renewed Controversy About Election Polls'"
+    url: https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/prediki.md
+++ b/docs/organisations/prediki.md
@@ -23,6 +23,9 @@ activity:
     note: "website active. News link https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/ . Last is at  Vienna, 30 September 2022 'Renewed Controversy About Election Polls'"
     url: https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 Prediki (Prediki Prediction Markets GmbH) is a peer-to-peer platform for opinion research and collective intelligence, built around prediction market methodology. Rather than simple polling, participants make structured predictions about outcomes, stake a position, and provide reasons — the system aggregates these into probability estimates while tracking the quality of each contributor's predictions over time.

--- a/docs/organisations/prs-legislative-research.md
+++ b/docs/organisations/prs-legislative-research.md
@@ -18,7 +18,7 @@ activity:
     date: 2021-07-17
     note: Page last modified (from sitemap)
   manual:
-    date: 2026-06-07
+    date: 2024-05-20
     note: "website loaded. Has blog in main page under a tab. Last one is at  May 20, 2024 'A note of gratitude to Mr. N. Vaghul"
     checked: 2026-06-07
 ---

--- a/docs/organisations/prsa.md
+++ b/docs/organisations/prsa.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2026-05-01
     note: "website loaded. News page at https://www.prsa.org.au/latest01.htm 2026-05a 'LETTER ON SOUTH AUSTRALIAN ELECTION OUTCOME TO ALL SA MPs:'"
+    url: https://www.prsa.org.au/latest01.htm
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/prsa.md
+++ b/docs/organisations/prsa.md
@@ -20,7 +20,7 @@ activity:
     note: "Latest post: Orders in Council gazetted for single-councillor wards have taken effect"
     url: "https://prsa.org.au/news/2020/#2020-07b"
   manual:
-    date: 2026-06-07
+    date: 2026-05-01
     note: "website loaded. News page at https://www.prsa.org.au/latest01.htm 2026-05a 'LETTER ON SOUTH AUSTRALIAN ELECTION OUTCOME TO ALL SA MPs:'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/rwanda-governance-board.md
+++ b/docs/organisations/rwanda-governance-board.md
@@ -20,6 +20,7 @@ activity:
   manual:
     date: 2026-05-29
     note: "website loaded. News page at https://www.rgb.rw/updates/news . Latest news  Friday, 29 May, 2026  'Former Ethipia Prime Minister H.E. Hailemariam visits RGB'"
+    url: https://www.rgb.rw/updates/news
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/rwanda-governance-board.md
+++ b/docs/organisations/rwanda-governance-board.md
@@ -18,7 +18,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-05-29
     note: "website loaded. News page at https://www.rgb.rw/updates/news . Latest news  Friday, 29 May, 2026  'Former Ethipia Prime Minister H.E. Hailemariam visits RGB'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/rwanda-governance-board.md
+++ b/docs/organisations/rwanda-governance-board.md
@@ -4,6 +4,7 @@ type: research
 status: active
 country: RW
 website: https://www.rgb.rw
+news_page: https://www.rgb.rw/updates/news
 summary: "Rwanda's government body for governance research and oversight — publishing annual governance scorecards, studying decentralisation and citizen participation, and administering the Ubudehe community classification system. Included for its governance design research, not as an independent watchdog of the Kagame government."
 location:
   latitude: -1.9441

--- a/docs/organisations/rwanda-governance-board.md
+++ b/docs/organisations/rwanda-governance-board.md
@@ -23,6 +23,12 @@ activity:
     note: "website loaded. News page at https://www.rgb.rw/updates/news . Latest news  Friday, 29 May, 2026  'Former Ethipia Prime Minister H.E. Hailemariam visits RGB'"
     url: https://www.rgb.rw/updates/news
     checked: 2026-06-07
+
+  scrape:
+    date: 2026-05-29
+    note: "Latest news page scraped"
+    url: https://www.rgb.rw/updates/news
+    checked: 2026-06-07
 ---
 
 > **Note on scope:** The RGB is a government body, not an independent civil society organisation. It is included here because it publishes substantive governance research — on decentralisation, citizen participation mechanisms, and Rwanda's distinctive governance innovations — rather than as a source of critical accountability. Rwanda's national political system under President Kagame does not meet DOD's accountability standard at the top level; elections are not genuinely competitive. The governance mechanisms documented by RGB are analytically interesting and separable from an overall assessment of the Rwandan political system.

--- a/docs/organisations/sortition-foundation-australia.md
+++ b/docs/organisations/sortition-foundation-australia.md
@@ -23,6 +23,7 @@ activity:
   manual:
     date: 2026-02-26
     note: "website loaded. News page at https://www.sortitionfoundation.org/updates 26 February, 2026 'Frontiers of Democratic Lotteries Workshop'"
+    url: https://www.sortitionfoundation.org/updates
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/sortition-foundation-australia.md
+++ b/docs/organisations/sortition-foundation-australia.md
@@ -4,6 +4,7 @@ type: advocacy
 status: active
 country: AU
 website: https://www.sortitionfoundation.org/become_a_member_australia
+news_page: https://www.sortitionfoundation.org/updates
 summary: "The Australian chapter of the UK-based Sortition Foundation, running monthly community meetings and providing sortition recruitment services for Australian democratic processes — including Victorian council deliberations, federal electorate pilots, and national citizen assemblies."
 location:
   latitude: -37.7749

--- a/docs/organisations/sortition-foundation-australia.md
+++ b/docs/organisations/sortition-foundation-australia.md
@@ -21,7 +21,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-02-26
     note: "website loaded. News page at https://www.sortitionfoundation.org/updates 26 February, 2026 'Frontiers of Democratic Lotteries Workshop'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/sortition-foundation.md
+++ b/docs/organisations/sortition-foundation.md
@@ -4,6 +4,7 @@ type: advocacy
 status: active
 country: UK
 website: https://www.sortitionfoundation.org
+news_page: https://www.sortitionfoundation.org/updates
 summary: "A UK-based organisation advocating for the use of random selection (sortition) in democratic institutions, most prominently campaigning to replace the House of Lords with a randomly selected citizens' chamber."
 location:
   latitude: 55.9533

--- a/docs/organisations/sortition-foundation.md
+++ b/docs/organisations/sortition-foundation.md
@@ -22,7 +22,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-02-26
     note: "website loaded. https://www.sortitionfoundation.org/updates is the news page. 26 February, 2026 'Frontiers of Democratic Lotteries Workshop'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/sortition-foundation.md
+++ b/docs/organisations/sortition-foundation.md
@@ -24,6 +24,7 @@ activity:
   manual:
     date: 2026-02-26
     note: "website loaded. https://www.sortitionfoundation.org/updates is the news page. 26 February, 2026 'Frontiers of Democratic Lotteries Workshop'"
+    url: https://www.sortitionfoundation.org/updates
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/susan-mckinnon-foundation.md
+++ b/docs/organisations/susan-mckinnon-foundation.md
@@ -4,6 +4,7 @@ type: philanthropy
 status: active
 country: AU
 website: https://mckinnon.co
+news_page: https://mckinnon.co/insights
 summary: "A non-partisan Australian foundation working across all sides of politics to find common ground and practical pathways on major national challenges, with a focus on democratic and public sector reform."
 location:
   latitude: -37.8136

--- a/docs/organisations/susan-mckinnon-foundation.md
+++ b/docs/organisations/susan-mckinnon-foundation.md
@@ -20,6 +20,7 @@ activity:
   manual:
     date: 2026-06-03
     note: "website loaded. https://mckinnon.co/insights is it's news page. Latest news is 03 JUN 2026 'McKinnon Political Leader of the Year 2025 - Federal – Shortlisted nominees'"
+    url: https://mckinnon.co/insights
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/susan-mckinnon-foundation.md
+++ b/docs/organisations/susan-mckinnon-foundation.md
@@ -18,7 +18,7 @@ activity:
     date: 2026-06-04
     note: Page last modified (from sitemap)
   manual:
-    date: 2026-06-07
+    date: 2026-06-03
     note: "website loaded. https://mckinnon.co/insights is it's news page. Latest news is 03 JUN 2026 'McKinnon Political Leader of the Year 2025 - Federal – Shortlisted nominees'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/susan-mckinnon-foundation.md
+++ b/docs/organisations/susan-mckinnon-foundation.md
@@ -23,6 +23,12 @@ activity:
     note: "website loaded. https://mckinnon.co/insights is it's news page. Latest news is 03 JUN 2026 'McKinnon Political Leader of the Year 2025 - Federal – Shortlisted nominees'"
     url: https://mckinnon.co/insights
     checked: 2026-06-07
+
+  scrape:
+    date: 2026-03-31
+    note: "Latest post: Insights"
+    url: https://mckinnon.co/insights
+    checked: 2026-06-07
 ---
 
 The Susan McKinnon Foundation is a private philanthropic foundation focused on strengthening Australian democracy and governance. It funds and supports work on electoral reform, parliamentary integrity, public sector capability, and cross-party collaboration.

--- a/docs/organisations/tev-dem.md
+++ b/docs/organisations/tev-dem.md
@@ -14,6 +14,7 @@ activity:
   manual:
     date: 2026-02-21
     note: "Website loaded at https://tev-dem.com/ . News is in front page. Latest is  Feb 21, 2026 ' roja Zimanê Dayîk A Cîhanî li hemû gelan pîroz be û Hêviya me ye ku bibe roja vekirina dergihê azadiya gelên Sûriyayê û aramiya wan.'"
+    url: https://tev-dem.com/
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/tev-dem.md
+++ b/docs/organisations/tev-dem.md
@@ -12,7 +12,7 @@ concepts:
   - democratic-confederalism
 activity:
   manual:
-    date: 2026-06-07
+    date: 2026-02-21
     note: "Website loaded at https://tev-dem.com/ . News is in front page. Latest is  Feb 21, 2026 ' roja Zimanê Dayîk A Cîhanî li hemû gelan pîroz be û Hêviya me ye ku bibe roja vekirina dergihê azadiya gelên Sûriyayê û aramiya wan.'"
     checked: 2026-06-07
 ---

--- a/docs/organisations/vtaiwan.md
+++ b/docs/organisations/vtaiwan.md
@@ -4,6 +4,7 @@ type: platform
 status: active
 country: TW
 website: https://vtaiwan.tw
+news_page: https://www.vtaiwan.tw/newsletters
 last_checked: "2026-05-30"
 summary: "A Taiwanese open-consultation platform (launched 2015) that uses Pol.is-based deliberation to surface consensus on contested policy. Influential in its early phase but never legally mandated; now continues as a volunteer-driven civic lab as the state's participation efforts moved to other platforms."
 location:

--- a/docs/organisations/vtaiwan.md
+++ b/docs/organisations/vtaiwan.md
@@ -22,6 +22,7 @@ activity:
   manual:
     date: 2026-06-05
     note: "website loaded. https://www.vtaiwan.tw/newsletters is it's news page. Latest is June 5, 2026 'vTaiwan Newsletter Issue Zero'. Its a mirror of their substack located at https://vtaiwantw.substack.com/p/vtaiwan-newsletter-issue-zero"
+    url: https://vtaiwantw.substack.com/p/vtaiwan-newsletter-issue-zero
     checked: 2026-06-07
 ---
 

--- a/docs/organisations/vtaiwan.md
+++ b/docs/organisations/vtaiwan.md
@@ -25,6 +25,9 @@ activity:
     note: "website loaded. https://www.vtaiwan.tw/newsletters is it's news page. Latest is June 5, 2026 'vTaiwan Newsletter Issue Zero'. Its a mirror of their substack located at https://vtaiwantw.substack.com/p/vtaiwan-newsletter-issue-zero"
     url: https://vtaiwantw.substack.com/p/vtaiwan-newsletter-issue-zero
     checked: 2026-06-07
+  scrape:
+    note: "News page found, no machine-readable date"
+    checked: 2026-06-07
 ---
 
 vTaiwan is a civic-technology platform for structured public consultation, developed collaboratively by the Taiwanese government's digital ministry and the **g0v** civic-tech community. It grew out of the 2014 Sunflower Movement: at the end of that year, minister Jaclyn Tsai attended a g0v hackathon and invited the community to design a neutral platform for large-scale deliberation on specific policy questions. vTaiwan launched in 2015, built around **Pol.is**, an opinion-mapping tool that surfaces consensus rather than amplifying disagreement.[^demtech]

--- a/docs/organisations/vtaiwan.md
+++ b/docs/organisations/vtaiwan.md
@@ -20,7 +20,7 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   manual:
-    date: 2026-06-07
+    date: 2026-06-05
     note: "website loaded. https://www.vtaiwan.tw/newsletters is it's news page. Latest is June 5, 2026 'vTaiwan Newsletter Issue Zero'. Its a mirror of their substack located at https://vtaiwantw.substack.com/p/vtaiwan-newsletter-issue-zero"
     checked: 2026-06-07
 ---

--- a/util/review_orgs.py
+++ b/util/review_orgs.py
@@ -111,8 +111,15 @@ def load_orgs(slug_filter=None, include_inactive=False):
     return orgs
 
 
-def write_manual_activity(path, date_str, note):
-    """Write or update activity.manual in org frontmatter using raw text edit."""
+def write_manual_activity(path, date_str, note, checked_str=None, url=None):
+    """Write or update activity.manual in org frontmatter using raw text edit.
+
+    date_str    — last observed activity date (e.g. date of article found)
+    checked_str — date of this review (defaults to date_str for back-compat)
+    url         — optional direct link to the evidence page
+    """
+    if checked_str is None:
+        checked_str = date_str
     with open(path, encoding="utf-8") as f:
         content = f.read()
     parts = content.split("---", 2)
@@ -125,8 +132,10 @@ def write_manual_activity(path, date_str, note):
         "  manual:",
         f"    date: {date_str}",
         f"    note: {json.dumps(note, ensure_ascii=False)}",
-        f"    checked: {date_str}",
     ]
+    if url:
+        source_lines.append(f"    url: {url}")
+    source_lines.append(f"    checked: {checked_str}")
 
     if meta.get("activity"):
         lines = yaml_block.split("\n")
@@ -357,12 +366,29 @@ def review_org(org, index, total):
             return True
         if choice in ("a", "i", "d"):
             new_status = {"a": "active", "i": "inactive", "d": "deregistered"}[choice]
+
             note = input("  Note (Enter to use default): ").strip()
             if not note:
                 note = f"Visited site, confirmed {new_status}"
 
-            write_manual_activity(org["path"], TODAY, note)
-            print(f"  ✓ Wrote activity.manual: {TODAY}")
+            raw_date = input(f"  Activity date found (YYYY-MM-DD, Enter for today {TODAY}): ").strip()
+            if raw_date:
+                parsed = parse_date(raw_date)
+                if parsed:
+                    activity_date = raw_date[:10]
+                else:
+                    print(f"  Invalid date — using {TODAY}")
+                    activity_date = TODAY
+            else:
+                activity_date = TODAY
+
+            url = input("  Evidence URL (Enter to skip): ").strip() or None
+
+            write_manual_activity(org["path"], activity_date, note, checked_str=TODAY, url=url)
+            if activity_date != TODAY:
+                print(f"  ✓ Wrote activity.manual: activity={activity_date}, checked={TODAY}")
+            else:
+                print(f"  ✓ Wrote activity.manual: {TODAY}")
 
             if new_status != org["status"]:
                 update_status_field(org["path"], new_status)


### PR DESCRIPTION
The June 7 manual review embedded discovered activity dates in note text
(e.g. "Last post 5 June 2026") but the tool recorded date: 2026-06-07
for every entry, conflating the review date with the actual last-activity date.

Data fix: correct activity.manual.date for 34 orgs to reflect the actual
discovered date from the note (checked: stays as the review date). Notable
cases: prediki 2022-09-30, newvote 2020-05-16, mass-lbp 2023-08-14,
democracy-technologies 2024-09-04.

Tool fix (util/review_orgs.py):
- write_manual_activity gains checked_str and url params; date/checked are
  now written independently so the reviewer can record what they found vs
  when they looked
- review_org() prompts for "Activity date found" (default: today) and
  "Evidence URL" (optional) after the note, so future reviews capture
  structured data without embedding it in free text

https://claude.ai/code/session_0197mLGTwq1hUanxPTq91qDq