### PR TITLE
Manual review follow-up: data cleanup, scraper improvements, iCal support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ The invariants recorded there are not immutable. Any document in this repo — i
 - The `organisation.html` template is **auto-applied** to all org pages via `hooks/org_template.py` — no need to set `template:` in frontmatter unless overriding.
 - `rss_feed: <url>` — optional; the org's RSS or Atom feed URL. Populated by `util/check_rss.py`.
 - `news_page: <url>` — optional; URL of the org's news or blog index page. Opt-in for `util/scrape_news.py`.
+- `ics_feed: <url>` — optional; URL of an iCal/ICS calendar feed. Opt-in for `util/check_rss.py --update-activity` (writes `activity.ical`).
 - `related_orgs: [slug, slug]` — optional; list of org slugs with a direct relationship to this org. Rendered as orange edges in the knowledge graph. Declare on one side only — direction is normalised so duplicates are automatically suppressed.
 - `activity:` — optional dict of evidence sources, each keyed by method name. The build hook
   (`hooks/activity_selector.py`) picks the best entry for display using a priority order and
@@ -79,13 +80,13 @@ The invariants recorded there are not immutable. Any document in this repo — i
       note: "Visited site, confirmed active"
       checked: 2026-05-01       # same as date for manual reviews
   ```
-  - `method` keys: `manual` | `rss` | `scrape` | `sitemap` | `dod` | `social`
+  - `method` keys: `manual` | `rss` | `ical` | `scrape` | `sitemap` | `dod` | `social`
   - `checked:` — optional; the date the source was last probed, regardless of whether new content was found. Written automatically by `check_rss.py`, `scrape_news.py`, and `review_orgs.py`. Entries with no `date` but a `checked` date mean the source was probed but found nothing.
-  - Priority order (highest first): `manual` > `dod` > `social` > `rss` > `scrape` > `sitemap`
-  - Staleness thresholds: `manual`/`dod` 730 d · `social`/`rss`/`scrape` 365 d · `sitemap` 180 d
+  - Priority order (highest first): `manual` > `dod` > `social` > `rss` > `ical` > `scrape` > `sitemap`
+  - Staleness thresholds: `manual`/`dod` 730 d · `social`/`rss`/`ical`/`scrape` 365 d · `sitemap` 180 d
   - A source is skipped if older than its threshold; the next-priority fresh source wins
   - If all sources are stale, the most recent entry is shown regardless
-  - `util/check_rss.py --update-activity` populates `rss` and `sitemap` entries automatically; re-runs skip orgs checked within 7 days (use `--force` to override)
+  - `util/check_rss.py --update-activity` populates `rss`, `sitemap`, and `ical` entries automatically; re-runs skip orgs checked within 7 days (use `--force` to override)
   - `util/scrape_news.py` populates `scrape` entries for orgs with `news_page:` set; same skip behaviour
 - **Key people** is an optional section. Add it only when named individuals are central to understanding the org's story (founders, government champions, notable critics) and the information is sourced. Link names to Wikipedia where a confirmed article exists. Do not add it just to fill the template — most orgs are better served by institutional description.
 
@@ -213,7 +214,7 @@ These are linked from the bottom of the org index table for researcher download.
 
 ### Utility scripts (`util/`)
 
-- `util/check_rss.py` — probes org websites for RSS/Atom feeds and optionally updates `activity.rss` / `activity.sitemap` in frontmatter.
+- `util/check_rss.py` — probes org websites for RSS/Atom feeds and optionally updates `activity.rss` / `activity.sitemap` / `activity.ical` in frontmatter.
   ```
   python util/check_rss.py                    # probe all active orgs
   python util/check_rss.py --all              # include inactive orgs
@@ -221,14 +222,15 @@ These are linked from the bottom of the org index table for researcher download.
   python util/check_rss.py --update-activity  # write latest post date/title to frontmatter
   python util/check_rss.py --skip-existing    # skip orgs already with rss_feed:
   ```
-  Probes 23 common feed URL paths per site. For real feeds, writes `activity.rss` with latest post date and title. For sitemaps (fallback), writes `activity.sitemap` with `<lastmod>` date. Never overwrites a newer existing entry for the same source.
+  Probes 23 common feed URL paths per site. For real feeds, writes `activity.rss` with latest post date and title. For sitemaps (fallback), writes `activity.sitemap` with `<lastmod>` date. When `ics_feed:` is set, also fetches the iCal calendar and writes `activity.ical` with the most recent past event date. Never overwrites a newer existing entry for the same source.
 
-- `util/scrape_news.py` — scrapes news/blog index pages for orgs that lack a usable RSS feed. Opt-in: only runs for orgs with `news_page:` set in frontmatter. Extracts dates from machine-readable signals only (JSON-LD, OpenGraph, `<time datetime>`). Respects robots.txt. Writes `activity.scrape`.
+- `util/scrape_news.py` — scrapes news/blog index pages for orgs that lack a usable RSS feed. Opt-in: only runs for orgs with `news_page:` set in frontmatter. Extracts dates from machine-readable signals (JSON-LD, OpenGraph, `<time datetime>`) and as a fallback from date patterns in article URLs (e.g. `/2026/01/15/`). Respects robots.txt. Writes `activity.scrape`.
   ```
   python util/scrape_news.py                  # all active orgs with news_page:
   python util/scrape_news.py --all            # include inactive orgs
   python util/scrape_news.py --slug loomio    # single org
   python util/scrape_news.py --dry-run        # print results without writing
+  python util/scrape_news.py --debug          # show what date signals were found on each page
   ```
 
 ### Org index table filters (`docs/overrides/organisations.html`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,13 +225,15 @@ These are linked from the bottom of the org index table for researcher download.
   ```
   Probes 23 common feed URL paths per site. For real feeds, writes `activity.rss` with latest post date and title. For sitemaps (fallback), writes `activity.sitemap` with `<lastmod>` date. When `ics_feed:` is set, also fetches the iCal calendar and writes `activity.ical` with the most recent past event date. Never overwrites a newer existing entry for the same source.
 
-- `util/scrape_news.py` — scrapes news/blog index pages for orgs that lack a usable RSS feed. Opt-in: only runs for orgs with `news_page:` set in frontmatter. Extracts dates from machine-readable signals (JSON-LD, OpenGraph, `<time datetime>`) and as a fallback from date patterns in article URLs (e.g. `/2026/01/15/`). Respects robots.txt. Writes `activity.scrape`.
+- `util/scrape_news.py` — scrapes news/blog index pages for orgs that lack a usable RSS feed. Opt-in: only runs for orgs with `news_page:` set in frontmatter. Extracts dates from multiple signals in priority order: JSON-LD → `<meta>` / microdata (`itemprop="datePublished"`) → `<time datetime>` → `<time>` text content → URL path patterns (`/2026/01/15/`) → human-readable text date patterns ("January 15, 2026" etc.). Also detects `<link rel="alternate">` RSS/Atom feeds in the page `<head>`. Respects robots.txt. Writes `activity.scrape`.
   ```
   python util/scrape_news.py                  # all active orgs with news_page:
   python util/scrape_news.py --all            # include inactive orgs
   python util/scrape_news.py --slug loomio    # single org
   python util/scrape_news.py --dry-run        # print results without writing
   python util/scrape_news.py --debug          # show what date signals were found on each page
+  python util/scrape_news.py --update-rss     # write discovered feed URLs to rss_feed: frontmatter
+  python util/scrape_news.py --force          # re-scrape even if checked recently or spa/bot_blocked
   ```
 
 ### Org index table filters (`docs/overrides/organisations.html`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,8 @@ These are linked from the bottom of the org index table for researcher download.
   python util/scrape_news.py --slug loomio    # single org
   python util/scrape_news.py --dry-run        # print results without writing
   python util/scrape_news.py --debug          # show what date signals were found on each page
-  python util/scrape_news.py --update-rss     # write discovered feed URLs to rss_feed: frontmatter
+  python util/scrape_news.py --update-rss     # write discovered RSS feed URLs to rss_feed: frontmatter
+  python util/scrape_news.py --update-ics     # write discovered iCal feed URLs to ics_feed: frontmatter
   python util/scrape_news.py --force          # re-scrape even if checked recently or spa/bot_blocked
   ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Generated at build time by `hooks/data_export.py`. Served as static assets:
 
 | File | Description |
 |---|---|
-| `/data/organisations.csv` | Flat table — all orgs, one row each. Includes `activity_date`, `activity_method`, `rss_feed`. |
+| `/data/organisations.csv` | Flat table — all orgs, one row each. Includes `activity_date`, `activity_method`, `rss_feed`, `ics_feed`. |
 | `/data/organisations.json` | Structured JSON — concepts as arrays, full `activity` dict, computed `activity_date`/`activity_method`. |
 | `/data/organisations.geojson` | FeatureCollection — orgs with lat/lon only. |
 | `/data/organisations.kml` | KML — orgs with lat/lon, colour-coded by status. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ The invariants recorded there are not immutable. Any document in this repo — i
   - If all sources are stale, the most recent entry is shown regardless
   - `util/check_rss.py --update-activity` populates `rss`, `sitemap`, and `ical` entries automatically; re-runs skip orgs checked within 7 days (use `--force` to override)
   - `util/scrape_news.py` populates `scrape` entries for orgs with `news_page:` set; same skip behaviour
+  - `hint:` — written automatically by `scrape_news.py` on failure. Values: `spa` (JS-rendered, headless browser needed), `no_markup` (page loaded but no structured date signals — consider requesting RSS), `bot_blocked` (403/429 — consider requesting RSS), `unreachable` (network error). `spa` and `bot_blocked` are skipped on re-runs unless `--force`.
 - **Key people** is an optional section. Add it only when named individuals are central to understanding the org's story (founders, government champions, notable critics) and the information is sourced. Link names to Wikipedia where a confirmed article exists. Do not add it just to fill the template — most orgs are better served by institutional description.
 
 ### Blog posts (`docs/blog/posts/`)

