### PR TITLE
fix: activity tooling reliability — checked: stamp + consistent index dates

### DIFF
--- a/docs/organisations/australian-democrats.md
+++ b/docs/organisations/australian-democrats.md
@@ -19,6 +19,7 @@ activity:
     date: 2026-05-24
     note: "Latest post: We took part in a Facebook Q&A"
     url: "https://www.democrats.org.au/posts/6v15DUfhxyWNVoSqBBFje4/we-took-part-in-a-facebook-q-a"
+    checked: 2026-06-08
 ---
 
 The Australian Democrats were originally founded in 1977 by Don Chipp with the stated aim to "keep the bastards honest" — a positioning as a principled centrist force holding the major parties accountable. The party held the balance of power in the Senate for many years before collapsing around 2008. It has since been re-established and is rebuilding a presence at state and federal levels.

--- a/docs/overrides/organisations.html
+++ b/docs/overrides/organisations.html
@@ -51,18 +51,14 @@
       {%- set country = file.page.meta.get('country', '') %}
       {%- set org_type = file.page.meta.get('type', '') %}
       {%- set website = file.page.meta.get('website', '') %}
-      {%- set activity = file.page.meta.get('activity') or {} %}
-      {%- set ns = namespace(best_date='', best_method='') %}
-      {%- for source, entry in activity.items() %}
-        {%- if entry is mapping and entry.date and (entry.date | string) > ns.best_date %}
-          {%- set ns.best_date = entry.date | string %}
-          {%- set ns.best_method = source %}
-        {%- endif %}
-      {%- endfor %}
+      {%- set slug = file.page.file.src_path | replace('organisations/', '') | replace('.md', '') %}
+      {%- set ca = org_activity_cache.get(slug) %}
+      {%- set ca_date = (ca.date | string) if ca else '' %}
+      {%- set ca_method = ca.method if ca else '' %}
       <tr data-status="{{ file.page.meta.get('status', '') }}"
           data-country="{{ country }}"
           data-type="{{ org_type }}"
-          data-activity="{{ ns.best_date }}">
+          data-activity="{{ ca_date }}">
         <td>
           <a href="/{{ file.page.url }}">{{ file.page.title }}</a>
           {%- if website and not website.startswith('https://web.archive.org') %}
@@ -72,9 +68,9 @@
         <td data-sort="{{ org_type }}">{{ type_icons.get(org_type, '🏛️') }} {{ org_type }}</td>
         <td>{{ country }}</td>
         <td><span class="project-status-badge status-{{ file.page.meta.get('status', '') }}">{{ file.page.meta.get('status', '') }}</span></td>
-        <td data-sort="{{ ns.best_date }}">
-          {%- if ns.best_date %}
-          {{ ns.best_date }}<span class="activity-method-chip method-{{ ns.best_method }}">{{ ns.best_method }}</span>
+        <td data-sort="{{ ca_date }}">
+          {%- if ca_date %}
+          {{ ca_date }}<span class="activity-method-chip method-{{ ca_method }}">{{ ca_method }}</span>
           {%- else %}—{%- endif %}
         </td>
         <td>

--- a/hooks/activity_selector.py
+++ b/hooks/activity_selector.py
@@ -19,8 +19,16 @@ Selection logic:
   1. Walk sources in priority order: manual > dod > social > rss > ical > scrape > sitemap
   2. Use the first source whose date is within its staleness threshold
   3. If none qualify (all stale), fall back to the most recent across all sources
