### PR TITLE
Add Heartbeat to main site nav

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
     - concepts/*.md
 - [Democracy Landscape](organisations/organisations.md)
     - organisations/*.md
+- [Heartbeat](/heartbeat/)
 - [Research](research/research.md)
     - research/*.md
 - [Knowledge Graph](knowledge-graph.md)


### PR DESCRIPTION
## Summary
- Follow-up to #103. `/heartbeat/` was reachable (via `/bot/` → "Our own automation") but not linked from the main nav, making it harder to find than intended.
- Adds `Heartbeat` as its own top-level nav tab in `docs/SUMMARY.md`, placed between "Democracy Landscape" and "Research" — discoverable, but deliberately not adjacent to "Blog" so it doesn't read as part of the human-written blog.

## Test plan
- [x] `mkdocs build --strict` passes with no warnings
- [x] Verified via local `mkdocs serve` + screenshot that "Heartbeat" renders as a top-level tab in the nav bar
- [x] Verified the tab links correctly to `/heartbeat/` (curl + rendered HTML check)
- [x] No changes to feed/blog separation from #103 — this is purely a nav-discoverability change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqDJ9GkJWjojYGezVRiVY7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqDJ9GkJWjojYGezVRiVY7)_