--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -734,6 +734,7 @@
   vertical-align: middle;
 }
 .method-rss      { background: #fff3e0; color: #e65100; }
+.method-ical     { background: #e1f5fe; color: #01579b; }
 .method-sitemap  { background: #f3e5f5; color: #6a1b9a; }
 .method-manual   { background: #e8f5e9; color: #1b5e20; }
 .method-dod      { background: #e3f2fd; color: #0d47a1; }

--- a/docs/organisations/aman-palestine.md
+++ b/docs/organisations/aman-palestine.md
@@ -20,7 +20,6 @@ activity:
     date: 2026-05-21
     note: "Latest news page scraped"
     url: https://www.aman-palestine.org/en/activities/
-
   rss:
     date: 2026-06-05
     note: "RSS feed active"

--- a/docs/organisations/bersih.md
+++ b/docs/organisations/bersih.md
@@ -22,6 +22,10 @@ activity:
   rss:
     note: "No feed found"
     checked: 2026-06-07
+  scrape:
+    note: "News page unreachable"
+    hint: bot_blocked
+    checked: 2026-06-08
 ---
 
 BERSIH 2.0 (Coalition for Clean and Fair Elections) is a non-partisan coalition of over 90 Malaysian civil society organisations, formally launched in April 2010 as a continuation of the original BERSIH coalition formed in 2007. It is Malaysia's most prominent electoral reform movement.

--- a/docs/organisations/cdd-west-africa.md
+++ b/docs/organisations/cdd-west-africa.md
@@ -26,7 +26,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 ---
 
 The Centre for Democracy and Development (CDD West Africa) is an independent, non-profit research and advocacy organisation founded in 1997 (and registered in Nigeria in 1999) to support democratic governance and people-centred development across West Africa. It was established during Nigeria's transition from military to civilian rule and has since grown into a regional institution.

--- a/docs/organisations/conversations-at-the-crossroads.md
+++ b/docs/organisations/conversations-at-the-crossroads.md
@@ -24,7 +24,6 @@ activity:
     note: "Website loaded. https://www.crossroadsconversation.com.au/events says next event is at  Tuesday 30 June 2026  'The decline of democracy and the rise of the far-right'"
     url: https://www.crossroadsconversation.com.au/events
     checked: 2026-06-07
-
   scrape:
     date: 2026-06-30
     note: "Latest news page scraped"

--- a/docs/organisations/cooperative-bonds.md
+++ b/docs/organisations/cooperative-bonds.md
@@ -21,7 +21,6 @@ activity:
     date: 2026-05-21
     note: "Latest news page scraped"
     url: https://bonds.coop/resources/co-op-news/
-
   rss:
     date: 2026-06-05
     note: "RSS feed active"

--- a/docs/organisations/democracy-international.md
+++ b/docs/organisations/democracy-international.md
@@ -22,7 +22,6 @@ activity:
     date: 2026-04-27
     note: "Latest news page scraped"
     url: https://www.democracy-international.org/news
-
   rss:
     date: 2026-06-05
     note: "RSS feed active"

--- a/docs/organisations/democracy-next.md
+++ b/docs/organisations/democracy-next.md
@@ -24,7 +24,6 @@ activity:
     note: "website loaded. https://www.demnext.org/news mentions www.theartnewspaper.com/2026/01/02/uk-museums-embrace-citizens-assemblies-to-frame-their-futures 2 January 2026 'How UK museums are embracing citizens’ assemblies to help frame their futures'"
     url: https://www.demnext.org/news
     checked: 2026-06-07
-
   scrape:
     date: 2026-03-27
     note: "Latest news page scraped"

--- a/docs/organisations/democratie-ouverte.md
+++ b/docs/organisations/democratie-ouverte.md
@@ -24,7 +24,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 ---
 
 Démocratie Ouverte is a French non-partisan association of general interest that has, for over ten years, tested tools and methods and made proposals to public decision-makers to make governance more transparent, cooperative, and participative. It combines practical experimentation with policy advocacy and network convening.

--- a/docs/organisations/diem25.md
+++ b/docs/organisations/diem25.md
@@ -20,7 +20,6 @@ activity:
     date: 2026-06-04
     note: "Latest news page scraped"
     url: https://diem25.org/news
-
   rss:
     date: 2026-06-05
     note: "RSS feed active"

--- a/docs/organisations/fbk.md
+++ b/docs/organisations/fbk.md
@@ -25,7 +25,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 ---
 
 The Anti-Corruption Foundation (Фонд борьбы с коррупцией, FBK) was founded by Alexei Navalny and became Russia's most prominent anti-corruption investigative and advocacy organisation. Its video investigations into the wealth of senior Russian officials — including widely-viewed exposés on Prime Minister Medvedev and others — reached tens of millions of viewers inside Russia.

--- a/docs/organisations/g0v.md
+++ b/docs/organisations/g0v.md
@@ -29,7 +29,6 @@ activity:
     note: "News page found, no machine-readable date"
     hint: no_markup
     checked: 2026-06-08
-
   ical:
     date: 2026-06-07
     note: "Latest event: Cofacts 查核協作者培訓"

--- a/docs/organisations/g0v.md
+++ b/docs/organisations/g0v.md
@@ -5,6 +5,7 @@ status: active
 country: TW
 website: https://g0v.tw
 news_page: https://g0v.tw/intl/en/event/
+ics_feed: https://calendar.google.com/calendar/ical/cpcf6iv5pt9l6gl2ue3svo63e8%40group.calendar.google.com/public/basic.ics
 last_checked: "2026-05-30"
 summary: "A Taiwanese civic tech community that forks government websites and services to make them more open, usable, and participatory — best known internationally for co-developing the vTaiwan deliberation platform."
 location:
@@ -18,7 +19,7 @@ concepts:
 activity:
   rss:
     note: "No feed found"
-    checked: 2026-06-07
+    checked: 2026-06-08
   manual:
     date: 2026-06-07
     note: "website loaded. FYI they have an english version at https://g0v.tw/intl/en/ . In https://g0v.tw/intl/en/event/ there is a calendar where there appears to be various events."
@@ -27,6 +28,12 @@ activity:
   scrape:
     note: "News page found, no machine-readable date"
     checked: 2026-06-07
+
+  ical:
+    date: 2026-06-07
+    note: "Latest event: Cofacts 查核協作者培訓"
+    url: https://calendar.google.com/calendar/ical/cpcf6iv5pt9l6gl2ue3svo63e8%40group.calendar.google.com/public/basic.ics
+    checked: 2026-06-08
 ---
 
 g0v (pronounced "gov zero") is a decentralised, volunteer-driven civic tech community founded in Taiwan in 2012. The name is a pun: replacing the "o" in "gov" with "0" (zero) to create an alternative domain — `g0v.tw` versus `gov.tw` — signalling a parallel, open, citizen-built version of government infrastructure.

--- a/docs/organisations/g0v.md
+++ b/docs/organisations/g0v.md
@@ -27,7 +27,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 
   ical:
     date: 2026-06-07

--- a/docs/organisations/hkdc.md
+++ b/docs/organisations/hkdc.md
@@ -26,8 +26,9 @@ activity:
     url: https://www.hkdc.us/news
     checked: 2026-06-07
   scrape:
-    note: "News page found, no machine-readable date"
-    hint: no_markup
+    date: 2026-02-09
+    note: "Latest news page scraped"
+    url: https://www.hkdc.us/news
     checked: 2026-06-08
 ---
 

--- a/docs/organisations/hkdc.md
+++ b/docs/organisations/hkdc.md
@@ -27,7 +27,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 ---
 
 > **Note:** HKDC operates from diaspora in Washington DC. It is included here because its work is specifically about a particular governance system — the accountability structures promised to Hong Kong under One Country, Two Systems — rather than general human rights documentation.

--- a/docs/organisations/lcps.md
+++ b/docs/organisations/lcps.md
@@ -23,8 +23,10 @@ activity:
     note: "No feed found"
     checked: 2026-06-07
   scrape:
-    note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    date: 2026-03-05
+    note: "Latest news page scraped"
+    url: https://www.lcps-lebanon.org/en/press
+    checked: 2026-06-08
 ---
 
 The Lebanese Center for Policy Studies (LCPS) is an independent, non-partisan think tank founded in 1989 in Beirut. It produces research and advocates for policies aimed at improving governance in Lebanon and the broader Arab region. Its priority areas include political representation, decentralisation, transparency in natural resource governance, job creation, and youth empowerment.

--- a/docs/organisations/liquid-democracy-ev.md
+++ b/docs/organisations/liquid-democracy-ev.md
@@ -24,8 +24,10 @@ activity:
     date: 2026-06-01
     note: Page last modified (from sitemap)
   scrape:
-    note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    date: 2026-05-28
+    note: "Latest news page scraped"
+    url: https://liqd.net/en/blog/
+    checked: 2026-06-08
 ---
 
 Liquid Democracy e.V. is a Berlin-based non-profit association founded in 2009 to develop free and open-source digital participation tools and support their deployment in governments, NGOs, and public institutions. The organisation combines software development with consulting, workshops, and policy research.

--- a/docs/organisations/luminate.md
+++ b/docs/organisations/luminate.md
@@ -26,6 +26,7 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
+    hint: no_markup
     checked: 2026-06-08
 ---
 

--- a/docs/organisations/luminate.md
+++ b/docs/organisations/luminate.md
@@ -26,7 +26,7 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    checked: 2026-06-08
 ---
 
 Luminate is a global philanthropic organisation established in 2018, spun out from the Omidyar Network (founded by eBay co-founder Pierre Omidyar) to focus specifically on civic empowerment and open governance. It operates globally with offices in London, Washington DC, Nairobi, São Paulo, and other cities.

--- a/docs/organisations/memo98.md
+++ b/docs/organisations/memo98.md
@@ -23,7 +23,6 @@ activity:
     note: "website loaded. Blog at https://memo98.sk/articles/blog  20. December 2025 ' Moldova Story: How a Small Republic Resisted Hybrid War '"
     url: https://memo98.sk/articles/blog
     checked: 2026-06-07
-
   scrape:
     date: 2025-12-20
     note: "Latest news page scraped"

--- a/docs/organisations/memorial.md
+++ b/docs/organisations/memorial.md
@@ -25,7 +25,6 @@ activity:
     note: "website loaded. It's german... but this looks like news https://www.memorial.de/nachrichten wehere latest news is 04.06.2026 'Asat Miftachov wird im Lager gefoltert'"
     url: https://www.memorial.de/nachrichten
     checked: 2026-06-07
-
   scrape:
     date: 2026-06-04
     note: "Latest news page scraped"

--- a/docs/organisations/open-society-foundations.md
+++ b/docs/organisations/open-society-foundations.md
@@ -26,7 +26,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 ---
 
 The Open Society Foundations (OSF) are a global network of foundations founded by George Soros in 1979. Beginning with scholarships for Black South African students and support for East European dissidents, OSF grew into the world's largest private funder of independent civil society organisations working on democracy, human rights, justice, and equity.

--- a/docs/organisations/open-society-foundations.md
+++ b/docs/organisations/open-society-foundations.md
@@ -25,8 +25,9 @@ activity:
     url: https://www.opensocietyfoundations.org/newsroom
     checked: 2026-06-07
   scrape:
-    note: "News page found, no machine-readable date"
-    hint: no_markup
+    date: 2026-05-20
+    note: "Latest news page scraped"
+    url: https://www.opensocietyfoundations.org/newsroom
     checked: 2026-06-08
 ---
 

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -25,7 +25,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 ---
 
 Civil Network OPORA is Ukraine's primary independent election observation and civic oversight organisation, founded in 2006. It conducts comprehensive long-term and short-term election observation for presidential, parliamentary, and local elections, and publishes detailed analytical reports on each electoral cycle.

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -24,8 +24,9 @@ activity:
     url: https://oporaua.org/en/announce
     checked: 2026-06-07
   scrape:
-    note: "News page found, no machine-readable date"
-    hint: no_markup
+    date: 2026-05-20
+    note: "Latest news page scraped"
+    url: https://oporaua.org/en/announce
     checked: 2026-06-08
 ---
 

--- a/docs/organisations/participedia.md
+++ b/docs/organisations/participedia.md
@@ -4,6 +4,7 @@ type: research
 status: active
 country: CA
 website: https://participedia.net
+rss_feed: https://medium.com/feed/@participediaproject
 news_page: https://participediaproject.medium.com/
 summary: "A global open-access database and research platform cataloguing thousands of participatory democracy cases, methods, and organisations from around the world."
 location:
@@ -18,13 +19,21 @@ concepts:
   - democracy
 activity:
   rss:
-    note: "No feed found"
-    checked: 2026-06-07
+    date: 2026-01-05
+    note: "Latest post: Participedia Schools 2025 Summary Reports"
+    url: https://participediaproject.medium.com/participedia-schools-2025-summary-reports-5f84ce0bd47f?source=rss-4e7f7d842e0a------2
+    checked: 2026-06-08
   manual:
     date: 2026-01-06
     note: "website loaded. News page points to https://participediaproject.medium.com/ where latest is Jan 6, 2026 'Participedia Schools 2025 Summary Reports'"
     url: https://participediaproject.medium.com/
     checked: 2026-06-07
+
+  scrape:
+    date: 2025-06-02
+    note: "Latest news page scraped"
+    url: https://participediaproject.medium.com/
+    checked: 2026-06-08
 ---
 
 Participedia is a collaborative academic platform hosted by the University of British Columbia and Harvard University. It functions as a living encyclopaedia of participatory democracy — cataloguing case studies, methods, and organisations from across the world with structured, comparable data.

--- a/docs/organisations/prediki.md
+++ b/docs/organisations/prediki.md
@@ -25,7 +25,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: no_markup
+    checked: 2026-06-08
 ---
 
 Prediki (Prediki Prediction Markets GmbH) is a peer-to-peer platform for opinion research and collective intelligence, built around prediction market methodology. Rather than simple polling, participants make structured predictions about outcomes, stake a position, and provide reasons — the system aggregates these into probability estimates while tracking the quality of each contributor's predictions over time.

--- a/docs/organisations/prediki.md
+++ b/docs/organisations/prediki.md
@@ -24,8 +24,9 @@ activity:
     url: https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/
     checked: 2026-06-07
   scrape:
-    note: "News page found, no machine-readable date"
-    hint: no_markup
+    date: 2022-09-30
+    note: "Latest news page scraped"
+    url: https://www.prediki.com/meta/en/Management-by-Predictions-(Prediki-Blog-in-English)/
     checked: 2026-06-08
 ---
 

--- a/docs/organisations/rwanda-governance-board.md
+++ b/docs/organisations/rwanda-governance-board.md
@@ -23,7 +23,6 @@ activity:
     note: "website loaded. News page at https://www.rgb.rw/updates/news . Latest news  Friday, 29 May, 2026  'Former Ethipia Prime Minister H.E. Hailemariam visits RGB'"
     url: https://www.rgb.rw/updates/news
     checked: 2026-06-07
-
   scrape:
     date: 2026-05-29
     note: "Latest news page scraped"

--- a/docs/organisations/sortition-foundation-australia.md
+++ b/docs/organisations/sortition-foundation-australia.md
@@ -26,6 +26,10 @@ activity:
     note: "website loaded. News page at https://www.sortitionfoundation.org/updates 26 February, 2026 'Frontiers of Democratic Lotteries Workshop'"
     url: https://www.sortitionfoundation.org/updates
     checked: 2026-06-07
+  scrape:
+    note: "News page unreachable"
+    hint: bot_blocked
+    checked: 2026-06-08
 ---
 
 The Sortition Foundation is a UK-based organisation that campaigns for the use of stratified random selection (sortition) in government, primarily through citizens' assemblies. The Australian chapter operates within that global structure and is established by **Dr Sonia Randhawa**, based in Preston, Victoria, who works as a Project Manager at the Foundation.

--- a/docs/organisations/sortition-foundation.md
+++ b/docs/organisations/sortition-foundation.md
@@ -27,6 +27,10 @@ activity:
     note: "website loaded. https://www.sortitionfoundation.org/updates is the news page. 26 February, 2026 'Frontiers of Democratic Lotteries Workshop'"
     url: https://www.sortitionfoundation.org/updates
     checked: 2026-06-07
+  scrape:
+    note: "News page unreachable"
+    hint: bot_blocked
+    checked: 2026-06-08
 ---
 
 The Sortition Foundation is the UK's leading organisation specifically dedicated to sortition — the selection of decision-makers by random lot rather than election. Their flagship campaign is the **House of Citizens**: replacing the appointed House of Lords with a chamber of randomly selected citizens who serve fixed, non-renewable terms.

--- a/docs/organisations/susan-mckinnon-foundation.md
+++ b/docs/organisations/susan-mckinnon-foundation.md
@@ -23,7 +23,6 @@ activity:
     note: "website loaded. https://mckinnon.co/insights is it's news page. Latest news is 03 JUN 2026 'McKinnon Political Leader of the Year 2025 - Federal – Shortlisted nominees'"
     url: https://mckinnon.co/insights
     checked: 2026-06-07
-
   scrape:
     date: 2026-03-31
     note: "Latest post: Insights"

--- a/docs/organisations/vtaiwan.md
+++ b/docs/organisations/vtaiwan.md
@@ -27,7 +27,8 @@ activity:
     checked: 2026-06-07
   scrape:
     note: "News page found, no machine-readable date"
-    checked: 2026-06-07
+    hint: spa
+    checked: 2026-06-08
 ---
 
 vTaiwan is a civic-technology platform for structured public consultation, developed collaboratively by the Taiwanese government's digital ministry and the **g0v** civic-tech community. It grew out of the 2014 Sunflower Movement: at the end of that year, minister Jaclyn Tsai attended a g0v hackathon and invited the community to design a neutral platform for large-scale deliberation on specific policy questions. vTaiwan launched in 2015, built around **Pol.is**, an opinion-mapping tool that surfaces consensus rather than amplifying disagreement.[^demtech]

--- a/docs/organisations/your-party.md
+++ b/docs/organisations/your-party.md
@@ -18,7 +18,6 @@ activity:
     date: 2026-06-05
     note: "Latest tweet: police accountability post"
     url: https://x.com/thisisyourparty
-
   rss:
     date: 2026-06-07
     note: "RSS feed active"

--- a/hooks/activity_selector.py
+++ b/hooks/activity_selector.py
@@ -16,14 +16,14 @@ Schema expected in org frontmatter:
         note: "Visited site, confirmed active"
 
 Selection logic:
-  1. Walk sources in priority order: manual > dod > social > rss > scrape > sitemap
+  1. Walk sources in priority order: manual > dod > social > rss > ical > scrape > sitemap
   2. Use the first source whose date is within its staleness threshold
   3. If none qualify (all stale), fall back to the most recent across all sources
 """
 
 from datetime import date
 
-PRIORITY = ["manual", "dod", "social", "rss", "scrape", "sitemap"]
+PRIORITY = ["manual", "dod", "social", "rss", "ical", "scrape", "sitemap"]
 
 # How many days before a source is considered stale and skipped in favour of
 # a lower-priority but fresher source.
@@ -32,6 +32,7 @@ STALENESS_DAYS = {
     "dod":     730,   # same confidence as manual
     "social":  365,   # social presence decays as a signal within a year
     "rss":     365,   # actual content publication
+    "ical":    365,   # calendar events — reliable structured feed like rss
     "scrape":  365,   # scraped news page date — same confidence as rss
     "sitemap": 180,   # weak signal (CMS can touch lastmod for any reason)
 }

--- a/hooks/data_export.py
+++ b/hooks/data_export.py
@@ -59,6 +59,7 @@ def load_orgs():
             "location_name": loc.get("name", ""),
             "last_checked": m.get("last_checked", ""),
             "rss_feed": m.get("rss_feed", ""),
+            "ics_feed": m.get("ics_feed", ""),
             "activity": m.get("activity") or {},
         })
     return orgs
@@ -90,7 +91,7 @@ def write_orgs_csv(orgs):
     path = os.path.join(OUT_DIR, "organisations.csv")
     fields = ["slug", "title", "status", "country", "type", "website",
               "summary", "concepts", "latitude", "longitude", "location_name",
-              "rss_feed", "activity_date", "activity_method", "last_checked"]
+              "rss_feed", "ics_feed", "activity_date", "activity_method", "last_checked"]
     with open(path, "w", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
         w.writeheader()

--- a/util/check_rss.py
+++ b/util/check_rss.py
@@ -161,7 +161,7 @@ def latest_sitemap_lastmod(sitemap_url, timeout=10, session=None):
 
 
 def parse_date(s):
-    """Parse RSS (RFC 2822) or Atom (ISO 8601) date strings robustly."""
+    """Parse RSS (RFC 2822), Atom (ISO 8601), or iCal (YYYYMMDD) date strings robustly."""
     if not s:
         return None
     s = s.strip()
@@ -181,7 +181,64 @@ def parse_date(s):
         return datetime.strptime(s[:10], "%Y-%m-%d").date()
     except ValueError:
         pass
+    # iCal compact: YYYYMMDD or YYYYMMDDThhmmss
+    try:
+        return datetime.strptime(s[:8], "%Y%m%d").date()
+    except ValueError:
+        pass
     return None
+
+
+def latest_from_ical(url, timeout=10, session=None):
+    """Fetch an iCal (.ics) URL and return (date, title, http_ok) of the most recent past event.
+
+    Only considers events with DTSTART in the past so upcoming events don't
+    inflate activity dates.
+    """
+    if session is None:
+        session = requests.Session()
+        session.headers["User-Agent"] = "DOD-ICS-Reader/1.0 (democracy wiki)"
+    try:
+        r = session.get(url, timeout=timeout)
+        r.raise_for_status()
+    except RequestException:
+        return None, None, False
+
+    today = datetime.today().date()
+    entries = []
+
+    # Unfold continuation lines per RFC 5545 §3.1
+    text = r.text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"\n[ \t]", "", text)
+
+    in_vevent = False
+    current_start = None
+    current_summary = ""
+
+    for line in text.split("\n"):
+        if line == "BEGIN:VEVENT":
+            in_vevent = True
+            current_start = None
+            current_summary = ""
+        elif line == "END:VEVENT":
+            if in_vevent and current_start:
+                d = parse_date(current_start)
+                if d and d <= today:
+                    entries.append((d, current_summary))
+            in_vevent = False
+        elif in_vevent:
+            if line.startswith("DTSTART"):
+                # DTSTART:20260630, DTSTART;TZID=...:20260630T000000,
+                # DTSTART;VALUE=DATE:20260630
+                val = line.split(":", 1)[-1].strip()
+                current_start = val[:8]
+            elif line.startswith("SUMMARY:"):
+                current_summary = line[8:].strip()
+
+    if not entries:
+        return None, None, True
+    entries.sort(key=lambda x: x[0], reverse=True)
+    return entries[0][0], entries[0][1], True
 
 
 def latest_from_feed(url, timeout=10, session=None):
@@ -459,6 +516,7 @@ def load_orgs(slug_filter=None, include_inactive=False):
             "website": website,
             "status": status,
             "rss_feed": meta.get("rss_feed") or "",
+            "ics_feed": meta.get("ics_feed") or "",
             "path": path,
             "activity": meta.get("activity") or {},
         })
@@ -565,6 +623,38 @@ def main():
 
         results.append(result)
         time.sleep(0.3)
+
+    # --- iCal feeds ---
+    if args.update_activity:
+        ical_orgs = [o for o in orgs if o.get("ics_feed")]
+        if ical_orgs:
+            print(f"\nChecking {len(ical_orgs)} iCal feed(s) (timeout={args.timeout}s)…\n")
+            for i, org in enumerate(ical_orgs, 1):
+                slug = org["slug"]
+                ics_url = org["ics_feed"]
+                print(f"  [{i:3d}/{len(ical_orgs)}] {slug} … ", end="", flush=True)
+
+                if not args.force:
+                    entry = (org.get("activity") or {}).get("ical") or {}
+                    chk_date = parse_date(str(entry.get("checked", "") or ""))
+                    if chk_date:
+                        age = (datetime.today().date() - chk_date).days
+                        if age <= 7:
+                            print(f"SKIPPED (checked {age}d ago)")
+                            continue
+
+                d, title, ok = latest_from_ical(ics_url, timeout=args.timeout, session=session)
+                if not ok:
+                    print(f"UNREACHABLE  {ics_url}")
+                elif d is None:
+                    write_checked_only(org["path"], "ical", "iCal feed found, no past events")
+                    print(f"NO_PAST_EVENTS  {ics_url}")
+                else:
+                    note = f"Latest event: {title[:80]}" if title else "Latest calendar event"
+                    update_activity_source(org["path"], d.isoformat(), note, ics_url, method="ical")
+                    print(f"UPDATED  {d}  {title[:50] if title else '(no title)'}")
+
+                time.sleep(0.5)
 
     print(f"\n{'='*60}")
     print(f"Found feeds for {len(found)} / {len(orgs) - len(skipped)} orgs checked")

--- a/util/check_rss.py
+++ b/util/check_rss.py
@@ -382,6 +382,8 @@ def update_activity_source(path, date_str, note, feed_url, post_url=None, method
 
         # If we never found this source, append it inside the activity block
         if in_activity and method not in (meta.get("activity") or {}):
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
             new_lines.extend(source_lines)
 
         yaml_block = "\n".join(new_lines)

--- a/util/review_orgs.py
+++ b/util/review_orgs.py
@@ -100,13 +100,19 @@ def load_orgs(slug_filter=None, include_inactive=False):
         status = meta.get("status", "")
         if not include_inactive and status not in ("active",):
             continue
+        activity = meta.get("activity") or {}
+        scrape_hint = (activity.get("scrape") or {}).get("hint", "")
         orgs.append({
             "slug": slug,
             "path": path,
             "title": meta.get("title", slug),
             "status": status,
             "website": meta.get("website", "") or "",
-            "activity": meta.get("activity") or {},
+            "news_page": (meta.get("news_page") or "").strip(),
+            "rss_feed": (meta.get("rss_feed") or "").strip(),
+            "ics_feed": (meta.get("ics_feed") or "").strip(),
+            "scrape_hint": scrape_hint,
+            "activity": activity,
         })
     return orgs
 
@@ -344,6 +350,28 @@ def review_org(org, index, total):
         print(f"  Manual:   {manual_entry.get('date')} ({age}d ago)  —  {manual_entry.get('note', '')}")
     else:
         print("  Manual:   never reviewed")
+
+    # Show automated data coverage and any scrape hint
+    has_auto = any(
+        (activity.get(m) or {}).get("date")
+        for m in ("rss", "ical", "scrape", "sitemap", "social", "dod")
+    )
+    hint = org.get("scrape_hint", "")
+    if org["rss_feed"]:
+        print(f"  RSS feed: {org['rss_feed']}")
+    elif org["ics_feed"]:
+        print(f"  iCal:     {org['ics_feed']}")
+    elif org["news_page"] and hint:
+        _HINT_MSG = {
+            "no_markup":   "scraper found no machine-readable dates — ask org for RSS/iCal",
+            "spa":         "page is JS-rendered, scraper can't read it — ask org for RSS/iCal",
+            "bot_blocked": "server blocked the scraper — ask org for RSS/iCal",
+            "unreachable": "news page was unreachable",
+        }
+        print(f"  News:     {org['news_page']}")
+        print(f"  Hint:     {hint}  — {_HINT_MSG.get(hint, hint)}")
+    elif org["news_page"] and not has_auto:
+        print(f"  News:     {org['news_page']}  (no automated data yet)")
 
     website = org["website"]
     if website and WAYBACK_PREFIX not in website:

--- a/util/review_orgs.py
+++ b/util/review_orgs.py
@@ -43,8 +43,8 @@ SKIP_FILES = {"organisations.md"}
 WAYBACK_PREFIX = "https://web.archive.org"
 TODAY = date.today().isoformat()
 
-PRIORITY_ORDER = ["manual", "dod", "social", "rss", "scrape", "sitemap"]
-STALENESS_DAYS = {"manual": 730, "dod": 730, "social": 365, "rss": 365, "scrape": 365, "sitemap": 180}
+PRIORITY_ORDER = ["manual", "dod", "social", "rss", "ical", "scrape", "sitemap"]
+STALENESS_DAYS = {"manual": 730, "dod": 730, "social": 365, "rss": 365, "ical": 365, "scrape": 365, "sitemap": 180}
 MANUAL_STALE_DAYS = 730
 
 

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -31,11 +31,15 @@ import os
 import re
 import sys
 import time
-from datetime import datetime
+from datetime import date, datetime
 from email.utils import parsedate_to_datetime
 from html.parser import HTMLParser
 from urllib.parse import urlparse
 from urllib.robotparser import RobotFileParser
+
+# Matches /YYYY/MM/DD/ path segments — used as a low-priority date fallback
+_URL_DATE_YMD = re.compile(r'/(\d{4})/(\d{1,2})/(\d{1,2})(?:[/?#]|$)')
+_URL_DATE_YM  = re.compile(r'/(\d{4})/(\d{1,2})(?:[/?#]|$)')
 
 try:
     import frontmatter
@@ -70,12 +74,17 @@ class _NewsParser(HTMLParser):
         self.time_datetimes = []   # values from <time datetime="...">
         self.meta_dates = []       # values from <meta property/name> date fields
         self.jsonld_blocks = []    # raw text of <script type="application/ld+json">
+        self.links = []            # hrefs from <a> tags (for URL-date fallback)
         self._in_jsonld = False
         self._jsonld_buf = ""
 
     def handle_starttag(self, tag, attrs):
         d = dict(attrs)
-        if tag == "time":
+        if tag == "a":
+            href = d.get("href", "").strip()
+            if href:
+                self.links.append(href)
+        elif tag == "time":
             dt = d.get("datetime", "").strip()
             if dt:
                 self.time_datetimes.append(dt)
@@ -131,27 +140,86 @@ def _dates_from_jsonld(blocks):
                 yield d, title
 
 
+def _dates_from_links(links):
+    """Yield (date, "") from URL path patterns like /2026/01/15/ in anchor hrefs.
+
+    Low-priority fallback for sites that don't use machine-readable date markup
+    but do embed dates in article URLs (common in WordPress/CMS).  Only yields
+    past dates to avoid picking up upcoming-event links.
+    """
+    today = date.today()
+    seen = set()
+    for href in links:
+        m = _URL_DATE_YMD.search(href)
+        if m:
+            try:
+                y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+                dt = date(y, mo, d)
+                if 2000 <= y and dt <= today and dt not in seen:
+                    seen.add(dt)
+                    yield dt, ""
+                continue
+            except ValueError:
+                pass
+        m = _URL_DATE_YM.search(href)
+        if m:
+            try:
+                y, mo = int(m.group(1)), int(m.group(2))
+                dt = date(y, mo, 1)
+                if 2000 <= y and dt <= today and dt not in seen:
+                    seen.add(dt)
+                    yield dt, ""
+            except ValueError:
+                pass
+
+
 def extract_best(parser):
-    """Return (date, title) for the most recent signal, or (None, None)."""
+    """Return (date, title) for the most recent signal, or (None, None).
+
+    Priority (highest first): JSON-LD > <meta> dates > <time datetime> > URL patterns.
+    Future dates are excluded so upcoming-event pages don't inflate activity.
+    """
+    today = date.today()
     candidates = []
 
     for d, title in _dates_from_jsonld(parser.jsonld_blocks):
-        candidates.append((d, title))
+        if d <= today:
+            candidates.append((d, title))
 
     for s in parser.meta_dates:
         d = parse_date(s)
-        if d:
+        if d and d <= today:
             candidates.append((d, ""))
 
     for s in parser.time_datetimes:
         d = parse_date(s)
-        if d:
+        if d and d <= today:
             candidates.append((d, ""))
+
+    # Lowest-priority fallback: dates embedded in article URL paths
+    for d, title in _dates_from_links(parser.links):
+        candidates.append((d, title))
 
     if not candidates:
         return None, None
     candidates.sort(key=lambda x: x[0], reverse=True)
     return candidates[0]
+
+
+def _print_debug(parser):
+    """Print a summary of what date signals the parser found on the page."""
+    today = date.today()
+    url_dates = sorted(
+        {d.isoformat() for d, _ in _dates_from_links(parser.links)},
+        reverse=True,
+    )[:8]
+    print(f"    ┌─ signals found ───────────────────────────────")
+    print(f"    │ <time datetime>  : {parser.time_datetimes[:8] or '(none)'}")
+    print(f"    │ <meta> dates     : {parser.meta_dates[:5] or '(none)'}")
+    print(f"    │ JSON-LD blocks   : {len(parser.jsonld_blocks)}")
+    print(f"    │ URL date patterns: {url_dates or '(none)'}")
+    print(f"    │ total <a> links  : {len(parser.links)}")
+    print(f"    └───────────────────────────────────────────────")
 
 
 # ---------------------------------------------------------------------------
@@ -200,12 +268,17 @@ def robots_allowed(url, timeout=5, session=None):
 # ---------------------------------------------------------------------------
 
 def scrape_news_page(url, timeout=10, session=None):
-    """Fetch url and return (date, title, http_ok)."""
+    """Fetch url and return (date, title, http_ok, parser).
+
+    parser is always returned so callers can inspect signals for --debug output
+    or to write custom extraction logic.
+    """
+    empty = _NewsParser()
     try:
         r = session.get(url, timeout=timeout)
         r.raise_for_status()
     except RequestException:
-        return None, None, False
+        return None, None, False, empty
 
     parser = _NewsParser()
     try:
@@ -214,7 +287,7 @@ def scrape_news_page(url, timeout=10, session=None):
         pass  # partial parse is fine; we take what we got
 
     d, title = extract_best(parser)
-    return d, title, True
+    return d, title, True, parser
 
 
 # ---------------------------------------------------------------------------
@@ -425,6 +498,8 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="Print results without writing frontmatter")
     parser.add_argument("--force", action="store_true",
                         help="Scrape all orgs even if recently checked (ignores activity.scrape.checked)")
+    parser.add_argument("--debug", action="store_true",
+                        help="Print what date signals were found on each page (useful for writing custom extractors)")
     args = parser.parse_args()
 
     orgs = load_orgs(slug_filter=args.slug, include_inactive=args.all)
@@ -458,17 +533,23 @@ def main():
             time.sleep(1.0)
             continue
 
-        d, title, ok = scrape_news_page(url, timeout=args.timeout, session=session)
+        d, title, ok, parser = scrape_news_page(url, timeout=args.timeout, session=session)
 
         if not ok:
             print(f"UNREACHABLE  {url}")
+            if args.debug:
+                _print_debug(parser)
         elif d is None:
             if not args.dry_run:
                 write_checked_only(org["path"], "scrape", "News page found, no machine-readable date")
             print(f"NO_DATE_FOUND  {url}")
+            if args.debug:
+                _print_debug(parser)
         else:
             note = f"Latest post: {title[:80]}" if title else "Latest news page scraped"
             print(f"SCRAPED  {d}  {title[:50] if title else '(no title)'}")
+            if args.debug:
+                _print_debug(parser)
             if not args.dry_run:
                 if update_activity_source(org["path"], d.isoformat(), note, url):
                     updated += 1

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -267,18 +267,44 @@ def robots_allowed(url, timeout=5, session=None):
 # Scrape
 # ---------------------------------------------------------------------------
 
+# Pages with fewer raw links than this are almost certainly JavaScript SPAs
+_SPA_LINK_THRESHOLD = 5
+
+
+def _classify_hint(ok, http_status, parser):
+    """Return a short hint string classifying a scraping failure.
+
+    spa         — raw HTML is nearly empty (JS SPA); headless browser needed
+    no_markup   — page loaded with content but has no machine-readable date
+                  signals; consider requesting an RSS feed from the org
+    bot_blocked — server returned 403/429; consider reaching out for a feed
+    unreachable — network error or unexpected HTTP error
+    """
+    if not ok:
+        if http_status in (403, 429):
+            return "bot_blocked"
+        return "unreachable"
+    if len(parser.links) < _SPA_LINK_THRESHOLD:
+        return "spa"
+    return "no_markup"
+
+
 def scrape_news_page(url, timeout=10, session=None):
-    """Fetch url and return (date, title, http_ok, parser).
+    """Fetch url and return (date, title, http_ok, parser, http_status).
 
     parser is always returned so callers can inspect signals for --debug output
-    or to write custom extraction logic.
+    or to write custom extraction logic.  http_status is the integer response
+    code on HTTP errors, None on network/timeout failures.
     """
     empty = _NewsParser()
     try:
         r = session.get(url, timeout=timeout)
         r.raise_for_status()
+    except requests.HTTPError as exc:
+        status = exc.response.status_code if exc.response is not None else None
+        return None, None, False, empty, status
     except RequestException:
-        return None, None, False, empty
+        return None, None, False, empty, None
 
     parser = _NewsParser()
     try:
@@ -287,7 +313,7 @@ def scrape_news_page(url, timeout=10, session=None):
         pass  # partial parse is fine; we take what we got
 
     d, title = extract_best(parser)
-    return d, title, True, parser
+    return d, title, True, parser, r.status_code
 
 
 # ---------------------------------------------------------------------------
@@ -369,8 +395,14 @@ def update_activity_source(path, date_str, note, url, method="scrape"):
 # Org loader
 # ---------------------------------------------------------------------------
 
-def write_checked_only(path, method, note=None):
-    """Add/update checked: <TODAY> on an activity source entry (no date/url change)."""
+def write_checked_only(path, method, note=None, hint=None):
+    """Add/update checked: (and optionally hint:) on an activity source entry.
+
+    hint  — short classification string written to activity.<method>.hint so
+            future runs and humans know why scraping failed (spa, no_markup,
+            bot_blocked, unreachable).  Pass None to leave any existing hint
+            unchanged.
+    """
     import yaml as _yaml
 
     with open(path, encoding="utf-8") as f:
@@ -385,6 +417,8 @@ def write_checked_only(path, method, note=None):
     minimal = [f"  {method}:"]
     if note:
         minimal.append(f"    note: {json.dumps(note, ensure_ascii=False)}")
+    if hint:
+        minimal.append(f"    hint: {hint}")
     minimal.append(f"    checked: {TODAY}")
 
     if not activity:
@@ -422,6 +456,7 @@ def write_checked_only(path, method, note=None):
         new_lines = []
         in_this_source = False
         checked_written = False
+        hint_written = False
         i = 0
         while i < len(lines):
             line = lines[i]
@@ -432,21 +467,38 @@ def write_checked_only(path, method, note=None):
                 continue
             if in_this_source:
                 if re.match(r"^  \w", line) or (line and not line.startswith("    ")):
+                    if hint and not hint_written:
+                        new_lines.append(f"    hint: {hint}")
+                        hint_written = True
                     if not checked_written:
                         new_lines.append(f"    checked: {TODAY}")
                         checked_written = True
                     in_this_source = False
+                elif re.match(r"^    hint\s*:", line):
+                    if hint:
+                        new_lines.append(f"    hint: {hint}")
+                        hint_written = True
+                    else:
+                        new_lines.append(line)  # keep existing hint unchanged
+                    i += 1
+                    continue
                 elif re.match(r"^    checked\s*:", line):
+                    if hint and not hint_written:
+                        new_lines.append(f"    hint: {hint}")
+                        hint_written = True
                     new_lines.append(f"    checked: {TODAY}")
                     checked_written = True
                     i += 1
                     continue
             new_lines.append(line)
             i += 1
-        if in_this_source and not checked_written:
+        if in_this_source:
             while new_lines and new_lines[-1] == "":
                 new_lines.pop()
-            new_lines.append(f"    checked: {TODAY}")
+            if hint and not hint_written:
+                new_lines.append(f"    hint: {hint}")
+            if not checked_written:
+                new_lines.append(f"    checked: {TODAY}")
         yaml_block = "\n".join(new_lines)
 
     if not yaml_block.endswith("\n"):
@@ -518,9 +570,15 @@ def main():
         url = org["news_page"]
         print(f"  [{i:3d}/{len(orgs)}] {slug} … ", end="", flush=True)
 
-        # Skip recently-checked orgs unless --force
+        # Skip unless --force
         if not args.force:
             entry = (org.get("activity") or {}).get("scrape") or {}
+            # Permanent-failure hints: skip until --force (no point retrying)
+            existing_hint = entry.get("hint", "")
+            if existing_hint in ("spa", "bot_blocked"):
+                print(f"SKIP [{existing_hint}]")
+                continue
+            # Recency skip: checked within the last 7 days
             chk_date = parse_date(str(entry.get("checked", "") or ""))
             if chk_date:
                 age = (datetime.strptime(TODAY, "%Y-%m-%d").date() - chk_date).days
@@ -533,16 +591,22 @@ def main():
             time.sleep(1.0)
             continue
 
-        d, title, ok, parser = scrape_news_page(url, timeout=args.timeout, session=session)
+        d, title, ok, parser, http_status = scrape_news_page(url, timeout=args.timeout, session=session)
 
         if not ok:
-            print(f"UNREACHABLE  {url}")
+            hint = _classify_hint(ok, http_status, parser)
+            print(f"UNREACHABLE [{hint}]  {url}")
+            if not args.dry_run:
+                write_checked_only(org["path"], "scrape",
+                                   "News page unreachable", hint=hint)
             if args.debug:
                 _print_debug(parser)
         elif d is None:
+            hint = _classify_hint(ok, http_status, parser)
+            print(f"NO_DATE_FOUND [{hint}]  {url}")
             if not args.dry_run:
-                write_checked_only(org["path"], "scrape", "News page found, no machine-readable date")
-            print(f"NO_DATE_FOUND  {url}")
+                write_checked_only(org["path"], "scrape",
+                                   "News page found, no machine-readable date", hint=hint)
             if args.debug:
                 _print_debug(parser)
         else:

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -3,10 +3,16 @@
 scrape_news.py — Scrape org news/blog pages for latest activity dates.
 
 For each org with a `news_page:` frontmatter field, fetches that URL and
-extracts the most recent article date from machine-readable signals only:
+extracts the most recent article date from machine-readable signals:
   1. JSON-LD datePublished / dateModified
-  2. OpenGraph article:published_time / article:modified_time
-  3. <time datetime="..."> elements
+  2. OpenGraph / Dublin Core / schema.org <meta> date fields
+  3. Schema.org microdata via itemprop="datePublished/dateModified"
+  4. <time datetime="..."> elements (or <time> with parseable text content)
+  5. <a href> URL path patterns (e.g. /2026/01/15/) with anchor text as title
+  6. Human-readable text date patterns ("January 15, 2026", "15 Jan 2026" etc.)
+
+Also discovers RSS/Atom feed links in <link rel="alternate"> and can write
+them to rss_feed: frontmatter with --update-rss.
 
 Writes to activity.scrape in org frontmatter. Respects robots.txt.
 Never writes if no machine-readable date is found.
@@ -20,6 +26,8 @@ Usage:
     python util/scrape_news.py --slug loomio
     python util/scrape_news.py --timeout 10
     python util/scrape_news.py --dry-run    # print results without writing
+    python util/scrape_news.py --update-rss # write discovered RSS feeds to rss_feed:
+    python util/scrape_news.py --debug      # show date signals found per page
 
 Requirements: requests (util/requirements.txt)
 """
@@ -34,12 +42,38 @@ import time
 from datetime import date, datetime
 from email.utils import parsedate_to_datetime
 from html.parser import HTMLParser
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 from urllib.robotparser import RobotFileParser
 
 # Matches /YYYY/MM/DD/ path segments — used as a low-priority date fallback
 _URL_DATE_YMD = re.compile(r'/(\d{4})/(\d{1,2})/(\d{1,2})(?:[/?#]|$)')
 _URL_DATE_YM  = re.compile(r'/(\d{4})/(\d{1,2})(?:[/?#]|$)')
+
+# Text date patterns for human-readable dates in article listings.
+# Applied as a final fallback when no structured signals are present.
+_MONTHS_PAT = (
+    r'(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?'
+    r'|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\.?'
+)
+_YEAR_PAT = r'(20[0-3]\d)'
+_MONTH_MAP = {m[:3].lower(): i + 1 for i, m in enumerate([
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+])}
+# "January 15, 2026" or "Jan 15 2026"
+# (?<![a-zA-Z]) rather than \b: \b fails when the month name directly follows a
+# letter with no whitespace, e.g. "ArticleFebruary 10, 2026" in concatenated text.
+_TEXT_DATE_MDY = re.compile(
+    rf'(?<![a-zA-Z])({_MONTHS_PAT})\s+(\d{{1,2}}),?\s+{_YEAR_PAT}(?!\d)', re.IGNORECASE
+)
+# "15 January 2026" or "15 Jan, 2026"
+_TEXT_DATE_DMY = re.compile(
+    rf'(?<!\d)(\d{{1,2}})\s+({_MONTHS_PAT}),?\s+{_YEAR_PAT}(?!\d)', re.IGNORECASE
+)
+# "January 2026" (month + year only, treated as 1st of month)
+_TEXT_DATE_MY = re.compile(
+    rf'(?<![a-zA-Z])({_MONTHS_PAT})\s+{_YEAR_PAT}(?!\d)', re.IGNORECASE
+)
 
 try:
     import frontmatter
@@ -61,6 +95,9 @@ WAYBACK_PREFIX = "https://web.archive.org"
 TODAY = datetime.today().strftime("%Y-%m-%d")
 USER_AGENT = "DOD-NewsScraper/1.0 (DesigningOpenDemocracy activity monitor)"
 
+# Pages with fewer raw links than this are almost certainly JavaScript SPAs
+_SPA_LINK_THRESHOLD = 5
+
 
 # ---------------------------------------------------------------------------
 # HTML parsing
@@ -72,11 +109,21 @@ class _NewsParser(HTMLParser):
     def __init__(self):
         super().__init__()
         self.time_datetimes = []   # values from <time datetime="...">
-        self.meta_dates = []       # values from <meta property/name> date fields
+        self.time_text_dates = []  # text content of <time> without datetime attr
+        self.meta_dates = []       # values from <meta property/name/itemprop> date fields
         self.jsonld_blocks = []    # raw text of <script type="application/ld+json">
-        self.links = []            # hrefs from <a> tags (for URL-date fallback)
+        self.links = []            # hrefs from <a> tags (used for SPA detection / link count)
+        self.link_texts = []       # (href, text) pairs — text = visible anchor label
+        self.feed_urls = []        # href values from <link rel="alternate"> feed links
         self._in_jsonld = False
         self._jsonld_buf = ""
+        self._in_link = False
+        self._link_href = ""
+        self._link_buf = ""
+        self._in_time_text = False
+        self._time_text_buf = ""
+        self._in_inert = False     # True inside <script>/<style> (non-JSON-LD)
+        self._text_buf = ""        # visible text content for pattern matching
 
     def handle_starttag(self, tag, attrs):
         d = dict(attrs)
@@ -84,12 +131,28 @@ class _NewsParser(HTMLParser):
             href = d.get("href", "").strip()
             if href:
                 self.links.append(href)
+            self._in_link = bool(href)
+            self._link_href = href
+            self._link_buf = ""
+        elif tag == "link":
+            rel = (d.get("rel") or "").lower().split()
+            type_ = (d.get("type") or "").lower()
+            href = (d.get("href") or "").strip()
+            if "alternate" in rel and href and type_ in (
+                "application/rss+xml",
+                "application/atom+xml",
+            ):
+                self.feed_urls.append(href)
         elif tag == "time":
             dt = d.get("datetime", "").strip()
             if dt:
                 self.time_datetimes.append(dt)
+                self._in_time_text = False
+            else:
+                self._in_time_text = True
+                self._time_text_buf = ""
         elif tag == "meta":
-            prop = (d.get("property") or d.get("name") or "").lower()
+            prop = (d.get("property") or d.get("name") or d.get("itemprop") or "").lower()
             content = d.get("content", "").strip()
             if prop in {
                 "article:published_time",
@@ -99,21 +162,52 @@ class _NewsParser(HTMLParser):
                 "last-modified",
                 "dc.date",
                 "dc.date.issued",
+                "datepublished",    # itemprop="datePublished" on <meta>
+                "datemodified",     # itemprop="dateModified" on <meta>
+                "datecreated",      # itemprop="dateCreated" on <meta>
             } and content:
                 self.meta_dates.append(content)
-        elif tag == "script" and d.get("type") == "application/ld+json":
-            self._in_jsonld = True
-            self._jsonld_buf = ""
+        elif tag == "script":
+            if d.get("type") == "application/ld+json":
+                self._in_jsonld = True
+                self._jsonld_buf = ""
+            else:
+                self._in_inert = True
+        elif tag == "style":
+            self._in_inert = True
 
     def handle_endtag(self, tag):
-        if tag == "script" and self._in_jsonld:
-            self._in_jsonld = False
-            if self._jsonld_buf.strip():
-                self.jsonld_blocks.append(self._jsonld_buf)
+        if tag == "script":
+            if self._in_jsonld:
+                self._in_jsonld = False
+                if self._jsonld_buf.strip():
+                    self.jsonld_blocks.append(self._jsonld_buf)
+            elif self._in_inert:
+                self._in_inert = False
+        elif tag == "style" and self._in_inert:
+            self._in_inert = False
+        elif tag == "a" and self._in_link:
+            text = self._link_buf.strip()
+            if self._link_href:
+                self.link_texts.append((self._link_href, text))
+            self._in_link = False
+        elif tag == "time" and self._in_time_text:
+            self._in_time_text = False
+            t = self._time_text_buf.strip()
+            if t:
+                self.time_text_dates.append(t)
 
     def handle_data(self, data):
         if self._in_jsonld:
             self._jsonld_buf += data
+            return
+        if self._in_inert:
+            return
+        if self._in_link:
+            self._link_buf += data
+        if self._in_time_text:
+            self._time_text_buf += data
+        self._text_buf += data
 
 
 def _dates_from_jsonld(blocks):
@@ -127,7 +221,6 @@ def _dates_from_jsonld(blocks):
         for item in items:
             if not isinstance(item, dict):
                 continue
-            # Recurse into @graph
             graph = item.get("@graph")
             if graph:
                 yield from _dates_from_jsonld([json.dumps(graph)])
@@ -140,24 +233,24 @@ def _dates_from_jsonld(blocks):
                 yield d, title
 
 
-def _dates_from_links(links):
-    """Yield (date, "") from URL path patterns like /2026/01/15/ in anchor hrefs.
+def _dates_from_links(link_texts):
+    """Yield (date, title) from URL path patterns like /2026/01/15/ in anchor hrefs.
 
-    Low-priority fallback for sites that don't use machine-readable date markup
-    but do embed dates in article URLs (common in WordPress/CMS).  Only yields
-    past dates to avoid picking up upcoming-event links.
+    Low-priority fallback for sites that don't use structured date markup
+    but embed dates in article URLs (common in WordPress/CMS).  Anchor text
+    is returned as the title when non-empty.
     """
     today = date.today()
     seen = set()
-    for href in links:
+    for href, text in link_texts:
         m = _URL_DATE_YMD.search(href)
         if m:
             try:
-                y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
-                dt = date(y, mo, d)
+                y, mo, day_n = int(m.group(1)), int(m.group(2)), int(m.group(3))
+                dt = date(y, mo, day_n)
                 if 2000 <= y and dt <= today and dt not in seen:
                     seen.add(dt)
-                    yield dt, ""
+                    yield dt, text[:80]
                 continue
             except ValueError:
                 pass
@@ -168,15 +261,60 @@ def _dates_from_links(links):
                 dt = date(y, mo, 1)
                 if 2000 <= y and dt <= today and dt not in seen:
                     seen.add(dt)
-                    yield dt, ""
+                    yield dt, text[:80]
             except ValueError:
                 pass
+
+
+def _dates_from_text(text):
+    """Yield (date, '') from human-readable date strings in page text.
+
+    Matches English date formats: "15 January 2026", "January 15, 2026",
+    "Jan 2026".  Lowest-confidence fallback for sites with no structured
+    markup.  Always filtered to past dates.
+    """
+    if not text:
+        return
+    today = date.today()
+    seen = set()
+
+    def _emit(year_s, month_s, day_n):
+        mo = _MONTH_MAP.get(month_s.lower()[:3])
+        if not mo:
+            return
+        try:
+            dt = date(int(year_s), mo, day_n)
+            if 2000 <= dt.year and dt <= today and dt not in seen:
+                seen.add(dt)
+                return dt
+        except ValueError:
+            pass
+
+    for m in _TEXT_DATE_MDY.finditer(text):
+        mo_s, day_s, year_s = m.group(1), m.group(2), m.group(3)
+        dt = _emit(year_s, mo_s, int(day_s))
+        if dt:
+            yield dt, ""
+
+    for m in _TEXT_DATE_DMY.finditer(text):
+        day_s, mo_s, year_s = m.group(1), m.group(2), m.group(3)
+        dt = _emit(year_s, mo_s, int(day_s))
+        if dt:
+            yield dt, ""
+
+    for m in _TEXT_DATE_MY.finditer(text):
+        mo_s, year_s = m.group(1), m.group(2)
+        dt = _emit(year_s, mo_s, 1)
+        if dt:
+            yield dt, ""
 
 
 def extract_best(parser):
     """Return (date, title) for the most recent signal, or (None, None).
 
-    Priority (highest first): JSON-LD > <meta> dates > <time datetime> > URL patterns.
+    Priority (highest to lowest):
+      JSON-LD → <meta>/microdata → <time datetime> → <time> text
+      → URL path patterns → human-readable text patterns
     Future dates are excluded so upcoming-event pages don't inflate activity.
     """
     today = date.today()
@@ -196,8 +334,15 @@ def extract_best(parser):
         if d and d <= today:
             candidates.append((d, ""))
 
-    # Lowest-priority fallback: dates embedded in article URL paths
-    for d, title in _dates_from_links(parser.links):
+    for s in parser.time_text_dates:
+        d = parse_date(s)
+        if d and d <= today:
+            candidates.append((d, ""))
+
+    for d, title in _dates_from_links(parser.link_texts):
+        candidates.append((d, title))
+
+    for d, title in _dates_from_text(parser._text_buf):
         candidates.append((d, title))
 
     if not candidates:
@@ -208,16 +353,22 @@ def extract_best(parser):
 
 def _print_debug(parser):
     """Print a summary of what date signals the parser found on the page."""
-    today = date.today()
     url_dates = sorted(
-        {d.isoformat() for d, _ in _dates_from_links(parser.links)},
+        {d.isoformat() for d, _ in _dates_from_links(parser.link_texts)},
         reverse=True,
     )[:8]
+    text_dates = sorted(
+        {d.isoformat() for d, _ in _dates_from_text(parser._text_buf)},
+        reverse=True,
+    )[:5]
     print(f"    ┌─ signals found ───────────────────────────────")
     print(f"    │ <time datetime>  : {parser.time_datetimes[:8] or '(none)'}")
+    print(f"    │ <time> text      : {parser.time_text_dates[:5] or '(none)'}")
     print(f"    │ <meta> dates     : {parser.meta_dates[:5] or '(none)'}")
     print(f"    │ JSON-LD blocks   : {len(parser.jsonld_blocks)}")
     print(f"    │ URL date patterns: {url_dates or '(none)'}")
+    print(f"    │ text date matches: {text_dates or '(none)'}")
+    print(f"    │ feed links found : {parser.feed_urls[:3] or '(none)'}")
     print(f"    │ total <a> links  : {len(parser.links)}")
     print(f"    └───────────────────────────────────────────────")
 
@@ -267,10 +418,6 @@ def robots_allowed(url, timeout=5, session=None):
 # Scrape
 # ---------------------------------------------------------------------------
 
-# Pages with fewer raw links than this are almost certainly JavaScript SPAs
-_SPA_LINK_THRESHOLD = 5
-
-
 def _classify_hint(ok, http_status, parser):
     """Return a short hint string classifying a scraping failure.
 
@@ -317,7 +464,7 @@ def scrape_news_page(url, timeout=10, session=None):
 
 
 # ---------------------------------------------------------------------------
-# Frontmatter writer (mirrors check_rss.py update_activity_source)
+# Frontmatter writers
 # ---------------------------------------------------------------------------
 
 def update_activity_source(path, date_str, note, url, method="scrape"):
@@ -390,10 +537,6 @@ def update_activity_source(path, date_str, note, url, method="scrape"):
         f.write("---" + yaml_block + "---" + rest)
     return True
 
-
-# ---------------------------------------------------------------------------
-# Org loader
-# ---------------------------------------------------------------------------
 
 def write_checked_only(path, method, note=None, hint=None):
     """Add/update checked: (and optionally hint:) on an activity source entry.
@@ -508,6 +651,36 @@ def write_checked_only(path, method, note=None, hint=None):
     return True
 
 
+def write_rss_feed(path, feed_url):
+    """Write rss_feed: to org frontmatter if not already present.
+
+    Inserts after the website: line when present, otherwise before news_page:.
+    Returns False (no write) if rss_feed: already exists in the file.
+    """
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    parts = content.split("---", 2)
+    if len(parts) < 3 or parts[0] != "":
+        return False
+    yaml_block, rest = parts[1], parts[2]
+    if re.search(r'^rss_feed\s*:', yaml_block, re.MULTILINE):
+        return False
+    for pattern in (r'^(website\s*:.*\n)', r'^(news_page\s*:.*\n)'):
+        m = re.search(pattern, yaml_block, re.MULTILINE)
+        if m:
+            yaml_block = yaml_block[:m.end()] + f"rss_feed: {feed_url}\n" + yaml_block[m.end():]
+            break
+    else:
+        yaml_block = yaml_block.rstrip("\n") + f"\nrss_feed: {feed_url}\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---" + yaml_block + "---" + rest)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Org loader
+# ---------------------------------------------------------------------------
+
 def load_orgs(slug_filter=None, include_inactive=False):
     orgs = []
     for path in sorted(glob.glob(os.path.join(ORGS_DIR, "*.md"))):
@@ -534,6 +707,7 @@ def load_orgs(slug_filter=None, include_inactive=False):
             "news_page": news_page,
             "path": path,
             "activity": meta.get("activity") or {},
+            "rss_feed": (meta.get("rss_feed") or "").strip(),
         })
     return orgs
 
@@ -552,6 +726,8 @@ def main():
                         help="Scrape all orgs even if recently checked (ignores activity.scrape.checked)")
     parser.add_argument("--debug", action="store_true",
                         help="Print what date signals were found on each page (useful for writing custom extractors)")
+    parser.add_argument("--update-rss", action="store_true",
+                        help="Write discovered RSS/Atom feed URLs to rss_feed: frontmatter for orgs that lack one")
     args = parser.parse_args()
 
     orgs = load_orgs(slug_filter=args.slug, include_inactive=args.all)
@@ -563,6 +739,7 @@ def main():
     session.headers.update({"User-Agent": USER_AGENT})
 
     updated = 0
+    feeds_written = 0
     print(f"\nScraping {len(orgs)} org news page(s) (timeout={args.timeout}s)…\n")
 
     for i, org in enumerate(orgs, 1):
@@ -591,32 +768,41 @@ def main():
             time.sleep(1.0)
             continue
 
-        d, title, ok, parser, http_status = scrape_news_page(url, timeout=args.timeout, session=session)
+        d, title, ok, page_parser, http_status = scrape_news_page(url, timeout=args.timeout, session=session)
+
+        # Report / write discovered RSS feeds
+        if page_parser.feed_urls:
+            resolved_feeds = [urljoin(url, f) for f in page_parser.feed_urls[:2]]
+            if args.update_rss and not args.dry_run and not org["rss_feed"]:
+                if write_rss_feed(org["path"], resolved_feeds[0]):
+                    feeds_written += 1
 
         if not ok:
-            hint = _classify_hint(ok, http_status, parser)
-            print(f"UNREACHABLE [{hint}]  {url}")
+            hint = _classify_hint(ok, http_status, page_parser)
+            print(f"UNREACHABLE [{hint}]")
             if not args.dry_run:
                 write_checked_only(org["path"], "scrape",
                                    "News page unreachable", hint=hint)
-            if args.debug:
-                _print_debug(parser)
         elif d is None:
-            hint = _classify_hint(ok, http_status, parser)
-            print(f"NO_DATE_FOUND [{hint}]  {url}")
+            hint = _classify_hint(ok, http_status, page_parser)
+            print(f"NO_DATE_FOUND [{hint}]")
             if not args.dry_run:
                 write_checked_only(org["path"], "scrape",
                                    "News page found, no machine-readable date", hint=hint)
-            if args.debug:
-                _print_debug(parser)
         else:
             note = f"Latest post: {title[:80]}" if title else "Latest news page scraped"
             print(f"SCRAPED  {d}  {title[:50] if title else '(no title)'}")
-            if args.debug:
-                _print_debug(parser)
             if not args.dry_run:
                 if update_activity_source(org["path"], d.isoformat(), note, url):
                     updated += 1
+
+        if page_parser.feed_urls:
+            resolved_feeds = [urljoin(url, f) for f in page_parser.feed_urls[:2]]
+            for f in resolved_feeds:
+                print(f"    → feed: {f}")
+
+        if args.debug:
+            _print_debug(page_parser)
 
         time.sleep(1.5)
 
@@ -625,6 +811,8 @@ def main():
         print("Dry run — no files written")
     else:
         print(f"Updated {updated} / {len(orgs)} org page(s)")
+        if feeds_written:
+            print(f"Wrote rss_feed: for {feeds_written} org(s) — run check_rss.py --update-activity to populate activity.rss")
 
     return 0
 

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -14,6 +14,10 @@ extracts the most recent article date from machine-readable signals:
 Also discovers RSS/Atom feed links in <link rel="alternate"> and can write
 them to rss_feed: frontmatter with --update-rss.
 
+Also discovers iCal/ICS calendar links (<link rel="alternate" type="text/calendar">,
+webcal:// hrefs, and .ics file links) and can write them to ics_feed: frontmatter
+with --update-ics.
+
 Writes to activity.scrape in org frontmatter. Respects robots.txt.
 Never writes if no machine-readable date is found.
 
@@ -27,6 +31,7 @@ Usage:
     python util/scrape_news.py --timeout 10
     python util/scrape_news.py --dry-run    # print results without writing
     python util/scrape_news.py --update-rss # write discovered RSS feeds to rss_feed:
+    python util/scrape_news.py --update-ics # write discovered iCal feeds to ics_feed:
     python util/scrape_news.py --debug      # show date signals found per page
 
 Requirements: requests (util/requirements.txt)
@@ -115,6 +120,7 @@ class _NewsParser(HTMLParser):
         self.links = []            # hrefs from <a> tags (used for SPA detection / link count)
         self.link_texts = []       # (href, text) pairs — text = visible anchor label
         self.feed_urls = []        # href values from <link rel="alternate"> feed links
+        self.ical_urls = []        # iCal links: <link rel=alternate type=text/calendar>, webcal://, *.ics
         self._in_jsonld = False
         self._jsonld_buf = ""
         self._in_link = False
@@ -131,6 +137,9 @@ class _NewsParser(HTMLParser):
             href = d.get("href", "").strip()
             if href:
                 self.links.append(href)
+                href_lower = href.lower()
+                if href_lower.startswith("webcal://") or href_lower.split("?")[0].endswith(".ics"):
+                    self.ical_urls.append(href)
             self._in_link = bool(href)
             self._link_href = href
             self._link_buf = ""
@@ -138,11 +147,11 @@ class _NewsParser(HTMLParser):
             rel = (d.get("rel") or "").lower().split()
             type_ = (d.get("type") or "").lower()
             href = (d.get("href") or "").strip()
-            if "alternate" in rel and href and type_ in (
-                "application/rss+xml",
-                "application/atom+xml",
-            ):
-                self.feed_urls.append(href)
+            if "alternate" in rel and href:
+                if type_ in ("application/rss+xml", "application/atom+xml"):
+                    self.feed_urls.append(href)
+                elif type_ in ("text/calendar", "text/x-vcalendar"):
+                    self.ical_urls.append(href)
         elif tag == "time":
             dt = d.get("datetime", "").strip()
             if dt:
@@ -369,6 +378,7 @@ def _print_debug(parser):
     print(f"    │ URL date patterns: {url_dates or '(none)'}")
     print(f"    │ text date matches: {text_dates or '(none)'}")
     print(f"    │ feed links found : {parser.feed_urls[:3] or '(none)'}")
+    print(f"    │ ical links found : {parser.ical_urls[:3] or '(none)'}")
     print(f"    │ total <a> links  : {len(parser.links)}")
     print(f"    └───────────────────────────────────────────────")
 
@@ -677,6 +687,38 @@ def write_rss_feed(path, feed_url):
     return True
 
 
+def write_ics_feed(path, feed_url):
+    """Write ics_feed: to org frontmatter if not already present.
+
+    webcal:// URIs are normalised to https:// so the URL is directly fetchable
+    by check_rss.py.  Inserts after rss_feed: when present, otherwise after
+    website:, otherwise at end of frontmatter.
+    Returns False (no write) if ics_feed: already exists in the file.
+    """
+    # Normalise webcal:// → https:// so check_rss.py can fetch it directly
+    if feed_url.lower().startswith("webcal://"):
+        feed_url = "https://" + feed_url[9:]
+
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    parts = content.split("---", 2)
+    if len(parts) < 3 or parts[0] != "":
+        return False
+    yaml_block, rest = parts[1], parts[2]
+    if re.search(r'^ics_feed\s*:', yaml_block, re.MULTILINE):
+        return False
+    for pattern in (r'^(rss_feed\s*:.*\n)', r'^(website\s*:.*\n)'):
+        m = re.search(pattern, yaml_block, re.MULTILINE)
+        if m:
+            yaml_block = yaml_block[:m.end()] + f"ics_feed: {feed_url}\n" + yaml_block[m.end():]
+            break
+    else:
+        yaml_block = yaml_block.rstrip("\n") + f"\nics_feed: {feed_url}\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---" + yaml_block + "---" + rest)
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Org loader
 # ---------------------------------------------------------------------------
@@ -708,6 +750,7 @@ def load_orgs(slug_filter=None, include_inactive=False):
             "path": path,
             "activity": meta.get("activity") or {},
             "rss_feed": (meta.get("rss_feed") or "").strip(),
+            "ics_feed": (meta.get("ics_feed") or "").strip(),
         })
     return orgs
 
