### PR TITLE
Add idea-stage project status + 3 new project proposals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ The invariants recorded there are not immutable. Any document in this repo — i
 ### Project pages (`docs/projects/`)
 
 - Use `template: project.html` in frontmatter — renders a metadata box (status, contributors, website)
-- `status` values: `active` | `mothballed` | `cancelled`
+- `status` values: `active` | `idea` | `mothballed` | `cancelled`
 - `status: active` pages appear in the front page projects section automatically
+- `status: idea` is for ideation-stage proposals with no committed owner — written up with pros/cons and open questions so anyone can adopt one. To activate an idea, change `status` to `active` and add yourself under `contributors`.
 - All projects (any status) appear grouped on the `/projects/` index page
 
 ### Organisation pages (`docs/organisations/`)

--- a/docs/assets/css/customizations.css
+++ b/docs/assets/css/customizations.css
@@ -26,6 +26,7 @@
 }
 
 .project-status-badge.status-active       { background: #e6f4ea; color: #2e7d32; }
+.project-status-badge.status-idea         { background: #e3f2fd; color: #1565c0; }
 .project-status-badge.status-mothballed   { background: #fff3e0; color: #e65100; }
 .project-status-badge.status-cancelled    { background: #f5f5f5; color: #757575; }
 .project-status-badge.status-inactive     { background: #fff3e0; color: #e65100; }

--- a/docs/overrides/projects.html
+++ b/docs/overrides/projects.html
@@ -4,6 +4,7 @@
 <div class="md-typeset">
 {% set status_groups = [
   ('active',     'Active'),
+  ('idea',       'Idea — Seeking an Owner'),
   ('mothballed', 'Mothballed'),
   ('cancelled',  'Cancelled')
 ] %}

--- a/docs/projects/federated-voting-guide.md
+++ b/docs/projects/federated-voting-guide.md
@@ -1,0 +1,53 @@
+---
+title: Federated Voting Guide
+template: project.html
+status: idea
+summary: "A 'tick who you trust' voting guide aggregator: voters select orgs, parties, and commentators they already trust, and the tool displays those sources' stated positions side-by-side per race or policy — without DOD ranking anyone itself."
+concepts: [liquid-democracy, democracy-tools, e-government]
+---
+
+An idea raised in DOD discussion: rather than building another voting advice application (VAA) that computes its own "match score," build an aggregator where **the voter picks which sources to trust**, and the tool simply displays what each of those sources has said about candidates, parties, and policies for an upcoming election — side by side, unranked.
+
+## How it could work
+
+1. Sources (parties, advocacy orgs, commentators, fact-checkers) publish their positions or endorsements in a structured feed
+2. A voter ticks the sources they already trust from a directory
+3. For the voter's electorate, the tool shows: "Source A says X about Candidate 1 on housing. Source B says Y."
+4. DOD provides the plumbing and the directory of available feeds — never an opinion on who's right
+
+This is structurally similar to how this wiki already aggregates organisation activity from RSS/sitemap feeds (`util/check_rss.py`, `hooks/activity_selector.py`) — applied to "stated positions" instead of "latest news."
+
+## Pros
+
+- DOD never rates or ranks political actors — it's pure aggregation based on the voter's own choices
+- Decentralised and federated: any org can publish a feed and be added to the directory, no central editorial bottleneck
+- Builds on infrastructure this wiki already has (RSS aggregation, structured data exports)
+- Complements rather than competes with existing single-org VAAs like [Build a Ballot](../organisations/build-a-ballot.md) — those could simply be one of the feeds a voter ticks
+
+## Cons / risks
+
+- **Feed bootstrapping problem**: almost no orgs currently publish per-candidate/per-policy positions in a structured format — there's no standard to point them at yet
+- **Menu curation**: even "which feeds are available to tick" is an editorial choice, though far lower-stakes than DOD ranking candidates directly
+- **Cold start for voters**: a first-time user doesn't know which sources to tick either — the tool needs a neutral way to help people discover sources without nudging them
+- **Echo chamber risk**: if people only tick sources they already agree with, the tool may reinforce existing views rather than broaden perspective — true of most information tools, but worth designing against (e.g. optionally surfacing a source the voter hasn't ticked, for contrast)
+
+## Open questions & potential evolution
+
+- Define a minimal feed schema for "positions on candidates/policies" — possibly building on schema.org's `Endorsement`/`Review` types or a simple RSS/JSON extension
+- Start small: hand-curate a handful of feeds from orgs already in the [organisations index](../organisations/organisations.md) that publish election-relevant content, as a proof of concept
+- Could connect to the [Political Creator Map](political-creator-map.md) idea — self-declared creator affiliations as one feed type
+- Could connect to the [Promise Ledger](promise-ledger.md) idea — past-term voting records as a "feed" alongside pre-election promises
+- Likely starts life as a concept page defining the feed format and listing candidate sources, well before any UI is built
+
+## Status
+
+This is an idea-stage proposal with no committed owner. If you want to develop it — even just drafting the feed schema as a concept page — raise it in the [DOD community channels](../community/community.md), then update this page's `status` to `active` and add yourself under `contributors`.
+
+## See also
+
+- [Liquid Democracy](../concepts/liquid-democracy.md)
+- [Democracy Apps & Tools](../concepts/democracy-tools.md)
+- [E-Government](../concepts/e-government.md)
+- [Build a Ballot](../organisations/build-a-ballot.md)
+- [Political Creator Map](political-creator-map.md)
+- [Promise Ledger](promise-ledger.md)

--- a/docs/projects/political-creator-map.md
+++ b/docs/projects/political-creator-map.md
@@ -1,0 +1,46 @@
+---
+title: Political Creator Map
+template: project.html
+status: idea
+summary: "A self-declared map of podcasts, YouTube channels, and independent commentators showing their stated political/party affiliations — helping audiences read the independent media landscape, without DOD assigning labels itself."
+concepts: [tribal-epistemology, isegoria, radical-transparency]
+---
+
+An idea raised in DOD discussion: build a map of podcasts, YouTube channels, newsletters, and other independent media creators showing which political parties, movements, or causes they've **declared themselves** aligned with — a "who's who" of the independent political media landscape, in their own words.
+
+## Why it could matter
+
+Many voters now get political information from independent creators rather than legacy outlets, but the affiliations and incentives behind those creators are often unclear. A map that surfaces "this commentator has publicly declared support for Party X" — sourced from the creator's own statements, not DOD's judgement — could improve media literacy without DOD adjudicating who is biased.
+
+## Pros
+
+- Adds transparency to an increasingly influential and under-mapped part of the political information ecosystem
+- Largely unaddressed gap: existing media-bias trackers (e.g. AllSides, Ad Fontes Media) focus on legacy outlets, not independent creators
+- Self-declared-only sourcing avoids DOD having to make contested calls about who is "really" aligned with whom
+- Could double as a directory for researchers and journalists studying the independent media landscape
+
+## Cons / risks
+
+- High ongoing maintenance: creators rebrand, change positions, go quiet, or dispute their listing
+- Even self-declared entries invite disputes — a creator may disavow a label while still being functionally aligned, or vice versa
+- Sits awkwardly against DOD's existing curation standard, which is built around *organisations working on governance systems*; individual commentators are a different category of subject entirely
+- Risk of DOD being perceived as a partisan media-bias arbiter, even with a strict self-declaration-only policy
+- Reputational/defamation exposure remains real if a quote is stripped of context or goes stale
+
+## Open questions & potential evolution
+
+- Scope strictly to **self-declaration** — sourced from a creator's own "About" page, stated endorsement, or declared party membership, never a DOD-assigned label
+- Could start life as a **concept page** (a discovery aid linking to existing third-party media-landscape trackers) rather than a DOD-built database
+- If it matures into structured data, it could plug into the [Federated Voting Guide](federated-voting-guide.md) idea as one type of "feed" — letting a voter tick "creators I trust" alongside orgs and parties
+- Worth discussing whether this is better run as an independent community project that DOD links to, rather than something DOD hosts and maintains directly
+
+## Status
+
+This is an idea-stage proposal with no committed owner. If you want to develop it — even just as a literature-review concept page on existing media-landscape trackers — raise it in the [DOD community channels](../community/community.md), then update this page's `status` to `active` and add yourself under `contributors`.
+
+## See also
+
+- [Tribal Epistemology](../concepts/tribal-epistemology.md)
+- [Isegoria](../concepts/isegoria.md)
+- [Radical Transparency](../concepts/radical-transparency.md)
+- [Federated Voting Guide](federated-voting-guide.md)

--- a/docs/projects/promise-ledger.md
+++ b/docs/projects/promise-ledger.md
@@ -1,0 +1,57 @@
+---
+title: Promise Ledger
+template: project.html
+status: idea
+summary: "A federated record of election promises versus subsequent votes and actions in office — closing the accountability loop on the other side of an election, by aggregating existing open parliamentary and civic data rather than DOD doing its own fact-checking."
+concepts: [accountability-sink, radical-transparency, e-government, representative-democracy]
+---
+
+A complementary idea to the [Federated Voting Guide](federated-voting-guide.md): if that tool helps voters decide *before* an election, this one helps them check *after* — did the people and parties anyone voted for actually do what they said they would?
+
+## The idea
+
+Track election promises (from manifestos, campaign speeches, press releases) against what representatives subsequently voted for or delivered in office — in the spirit of projects like the ABC's "Promise Tracker" or PolitiFact's "Obameter," but built as an **aggregator over existing open data** rather than a new DOD fact-checking operation.
+
+Possible sources:
+
+- Parliamentary voting records (e.g. Hansard, or open data from civic tech groups such as [Democracy Club](../organisations/democracy-club.md))
+- Manifestos and policy platforms published by parties themselves
+- Existing fact-checking and promise-tracking projects, aggregated rather than duplicated
+
+## Why it could matter
+
+Voting-advice tools — including the [Federated Voting Guide](federated-voting-guide.md) idea — only cover half the loop. Informed voting also depends on being able to look back and see whether promises translated into action. Without that feedback, election promises carry little cost when broken, which is itself a structural [accountability sink](../concepts/accountability-sink.md).
+
+## Pros
+
+- Closes the loop with the Federated Voting Guide idea — past performance becomes one more "feed" a voter can tick
+- Builds on existing open parliamentary data rather than requiring DOD to do original fact-checking
+- Strengthens the case for [radical transparency](../concepts/radical-transparency.md) in legislatures that don't yet publish machine-readable voting records
+- Can be genuinely nonpartisan if scoped to "promise vs. recorded vote/action" — a mechanical comparison, not DOD's opinion on whether the promise was good policy
+
+## Cons / risks
+
+- Matching "promise" text to "voting record" is hard to automate reliably — premature automation could misrepresent a representative's actual position
+- Even a "neutral" promise-tracker can read as a scorecard in practice if, say, one party is shown breaking more promises than another — framing needs care
+- Coverage will be very uneven across countries — some legislatures publish rich open data (UK, EU), many publish almost nothing
+- Risk of becoming a large ongoing maintenance commitment if not scoped tightly to "aggregate existing trackers" rather than "build a new one from scratch"
+
+## Open questions & potential evolution
+
+- Start narrow: pick one jurisdiction with good open data (e.g. UK, via Democracy Club-style sources) as a proof of concept
+- Could begin as a **links/aggregation concept page** — pointing to existing promise-trackers and open parliamentary data sources — before any DOD-built matching logic exists
+- Long-term, could feed the [Federated Voting Guide](federated-voting-guide.md) as a "voting record" feed type
+- Worth checking for overlap with the existing [Civics Ecosystem Toolkit](civics-ecosystem-toolkit.md) and [ElectionDates.org](electiondates.org.md) projects' data work
+
+## Status
+
+This is an idea-stage proposal with no committed owner. If you want to develop it — even just a concept page surveying existing promise-trackers and open parliamentary data sources — raise it in the [DOD community channels](../community/community.md), then update this page's `status` to `active` and add yourself under `contributors`.
+
+## See also
+
+- [Accountability Sink](../concepts/accountability-sink.md)
+- [Radical Transparency](../concepts/radical-transparency.md)
+- [E-Government](../concepts/e-government.md)
+- [Representative Democracy](../concepts/representative-democracy.md)
+- [Democracy Club](../organisations/democracy-club.md)
+- [Federated Voting Guide](federated-voting-guide.md)


### PR DESCRIPTION
## Summary

Adds a new `status: idea` value for project pages — ideation-stage proposals with no committed owner, written up with pros/cons and open questions so anyone can adopt and "activate" them (by switching `status` to `active` and adding themselves as a contributor).

- `docs/overrides/projects.html` — new "Idea — Seeking an Owner" section on the `/projects/` index, between Active and Mothballed
- `docs/assets/css/customizations.css` — `.status-idea` badge (blue)
- `CLAUDE.md` — documents the new status value and activation convention

Also adds three idea-stage project pages drafted from community brainstorming, each cross-linked as a set:

- **[Political Creator Map](docs/projects/political-creator-map.md)** — a self-declared map of podcasts/creators and their political affiliations
- **[Federated Voting Guide](docs/projects/federated-voting-guide.md)** — a "tick who you trust" aggregator that shows ticked sources' stated positions per race/policy, without DOD ranking anyone
- **[Promise Ledger](docs/projects/promise-ledger.md)** — closes the loop post-election by aggregating existing open data on promises vs. voting records

`status: idea` pages are deliberately excluded from the home page / community grids (which filter on `status == 'active'`), so they're discoverable only via the `/projects/` index until someone picks them up.

## Test plan

- [x] Validated frontmatter YAML for all new pages
- [x] Validated all internal markdown links resolve to existing files
- [x] Validated Jinja2 syntax of `projects.html` template change
- [ ] `mkdocs build` (could not run locally — `mkdocs-ezlinks-plugin` failed to build in this sandbox; CI should verify)

https://claude.ai/code/session_01KDbbatku3BCKdPWfGoFAoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDbbatku3BCKdPWfGoFAoS)_