### PR TITLE
Document bot infrastructure and unify User-Agent strings

### DIFF
--- a/docs/bot.md
+++ b/docs/bot.md
@@ -1,0 +1,45 @@
+---
+title: DOD Bot
+---
+
+# DOD Bot
+
+**Designing Open Democracy** runs automated scripts to monitor the organisations listed in its [Democracy Landscape](/organisations/). This page describes what those scripts do, how often they run, and how to opt out.
+
+## What the bot does
+
+The bot performs read-only checks against publicly accessible URLs. It does not create accounts, submit forms, or interact with authenticated content.
+
+| Script | Purpose |
+|---|---|
+| `check_rss.py` | Probes for RSS/Atom feeds and sitemaps; records the latest post date to show activity status |
+| `scrape_news.py` | Reads news/blog index pages for orgs that lack a machine-readable feed; extracts dates from structured markup only (JSON-LD, OpenGraph, `<time>` tags) |
+| `check_urls.py` | Verifies that `website:` URLs in the landscape are still reachable |
+| `check_wikipedia.py` | Checks that Wikipedia links in org pages resolve correctly |
+
+## Frequency
+
+Scripts run as part of periodic maintenance passes — roughly monthly, not continuously. They are not high-frequency crawlers.
+
+## User-Agent string
+
+All requests identify as:
+
+```
+DOD-Bot/1.0 (+https://www.designingopendemocracy.com/bot/)
+```
+
+## Opting out
+
+If you would prefer your site not be checked, add the following to your `robots.txt`:
+
+```
+User-agent: DOD-Bot
+Disallow: /
+```
+
+All scripts respect `robots.txt`. Alternatively, [contact us](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io/issues) and we will remove your organisation from automated checks.
+
+## Source code
+
+The scripts are open source: [util/](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io/tree/main/util)

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -29,6 +29,31 @@ All requests identify as:
 DOD-Bot/1.0 (+https://www.designingopendemocracy.com/bot/)
 ```
 
+## Making your site bot-friendly
+
+The bot works best when your site publishes machine-readable signals. In priority order:
+
+**1. Publish an RSS or Atom feed**
+This is the most reliable signal. The bot probes [23 common feed paths](/util/check_rss.py) automatically — no configuration needed on your end if your CMS already generates one. WordPress, Ghost, Substack, and most modern platforms do this by default.
+
+**2. Add structured markup to your news/blog pages**
+If you don't have a feed, the bot falls back to scraping your news page. It reads dates only from machine-readable markup — not from visible text. Any of these work:
+
+- **JSON-LD** — `"datePublished"` or `"dateModified"` in a `<script type="application/ld+json">` block
+- **OpenGraph** — `<meta property="article:published_time">` or `article:modified_time`
+- **HTML time element** — `<time datetime="2026-05-01">` on article listings
+
+**3. Publish a sitemap**
+A `sitemap.xml` with `<lastmod>` dates is used as a last-resort activity signal when no feed or structured news page is available.
+
+**4. Explicitly allow the bot in robots.txt**
+If your site uses aggressive bot-blocking, add an explicit allow:
+
+```
+User-agent: DOD-Bot
+Allow: /
+```
+
 ## Opting out
 
 If you would prefer your site not be checked, add the following to your `robots.txt`:

--- a/docs/projects/democracy-landscape.md
+++ b/docs/projects/democracy-landscape.md
@@ -1,0 +1,52 @@
+---
+title: Democracy Landscape Maintenance
+template: project.html
+status: active
+summary: "Internal tooling and processes for keeping the Democracy Landscape directory accurate, active, and machine-readable."
+contributors:
+  - BrianKhuu
+concepts: [democracy, e-government]
+---
+
+Internal project covering the technical infrastructure that keeps the [Democracy Landscape](/organisations/) directory healthy — activity tracking, data quality checks, and automated maintenance scripts.
+
+## Scope
+
+- **Activity tracking** — automated scripts probe org websites for RSS feeds, sitemaps, and structured news content to keep "last active" dates current
+- **Data quality** — URL reachability checks, Wikipedia link verification, frontmatter consistency
+- **Data exports** — CSV, JSON, GeoJSON, and KML snapshots generated at build time from org frontmatter
+- **Bot infrastructure** — unified crawler identity, robots.txt compliance, public [bot page](/bot/)
+
+## Tooling
+
+Utility scripts live under [`util/`](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io/tree/main/util):
+
+| Script | Purpose |
+|---|---|
+| `check_rss.py` | Probes for RSS/Atom feeds and sitemaps; writes latest post dates to frontmatter |
+| `scrape_news.py` | Scrapes news pages for orgs without feeds (opt-in via `news_page:` frontmatter) |
+| `check_urls.py` | Verifies org website URLs are still reachable |
+| `check_wikipedia.py` | Checks Wikipedia links in org pages resolve correctly |
+
+All scripts identify as `DOD-Bot/1.0` — see the [bot page](/bot/) for details.
+
+## Recurring tasks
+
+Run these periodically (roughly monthly) during maintenance passes:
+
+```bash
+python util/check_rss.py --update-activity   # update activity dates from feeds
+python util/scrape_news.py                   # update activity dates from news pages
+python util/check_urls.py                    # verify org URLs still resolve
+```
+
+## Future ideas
+
+- Aggregated iCal feed from orgs that publish calendar feeds
+- Outreach to orgs to encourage RSS/iCal feed adoption
+
+## See also
+
+- [Democracy Landscape](/organisations/)
+- [Bot page](/bot/)
+- [HEARTBEAT.md](https://github.com/DesigningOpenDemocracy/DesigningOpenDemocracy.github.io/blob/main/HEARTBEAT.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ hooks:
 
 not_in_nav: |
   llms.txt
+  bot.md
 
 extra_javascript:
   - https://unpkg.com/leaflet@1.9.4/dist/leaflet.js

--- a/util/check_rss.py
+++ b/util/check_rss.py
@@ -42,6 +42,8 @@ except ImportError:
     print("Missing dependency: pip install requests")
     sys.exit(1)
 
+DOD_USER_AGENT = "DOD-Bot/1.0 (+https://www.designingopendemocracy.com/bot/)"
+
 DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
 ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
 SKIP_FILES = {"organisations.md"}
@@ -125,7 +127,7 @@ def probe_sitemap(base_url, timeout=8, session=None):
     """
     if session is None:
         session = requests.Session()
-        session.headers["User-Agent"] = "DOD-RSS-Probe/1.0 (democracy wiki feed discovery)"
+        session.headers["User-Agent"] = DOD_USER_AGENT
 
     parsed = urlparse(base_url)
     root = f"{parsed.scheme}://{parsed.netloc}"
@@ -166,7 +168,7 @@ def probe_feeds(base_url, timeout=8, session=None):
     """Return the first feed URL found (RSS/Atom/sitemap), or None."""
     if session is None:
         session = requests.Session()
-    session.headers.update({"User-Agent": "DOD-RSS-Probe/1.0 (democracy wiki feed discovery)"})
+    session.headers.update({"User-Agent": DOD_USER_AGENT})
 
     parsed = urlparse(base_url)
     root = f"{parsed.scheme}://{parsed.netloc}"
@@ -188,7 +190,7 @@ def latest_sitemap_lastmod(sitemap_url, timeout=10, session=None):
     """Return the most recent <lastmod> date from a sitemap, or None."""
     if session is None:
         session = requests.Session()
-        session.headers["User-Agent"] = "DOD-RSS-Reader/1.0 (democracy wiki)"
+        session.headers["User-Agent"] = DOD_USER_AGENT
     try:
         r = session.get(sitemap_url, timeout=timeout)
         r.raise_for_status()
@@ -251,7 +253,7 @@ def latest_from_feed(url, timeout=10, session=None):
     """
     if session is None:
         session = requests.Session()
-        session.headers["User-Agent"] = "DOD-RSS-Reader/1.0 (democracy wiki)"
+        session.headers["User-Agent"] = DOD_USER_AGENT
     try:
         r = session.get(url, timeout=timeout)
         r.raise_for_status()
@@ -542,7 +544,7 @@ def main():
         sys.exit(0)
 
     session = requests.Session()
-    session.headers.update({"User-Agent": "DOD-RSS-Probe/1.0 (democracy wiki feed discovery)"})
+    session.headers.update({"User-Agent": DOD_USER_AGENT})
 
     results = []
     found = []

--- a/util/check_urls.py
+++ b/util/check_urls.py
@@ -46,10 +46,7 @@ WAYBACK_PREFIX = "https://web.archive.org"
 TODAY = date.today()
 
 HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (compatible; DOD-wiki-checker/1.0; "
-        "+https://designingopendemocracy.github.io)"
-    )
+    "User-Agent": "DOD-Bot/1.0 (+https://www.designingopendemocracy.com/bot/)"
 }
 
 

--- a/util/check_wikipedia.py
+++ b/util/check_wikipedia.py
@@ -47,7 +47,7 @@ CANDIDATES = [
 ]
 
 API_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary/"
-HEADERS = {"User-Agent": "DOD-wiki-checker/1.0 (https://designingopendemocracy.com)"}
+HEADERS = {"User-Agent": "DOD-Bot/1.0 (+https://www.designingopendemocracy.com/bot/)"}
 
 
 def check(title):

--- a/util/scrape_news.py
+++ b/util/scrape_news.py
@@ -55,7 +55,7 @@ ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
 SKIP_FILES = {"organisations.md"}
 WAYBACK_PREFIX = "https://web.archive.org"
 TODAY = datetime.today().strftime("%Y-%m-%d")
-USER_AGENT = "DOD-NewsScraper/1.0 (DesigningOpenDemocracy activity monitor)"
+USER_AGENT = "DOD-Bot/1.0 (+https://www.designingopendemocracy.com/bot/)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds public documentation for the DOD Bot automation infrastructure and standardizes the User-Agent string across all utility scripts to a single, consistent identity.

## Changes

- **New documentation**
  - `docs/bot.md` — Public-facing bot page explaining what automated scripts do, how often they run, opt-out instructions, and guidance for making sites bot-friendly (RSS feeds, structured markup, sitemaps, robots.txt)
  - `docs/projects/democracy-landscape.md` — Internal project page documenting the Democracy Landscape maintenance tooling, recurring tasks, and future ideas

- **Unified User-Agent string**
  - All utility scripts now identify as `DOD-Bot/1.0 (+https://www.designingopendemocracy.com/bot/)` instead of ad-hoc variants
  - `check_rss.py`: Defined `DOD_USER_AGENT` constant and updated all four functions that set headers
  - `check_urls.py`: Replaced Mozilla-style user agent with standard bot identity
  - `check_wikipedia.py`: Updated Wikipedia API headers to match
  - `scrape_news.py`: Standardized news scraper user agent

- **Site configuration**
  - Added `bot.md` to `not_in_nav` in `mkdocs.yml` (page exists but not in sidebar navigation)

## Implementation notes

The User-Agent unification makes the bot's identity transparent and consistent across all probes. The public bot page provides transparency about what the scripts do and how to opt out, supporting the project's philosophy of open governance and good-faith engagement with monitored organisations.

https://claude.ai/code/session_014YZdU3TohH2zqw4EsQ1qJT