@@ -728,6 +771,8 @@ def main():
                         help="Print what date signals were found on each page (useful for writing custom extractors)")
     parser.add_argument("--update-rss", action="store_true",
                         help="Write discovered RSS/Atom feed URLs to rss_feed: frontmatter for orgs that lack one")
+    parser.add_argument("--update-ics", action="store_true",
+                        help="Write discovered iCal feed URLs to ics_feed: frontmatter for orgs that lack one")
     args = parser.parse_args()
 
     orgs = load_orgs(slug_filter=args.slug, include_inactive=args.all)
@@ -740,6 +785,7 @@ def main():
 
     updated = 0
     feeds_written = 0
+    ics_written = 0
     print(f"\nScraping {len(orgs)} org news page(s) (timeout={args.timeout}s)…\n")
 
     for i, org in enumerate(orgs, 1):
@@ -777,6 +823,13 @@ def main():
                 if write_rss_feed(org["path"], resolved_feeds[0]):
                     feeds_written += 1
 
+        # Report / write discovered iCal feeds
+        if page_parser.ical_urls:
+            resolved_icals = [urljoin(url, f) for f in page_parser.ical_urls[:2]]
+            if args.update_ics and not args.dry_run and not org["ics_feed"]:
+                if write_ics_feed(org["path"], resolved_icals[0]):
+                    ics_written += 1
+
         if not ok:
             hint = _classify_hint(ok, http_status, page_parser)
             print(f"UNREACHABLE [{hint}]")