+
+The computed result is available two ways:
+  - page.meta.computed_activity  — set per-page in on_page_context (used by organisation.html)
+  - org_activity_cache Jinja2 global (keyed by slug) — pre-computed in on_pre_build and
+    injected in on_env so the organisations index template can use it before individual
+    org pages have been rendered.
 """
 
+import glob
+import os
 from datetime import date
 
 PRIORITY = ["manual", "dod", "social", "rss", "ical", "scrape", "sitemap"]
@@ -37,6 +45,12 @@ STALENESS_DAYS = {
     "sitemap": 180,   # weak signal (CMS can touch lastmod for any reason)
 }
 
+# Pre-computed cache populated by on_pre_build; slug → computed_activity dict.
+# Injected as a Jinja2 global (org_activity_cache) in on_env so the org index
+# template can use consistent selection logic even though it renders before
+# individual org pages (before on_page_context has run on those pages).
+_cache: dict = {}
+
 
 def _parse_date(val):
     if val is None:
@@ -49,14 +63,16 @@ def _parse_date(val):
         return None
 
 
-def on_page_context(context, page, config, nav):
-    activity = page.meta.get("activity")
+def select_activity(activity, today=None):
+    """Return a computed_activity dict for the given activity mapping, or None.
+
+    Exported so data_export.py and other utilities can share the same logic.
+    """
     if not activity or not isinstance(activity, dict):
-        return context
+        return None
+    if today is None:
+        today = date.today()
 
-    today = date.today()
-
-    # Walk in priority order, pick first fresh-enough source
     for source in PRIORITY:
         entry = activity.get(source)
         if not entry or not isinstance(entry, dict):
@@ -66,8 +82,7 @@ def on_page_context(context, page, config, nav):
             continue
         age = (today - d).days
         if age <= STALENESS_DAYS.get(source, 365):
-            page.meta["computed_activity"] = {**entry, "method": source, "age_days": age, "date": d}
-            return context
+            return {**entry, "method": source, "age_days": age, "date": d}
 
     # All sources stale — fall back to most recent
     best = None
@@ -81,7 +96,47 @@ def on_page_context(context, page, config, nav):
             best_date = d
             best = {**entry, "method": source, "age_days": (today - d).days, "date": d}
 
-    if best:
-        page.meta["computed_activity"] = best
+    return best
 
+
+def on_pre_build(config):
+    """Pre-compute activity selection for all org pages.
+
+    Populates _cache so on_env can inject it as a Jinja2 global before any
+    page templates render.  This is needed because the organisations index
+    page renders before individual org pages, so on_page_context hasn't run
+    on those pages yet when the index template executes.
+    """
+    try:
+        import frontmatter as _fm
+    except ImportError:
+        return
+
+    _cache.clear()
+    today = date.today()
+    orgs_dir = os.path.join(os.path.dirname(__file__), "..", "docs", "organisations")
+    for path in glob.glob(os.path.join(orgs_dir, "*.md")):
+        if os.path.basename(path) == "organisations.md":
+            continue
+        try:
+            post = _fm.load(path)
+        except Exception:
+            continue
+        slug = os.path.basename(path)[:-3]
+        ca = select_activity(post.metadata.get("activity"), today)
+        if ca:
+            _cache[slug] = ca
+
+
+def on_env(env, config, files):
+    """Inject pre-computed activity cache as a Jinja2 global."""
+    env.globals["org_activity_cache"] = _cache
+
+
+def on_page_context(context, page, config, nav):
+    """Set page.meta.computed_activity for individual org page rendering."""
+    activity = page.meta.get("activity")
+    ca = select_activity(activity)
+    if ca:
+        page.meta["computed_activity"] = ca
     return context

--- a/hooks/data_export.py
+++ b/hooks/data_export.py
@@ -17,7 +17,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
-from activity_selector import PRIORITY, STALENESS_DAYS, _parse_date
+from activity_selector import select_activity
 
 
 def _json_default(obj):
@@ -66,25 +66,11 @@ def load_orgs():
 
 
 def _best_activity(activity_dict):
-    """Return (date_str, method) of the best activity entry, mirroring activity_selector logic."""
-    today = datetime.date.today()
-    for source in PRIORITY:
-        entry = activity_dict.get(source)
-        if not entry:
-            continue
-        d = _parse_date(entry.get("date"))
-        if d and (today - d).days <= STALENESS_DAYS.get(source, 365):
-            return str(d), source
-    # fallback: most recent
-    best_date, best_source = None, None
-    for source in PRIORITY:
-        entry = activity_dict.get(source)
-        if not entry:
-            continue
-        d = _parse_date(entry.get("date"))
-        if d and (best_date is None or d > best_date):
-            best_date, best_source = d, source
-    return (str(best_date), best_source) if best_date else ("", "")
+    """Return (date_str, method) of the best activity entry."""
+    ca = select_activity(activity_dict)
+    if ca:
+        return str(ca["date"]), ca["method"]
+    return "", ""
 
 
 def write_orgs_csv(orgs):

--- a/util/check_rss.py
+++ b/util/check_rss.py
@@ -647,9 +647,10 @@ def main():
                 if is_sitemap_url(feed_url):
                     d = latest_sitemap_lastmod(feed_url, timeout=args.timeout, session=session)
                     if d:
-                        update_activity_source(org["path"], d.isoformat(),
-                                             "Page last modified (from sitemap)", feed_url,
-                                             method="sitemap")
+                        if not update_activity_source(org["path"], d.isoformat(),
+                                                      "Page last modified (from sitemap)", feed_url,
+                                                      method="sitemap"):
+                            write_checked_only(org["path"], "sitemap")
                         print(f"SITEMAP  {d}")
                         result["latest_date"] = d.isoformat()
                     else:
@@ -659,7 +660,8 @@ def main():
                     d, title, link, http_ok = latest_from_feed(feed_url, timeout=args.timeout, session=session)
                     if d:
                         note = f"Latest post: {title[:80]}" if title else "RSS feed active"
-                        update_activity_source(org["path"], d.isoformat(), note, feed_url, link or None)
+                        if not update_activity_source(org["path"], d.isoformat(), note, feed_url, link or None):
+                            write_checked_only(org["path"], "rss")
                         print(f"UPDATED  {d}  {title[:50]}")
                         result["latest_date"] = d.isoformat()
                         result["latest_title"] = title
@@ -711,7 +713,8 @@ def main():
                     print(f"NO_PAST_EVENTS  {ics_url}")
                 else:
                     note = f"Latest event: {title[:80]}" if title else "Latest calendar event"
-                    update_activity_source(org["path"], d.isoformat(), note, ics_url, method="ical")
+                    if not update_activity_source(org["path"], d.isoformat(), note, ics_url, method="ical"):
+                        write_checked_only(org["path"], "ical")
                     print(f"UPDATED  {d}  {title[:50] if title else '(no title)'}")
 
                 time.sleep(0.5)

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -850,6 +850,8 @@ def main():
             if not args.dry_run:
                 if update_activity_source(org["path"], d.isoformat(), note, url):
                     updated += 1
+                else:
+                    write_checked_only(org["path"], "scrape")
 
         if page_parser.feed_urls:
             resolved_feeds = [urljoin(url, f) for f in page_parser.feed_urls[:2]]


### PR DESCRIPTION
## Summary

Two reliability fixes for the activity tracking tooling, following PR #86.

### `checked:` not written when feed date hasn't advanced (`cdd9a8b`)

`update_activity_source` returns `False` (no-op) when the feed/scrape date hasn't changed since the last run. The call sites in `check_rss.py` and `scrape_news.py` weren't handling that case, so `checked:` was never written for orgs whose latest content stays the same between runs.

Without `checked:`, the 7-day skip guard never fires — those orgs get re-probed on every run rather than being skipped. Fixed by wrapping all `update_activity_source` calls with a `write_checked_only` fallback for RSS, sitemap, iCal, and scrape paths. Also backfills `checked:` on `australian-democrats.md` (the reported case).

### Org index table activity dates inconsistent with individual pages (`04797e7`)

The organisations index was using raw max-date comparison across all activity sources, while individual org pages used priority + staleness selection (`manual > dod > social > rss > ical > scrape > sitemap` with per-source staleness thresholds). This caused visible inconsistencies — e.g. the index would show a recent sitemap date while the page showed an older but higher-priority manual entry.

Root cause: the index template renders **before** `on_page_context` has run on individual org pages, so `computed_activity` is never available there when the index renders.

Fix:
- Extract selection logic into public `select_activity()` in `activity_selector.py`
- Add `on_pre_build` to pre-compute all org activities into a module-level cache
- Add `on_env` to inject the cache as the `org_activity_cache` Jinja2 global
- `organisations.html` now looks up `org_activity_cache[slug]` — same logic, same result as the individual page
- `data_export.py` drops its duplicate `_best_activity` logic and delegates to `select_activity()` instead

## Test plan

- [ ] Build the site and confirm no errors from the hook changes
- [ ] Check that an org with a high-priority manual entry shows the manual date (not sitemap) in both the index table and the individual page
- [ ] Run `check_rss.py --update-activity` on an org and confirm `checked:` is written even when the feed date hasn't changed

https://claude.ai/code/session_0197mLGTwq1hUanxPTq91qDq

---
_Generated by [Claude Code](https://claude.ai/code/session_0197mLGTwq1hUanxPTq91qDq)_