### PR TITLE
Improve machine-readability signals and sitemap discovery robustness

### DIFF
--- a/hooks/data_export.py
+++ b/hooks/data_export.py
@@ -245,10 +245,13 @@ def on_pre_build(config):
     os.makedirs(OUT_DIR, exist_ok=True)
     orgs = load_orgs()
     site_url = (config.get("site_url") or "").rstrip("/")
+    all_activity_dates = [_best_activity(o["activity"])[0] for o in orgs]
+    last_activity_date = max((d for d in all_activity_dates if d), default="")
     meta = {
         "generated_at": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "source": site_url or "https://designingopendemocracy.com",
         "org_count": len(orgs),
+        "last_activity_date": last_activity_date,
     }
     write_orgs_csv(orgs)
     write_edge_list_csv(orgs)

--- a/hooks/llms_txt.py
+++ b/hooks/llms_txt.py
@@ -143,6 +143,7 @@ def build_llms_txt(site_url):
         f"- Concept index: {site_url}/concepts/",
         f"- Knowledge graph (org↔concept relationships): {site_url}/graph/",
         f"- Blog (event posts, meetup summaries): {site_url}/blog/",
+        f"- Blog RSS feed (subscribe for new posts): {site_url}/feed_rss_created.xml",
         f"- About / philosophy: {site_url}/about/",
         f"- DOD's own projects (wiki, tools, research): {site_url}/community/",
         "",

--- a/util/check_rss.py
+++ b/util/check_rss.py
@@ -73,7 +73,14 @@ FEED_PATHS = [
     "/?feed=rss",
     "/?feed=atom",
     "/index.xml",
-    "/sitemap.xml",   # fallback: at least shows site is alive
+]
+
+# Sitemap paths tried in order when no RSS/Atom feed is found.
+# robots.txt Sitemap: declarations are checked first (see probe_sitemap()).
+SITEMAP_PATHS = [
+    "/sitemap.xml",
+    "/sitemap_index.xml",
+    "/sitemaps.xml",
 ]
 
 # Content-type fragments that indicate a feed
@@ -105,8 +112,58 @@ def looks_like_feed(response):
     return body.startswith(FEED_BODY_PREFIXES)
 
 
+def is_sitemap_url(url):
+    """True if url looks like a sitemap rather than an RSS/Atom feed."""
+    return "sitemap" in urlparse(url).path.lower()
+
+
+def probe_sitemap(base_url, timeout=8, session=None):
+    """Return a sitemap URL for base_url, or None.
+
+    Checks robots.txt for Sitemap: declarations first, then falls back to
+    SITEMAP_PATHS. Handles both /sitemap.xml and /sitemap_index.xml.
+    """
+    if session is None:
+        session = requests.Session()
+        session.headers["User-Agent"] = "DOD-RSS-Probe/1.0 (democracy wiki feed discovery)"
+
+    parsed = urlparse(base_url)
+    root = f"{parsed.scheme}://{parsed.netloc}"
+
+    # 1. robots.txt Sitemap: declarations are the canonical source
+    try:
+        r = session.get(urljoin(root, "/robots.txt"), timeout=timeout, allow_redirects=True)
+        if r.status_code == 200:
+            for line in r.text.splitlines():
+                line = line.strip()
+                if line.lower().startswith("sitemap:"):
+                    candidate = line.split(":", 1)[1].strip()
+                    if not candidate.startswith("http"):
+                        candidate = urljoin(root, candidate)
+                    try:
+                        chk = session.get(candidate, timeout=timeout, allow_redirects=True)
+                        if chk.status_code == 200:
+                            return candidate
+                    except RequestException:
+                        pass
+    except RequestException:
+        pass
+
+    # 2. Standard paths
+    for path in SITEMAP_PATHS:
+        url = urljoin(root, path)
+        try:
+            r = session.get(url, timeout=timeout, allow_redirects=True)
+            if r.status_code == 200 and r.content:
+                return url
+        except RequestException:
+            pass
+
+    return None
+
+
 def probe_feeds(base_url, timeout=8, session=None):
-    """Return the first feed URL found, or None."""
+    """Return the first feed URL found (RSS/Atom/sitemap), or None."""
     if session is None:
         session = requests.Session()
     session.headers.update({"User-Agent": "DOD-RSS-Probe/1.0 (democracy wiki feed discovery)"})
@@ -123,7 +180,8 @@ def probe_feeds(base_url, timeout=8, session=None):
         except RequestException:
             pass
 
-    return None
+    # Fallback: sitemap (at least proves the site is alive)
+    return probe_sitemap(root, timeout=timeout, session=session)
 
 
 def latest_sitemap_lastmod(sitemap_url, timeout=10, session=None):
@@ -526,7 +584,7 @@ def main():
 
         if feed_url:
             if args.update_activity:
-                if feed_url.endswith("sitemap.xml"):
+                if is_sitemap_url(feed_url):
                     d = latest_sitemap_lastmod(feed_url, timeout=args.timeout, session=session)
                     if d:
                         update_activity_source(org["path"], d.isoformat(),


### PR DESCRIPTION
- check_rss.py: probe robots.txt for Sitemap: declarations before trying
  standard paths; add /sitemap_index.xml and /sitemaps.xml to fallback
  list; replace fragile endswith("sitemap.xml") check with is_sitemap_url()
  helper that matches any sitemap-style URL path
- llms_txt.py: add blog RSS feed URL to the Key pages section so bots
  reading llms.txt can discover the feed without crawling
- data_export.py: add last_activity_date to JSON/GeoJSON/KML metadata so
  external tools probing our data exports can see when org data was last
  updated without reading every record

https://claude.ai/code/session_0166SpSQxcLsyU3zsVNySWnJ