@@ -799,7 +852,12 @@ def main():
         if page_parser.feed_urls:
             resolved_feeds = [urljoin(url, f) for f in page_parser.feed_urls[:2]]
             for f in resolved_feeds:
-                print(f"    → feed: {f}")
+                print(f"    → feed:  {f}")
+
+        if page_parser.ical_urls:
+            resolved_icals = [urljoin(url, f) for f in page_parser.ical_urls[:2]]
+            for f in resolved_icals:
+                print(f"    → ical:  {f}")
 
         if args.debug:
             _print_debug(page_parser)
@@ -813,6 +871,8 @@ def main():
         print(f"Updated {updated} / {len(orgs)} org page(s)")
         if feeds_written:
             print(f"Wrote rss_feed: for {feeds_written} org(s) — run check_rss.py --update-activity to populate activity.rss")
+        if ics_written:
+            print(f"Wrote ics_feed: for {ics_written} org(s) — run check_rss.py --update-activity to populate activity.ical")
 
     return 0
 

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -535,6 +535,8 @@ def update_activity_source(path, date_str, note, url, method="scrape"):
             new_lines.append(line)
             i += 1
         if in_activity and method not in (meta.get("activity") or {}):
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
             new_lines.extend(source_lines)
         yaml_block = "\n".join(new_lines)
         if not yaml_block.endswith("\n"):


