### PR TITLE
Add MieuxVoter, DEMOCRACY Deutschland, and Democracy Apps & Tools index

### DIFF
--- a/docs/concepts/democracy-tools.md
+++ b/docs/concepts/democracy-tools.md
@@ -1,0 +1,57 @@
+---
+title: Democracy Apps & Tools
+summary: A curated list of apps and web platforms for democratic participation, collective decision-making, and civic engagement — from mobile voting apps to city-scale deliberation platforms.
+---
+
+# Democracy Apps & Tools
+
+Most democracy tooling lives on the web. Native mobile apps are rare — the ones that exist tend to serve specific, offline-friendly use cases. This page maps the landscape of what's usable, pointing to organisation pages for the full story on each tool.
+
+---
+
+## Mobile apps
+
+Tools with a native Android or iOS app you can install and use offline or on the go.
+
+| Tool | What it does | Open source |
+|---|---|---|
+| [Urn](../organisations/mieuxvoter.md) | Pass-the-phone offline voting using Majority Judgment — works for a friend group picking a restaurant just as well as a formal meeting. F-Droid: `com.illiouchine.jm` | Yes (GPL-3.0) |
+| [DEMOCRACY Deutschland](../organisations/democracy-deutschland.md) | Shadow-vote on live Bundestag procedures; compare your choices with how your actual representatives voted. F-Droid: `de.democracydeutschland.app` | Yes (Apache 2.0) |
+
+---
+
+## Deliberation & participation platforms
+
+Web platforms (responsive, no native app) used by governments, cities, and communities for structured participation — proposals, comments, participatory budgeting, citizens' assemblies.
+
+| Tool | Made by | What it does |
+|---|---|---|
+| [Decidim](../organisations/decidim.md) | Decidim Association | Full-featured participatory democracy platform; used by Barcelona, Helsinki, and hundreds of cities |
+| [Consul](../organisations/consul-democracy.md) | Madrid City Council (open source) | Citizen proposals, debates, and participatory budgeting; deployed in 250+ cities |
+| [Loomio](../organisations/loomio.md) | Loomio Co-op | Structured proposals and consent-based decisions for groups and organisations |
+| [Your Priorities](../organisations/citizens-foundation.md) | Citizens Foundation (Iceland) | Policy idea generation and deliberation; used in 45+ countries |
+| [Pol.is](../organisations/polis.md) | Computational Democracy Project | Opinion mapping — surfaces areas of consensus across large groups |
+| [Kialo](../organisations/kialo.md) | Kialo | Structured pro/con argument trees for complex decisions |
+| [adhocracy+](../organisations/liquid-democracy-ev.md) | Liquid Democracy e.V. | Participatory proposal and comment platform for municipalities and organisations |
+
+---
+
+## Voting & decision tools
+
+Web tools focused on the mechanics of reaching a group decision — alternative voting methods, multi-criteria ranking, or prediction-based deliberation.
+
+| Tool | Made by | What it does |
+|---|---|---|
+| [MieuxVoter web app](../organisations/mieuxvoter.md) | MieuxVoter | Browser-based polls using Majority Judgment; also provides embeddable libraries for developers |
+| [Ethelo](../organisations/ethelo.md) | Ethelo Decisions | Multi-criteria group decisions with analytics; used for participatory budgeting and policy design |
+| [Prediki](../organisations/prediki.md) | Prediki | Prediction markets applied to policy and organisational decisions |
+
+---
+
+## See also
+
+- [Majority Judgment](majority-judgment.md) — the voting method behind the Urn app and MieuxVoter
+- [E-Government](e-government.md)
+- [Deliberative Democracy](deliberative-democracy.md)
+- [Participatory Budgeting](participatory-budgeting.md)
+- [Liquid Democracy](liquid-democracy.md)

