### PR TITLE
Emoji flags in org table; expose RSS/iCal/news links on org pages

### DIFF
--- a/docs/overrides/organisation.html
+++ b/docs/overrides/organisation.html
@@ -42,6 +42,24 @@
         </td>
       </tr>
       {%- endif %}
+      {%- if page.meta.rss_feed %}
+      <tr>
+        <th>RSS feed</th>
+        <td><a href="{{ page.meta.rss_feed }}">{{ page.meta.rss_feed | replace('https://', '') | replace('http://', '') }}</a></td>
+      </tr>
+      {%- endif %}
+      {%- if page.meta.ics_feed %}
+      <tr>
+        <th>Calendar feed</th>
+        <td><a href="{{ page.meta.ics_feed }}">{{ page.meta.ics_feed | replace('https://', '') | replace('http://', '') }}</a></td>
+      </tr>
+      {%- endif %}
+      {%- if page.meta.news_page %}
+      <tr>
+        <th>News page</th>
+        <td><a href="{{ page.meta.news_page }}">{{ page.meta.news_page | replace('https://', '') | replace('http://', '') }}</a></td>
+      </tr>
+      {%- endif %}
       {%- if page.meta.concepts %}
       <tr>
         <th>Concepts</th>

--- a/docs/overrides/organisations.html
+++ b/docs/overrides/organisations.html
@@ -66,7 +66,7 @@
           {%- endif %}
         </td>
         <td data-sort="{{ org_type }}">{{ type_icons.get(org_type, '🏛️') }} {{ org_type }}</td>
-        <td>{{ country }}</td>
+        <td data-sort="{{ country }}">{{ country }}</td>
         <td><span class="project-status-badge status-{{ file.page.meta.get('status', '') }}">{{ file.page.meta.get('status', '') }}</span></td>
         <td data-sort="{{ ca_date }}">
           {%- if ca_date %}
@@ -94,6 +94,13 @@
 </div>
 <script>
 (function () {
+  function toFlag(code) {
+    if (!code || code.length !== 2) return code;
+    var base = 0x1F1E6 - 65;
+    return String.fromCodePoint(code.toUpperCase().charCodeAt(0) + base) +
+           String.fromCodePoint(code.toUpperCase().charCodeAt(1) + base);
+  }
+
   var table        = document.getElementById('org-table');
   var tbody        = table.querySelector('tbody');
   var headers      = Array.from(table.querySelectorAll('th.sortable'));
@@ -119,8 +126,16 @@
   var countries = [...new Set(rows().map(function(r){ return r.dataset.country; }).filter(Boolean))].sort();
   countries.forEach(function(c) {
     var opt = document.createElement('option');
-    opt.value = c; opt.textContent = c;
+    opt.value = c; opt.textContent = toFlag(c) + ' ' + c;
     countrySelect.appendChild(opt);
+  });
+
+  // Replace country code text with emoji flag + code in table cells
+  rows().forEach(function(r) {
+    var code = r.dataset.country;
+    if (code && code.length === 2) {
+      r.cells[2].textContent = toFlag(code) + ' ' + code;
+    }
   });
 
   function daysSince(dateStr) {


### PR DESCRIPTION
## Summary

- **Emoji flags in the org index table** — ISO country codes (`FR`, `DE`, `AU`…) are converted to emoji flags (🇫🇷, 🇩🇪, 🇦🇺…) in the table cells and country dropdown. Uses Unicode regional indicator arithmetic in JS — no lookup table. `data-sort` preserves alphabetical sort by code.

- **Feed and news links on org pages** — the org metadata box now exposes three optional rows when set in frontmatter: `rss_feed`, `ics_feed` (calendar feed), and `news_page`. Useful for readers who want to subscribe or follow an org directly.

## Test plan

- [ ] Org index table shows emoji flags in Country column and dropdown
- [ ] Sorting by Country still works alphabetically
- [ ] An org with `rss_feed:` set shows an RSS feed row in the metadata box
- [ ] An org with `ics_feed:` set shows a Calendar feed row
- [ ] An org with `news_page:` set shows a News page row
- [ ] Orgs without those fields show no extra rows

https://claude.ai/code/session_01Bs1Ks6wVpYQi5UMf8CHEeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs1Ks6wVpYQi5UMf8CHEeT)_