### PR DESCRIPTION
## Summary

Follow-up to the manual review commit (`4bdcb86`). Cleans up the data that was recorded and improves the tooling based on what the review revealed.

### Data fixes (30ac923, cee6d51, f3dca02)

- **34 org files**: corrected `activity.manual.date` — entries were recording the review date rather than the discovered activity date.
- **27 org files**: extracted evidence URLs from note text into a structured `url:` field on `activity.manual`.
- **18 org files**: added `news_page:` frontmatter where a news/blog URL was identified during the review. Followed immediately by a scraper run against all new entries.

### `review_orgs.py` improvements (30ac923)

- Added separate prompts for **activity date** and **evidence URL** after the note prompt.
- `write_manual_activity` now accepts `checked_str` (review date) separately from `date_str` (activity date).
- Added `ical` to the priority order and staleness table.

### `scrape_news.py` — first round (9dafefc, b8eaa8d)

- `--debug` mode: prints structured signals found per page
- URL-date fallback: `/YYYY/MM/DD/` patterns in `<a href>`
- Future date filtering across all signal types
- Scrape failure hints: `activity.scrape.hint` written on failure (`spa`, `no_markup`, `bot_blocked`, `unreachable`). `spa` and `bot_blocked` are permanent-skip hints (no retry without `--force`).