--- a/docs/organisations/democracy-deutschland.md
+++ b/docs/organisations/democracy-deutschland.md
@@ -1,0 +1,50 @@
+---
+title: DEMOCRACY Deutschland
+type: civil-society
+status: active
+country: DE
+website: https://democracy-app.de
+summary: "A German volunteer-run nonprofit that brings the Bundestag to citizens' smartphones — users can vote on live parliamentary procedures and compare their choices with how their actual representatives voted."
+concepts:
+  - e-government
+  - representative-democracy
+location:
+  latitude: 52.5200
+  longitude: 13.4050
+  name: Germany
+activity:
+  manual:
+    date: 2026-03-15
+    note: "Latest commit: update GitHub Actions to Node.js 24-compatible versions"
+    url: https://github.com/demokratie-live/democracy-client/commits/main
+    checked: 2026-06-08
+  rss:
+    note: "No feed found"
+    checked: 2026-06-08
+---
+
+DEMOCRACY Deutschland e.V. is a German nonprofit building open-source civic technology to close the gap between parliamentary decisions and the citizens affected by them. Their flagship product is the **DEMOCRACY app**, available on Android (including [F-Droid](https://f-droid.org/en/packages/de.democracydeutschland.app/)), iOS, and as a web interface.
+
+The app tracks every procedure coming to a vote in the German Bundestag. Citizens can cast their own shadow vote on each item before the session, then see how their chosen parties and individual representatives actually voted. The comparison is the point: it makes the distance between a citizen's preferences and their representatives' choices concrete and visible.
+
+Key features:
+
+- **Live Bundestag tracking** — procedures listed by upcoming session week
+- **Shadow voting** — cast a personal vote before the official result is known
+- **Party and MP alignment** — compare your voting record against parties and named representatives
+- **Community results** — see the aggregate shadow vote from all app users
+- **Parliamentary notifications** — alerts when a tracked vote goes live
+
+The codebase (TypeScript / React Native / Expo) is open source under Apache 2.0 at [github.com/demokratie-live](https://github.com/demokratie-live). The app has an F-Droid anti-feature flag for a hard-coded API endpoint (`api.democracy-app.de`), which is worth noting for self-hosting but does not affect typical use.
+
+## Links
+
+- Website: [democracy-app.de](https://democracy-app.de)
+- F-Droid: [f-droid.org/packages/de.democracydeutschland.app](https://f-droid.org/en/packages/de.democracydeutschland.app/)
+- GitHub: [github.com/demokratie-live](https://github.com/demokratie-live)
+
+## See also
+
+- [E-Government](../concepts/e-government.md)
+- [Representative Democracy](../concepts/representative-democracy.md)
+- [Democracy Apps & Tools](../concepts/democracy-tools.md)

--- a/docs/organisations/mieuxvoter.md
+++ b/docs/organisations/mieuxvoter.md
@@ -50,4 +50,5 @@ MieuxVoter runs citizen experiments, supports campaigns for local adoption of Ma
 
 - [Majority Judgment](../concepts/majority-judgment.md)
 - [E-Government](../concepts/e-government.md)
+- [Democracy Apps & Tools](../concepts/democracy-tools.md)
 - [Démocratie Ouverte](democratie-ouverte.md)


### PR DESCRIPTION
## Summary

Discovered via F-Droid package `com.illiouchine.jm` (the Urn app), which led to MieuxVoter and then a broader look at the democracy app/tool landscape.

- **MieuxVoter** (`docs/organisations/mieuxvoter.md`) — French association promoting Majority Judgment voting; open-source ecosystem including the Urn offline pass-the-phone voting app (F-Droid), web platform, Discord bot, and multi-language libraries
- **DEMOCRACY Deutschland** (`docs/organisations/democracy-deutschland.md`) — German nonprofit whose app lets citizens shadow-vote on live Bundestag procedures and compare with how their actual representatives voted (F-Droid: `de.democracydeutschland.app`, active March 2026)
- **Majority Judgment** (`docs/concepts/majority-judgment.md`) — new concept page for the Balinski & Laraki voting method; gives MieuxVoter and similar orgs a proper concept tag
- **Democracy Apps & Tools** (`docs/concepts/democracy-tools.md`) — curated index of mobile apps and web platforms across the landscape, split into: mobile apps, deliberation & participation platforms, voting & decision tools

## Test plan

- [ ] Check MieuxVoter org page renders correctly with `majority-judgment` concept chip
- [ ] Check DEMOCRACY Deutschland appears on the map (Berlin coordinates)
- [ ] Check Democracy Apps & Tools page is reachable under Concepts nav
- [ ] Check Majority Judgment concept page links correctly to MieuxVoter

https://claude.ai/code/session_01Bs1Ks6wVpYQi5UMf8CHEeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs1Ks6wVpYQi5UMf8CHEeT)_