### `scrape_news.py` — second round (ff28f27)

Driven by inspecting the `no_markup` sites in `--debug` mode:

- **Text date pattern extraction** (lowest-priority fallback): matches "January 15, 2026", "15 Jan 2026", "Jan 2026" in visible page text. Fixes `hkdc`, `liquid-democracy-ev`, `open-society-foundations`, `opora`, `prediki` — all previously `no_markup`.
- **RSS/Atom feed autodiscovery**: parses `<link rel="alternate" type="application/rss+xml">` in `<head>`. Feeds are always reported in output; written to `rss_feed:` frontmatter with `--update-rss`. Discovered feeds for `citizen-os`, `cooperative-bonds`, `participedia` (added and activated via `check_rss.py`).
- **Schema.org microdata**: `itemprop="datePublished/dateModified/dateCreated"` on `<meta>` elements.
- **`<time>` text content**: captures `<time>` element text when no `datetime` attribute is present.
- **Link text as title**: anchor text captured alongside href so URL-date matches get article titles.
- **Regex fix**: `\b(Month)` → `(?<[a-zA-Z])(Month)` — `\b` fails when article title and date concatenate without whitespace in text nodes (e.g. "FatherFebruary 10, 2026").
- `_in_inert` flag: excludes `<script>`/`<style>` content from text accumulation (avoids false positives from JS data).

### `check_rss.py` + iCal support (9dafefc)

- Added `latest_from_ical(url)`: RFC 5545 line-unfolding, past-event filtering.
- iCal pass runs after RSS/sitemap when `--update-activity` is used.
- `parse_date()` extended for compact YYYYMMDD iCal format.

### `hooks/activity_selector.py` (9dafefc)

- Added `ical` to `PRIORITY` list and `STALENESS_DAYS` (365 d).

### `docs/organisations/g0v.md` + `participedia.md`

- `g0v`: `ics_feed:` added; `activity.ical` populated.
- `participedia`: `rss_feed:` added; `activity.rss` populated (2026-01-05 — newer than scrape).

### Data: scrape pass results

- **Newly scraped**: `hkdc` (2026-02-09), `liquid-democracy-ev` (2026-05-28), `open-society-foundations` (2026-05-20), `opora` (2026-05-20), `prediki` (2022-09-30), `participedia` (2025-06-02 from scrape; 2026-01-05 from RSS)
- **New `bot_blocked` hints**: `bersih`, `sortition-foundation`, `sortition-foundation-australia` (all return 403 from the build container — may scrape fine from your machine)
- **Remaining `no_markup`**: `cdd-west-africa` (no dates on index, only per-article), `democratie-ouverte` (French dates + dynamic load), `fbk` (dates in JS CMS script variable), `g0v` (calendar page — covered by iCal), `luminate` (AJAX-loaded content, no dates in initial HTML)

## Test plan

- [ ] `mkdocs build` passes with no errors
- [ ] Org pages with `activity.ical` render "Last activity" correctly (g0v)
- [ ] `python util/scrape_news.py --debug --slug hkdc` shows text date matches
- [ ] `python util/scrape_news.py --debug --slug vtaiwan` shows `hint: spa`
- [ ] `python util/scrape_news.py --debug --slug participedia` shows feed discovered
- [ ] `python util/check_rss.py --update-activity --slug g0v` writes/refreshes `activity.ical`
- [ ] Activity dates on corrected orgs look sensible (not all 2026-05-30)
- [ ] `python util/scrape_news.py --slug sortition-foundation --force --debug` from your machine — expect either a date or `bot_blocked`