### PR TITLE
Separate human/AI activity evidence + two more heartbeat util tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,13 @@ The invariants recorded there are not immutable. Any document in this repo — i
       checked: 2026-05-01       # same as date for manual reviews
   ```
   - `method` keys: `manual` | `rss` | `ical` | `scrape` | `sitemap` | `dod` | `social`
+    - `manual` — a human personally visited the site via `review_orgs.py` (730-day staleness)
+    - `dod` — an AI/bot acting on DOD's behalf fetched or searched for evidence (365-day staleness); use this for heartbeat-run checks, not `manual`
+    - `social`/`rss`/`ical`/`scrape` — automated third-party signals (365-day staleness)
+    - `sitemap` — site-level lastmod, weakest signal (180-day staleness)
   - `checked:` — optional; the date the source was last probed, regardless of whether new content was found. Written automatically by `check_rss.py`, `scrape_news.py`, and `review_orgs.py`. Entries with no `date` but a `checked` date mean the source was probed but found nothing.
   - Selection logic: (1) pick the **most recent** date among content sources (`manual`, `dod`, `social`, `rss`, `ical`, `scrape`) that are within their staleness threshold; (2) if none qualify, fall back to `sitemap` within its threshold; (3) if all stale, show the most recent across everything
-  - Staleness thresholds: `manual`/`dod` 730 d · `social`/`rss`/`ical`/`scrape` 365 d · `sitemap` 180 d
+  - Staleness thresholds: `manual` 730 d · `dod`/`social`/`rss`/`ical`/`scrape` 365 d · `sitemap` 180 d
   - If all sources are stale, the most recent entry is shown regardless
   - `util/check_rss.py --update-activity` populates `rss`, `sitemap`, and `ical` entries automatically; re-runs skip orgs checked within 7 days (use `--force` to override)
   - `util/scrape_news.py` populates `scrape` entries for orgs with `news_page:` set; same skip behaviour

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -85,7 +85,9 @@ Pick the oldest 10–15 pages. For each:
 - Visit the org's website; confirm it loads and the org is still active
 - Check the summary and status are still accurate
 - Fix anything stale (summary, concepts, location, status)
-- Stamp: `python util/stamp.py <slug>`
+- Record the check: `python util/record_dod.py <slug> --note "..." [--url ...] [--date ...]`
+  (this writes `activity.dod` and stamps `last_checked` in one step; use `--date` when
+  you found evidence dated earlier than today, e.g. a publication date)
 
 If a page needs status changed (active → inactive), update `website:` to a
 Wayback URL per the CLAUDE.md convention.
@@ -211,7 +213,9 @@ draft, since the content now lives at its permanent post URL instead.
 ## Landscape update
 
 [2–3 sentences: current counts from stats.py, what was verified this run,
-any status changes or notable findings]
+any status changes or notable findings. Use
+`python util/check_orgs.py --since YYYY-MM-DD` (today's date) to get the
+title list of orgs verified this run for the paragraph.]
 
 ## In the world  ← omit entirely if nothing notable
 

--- a/docs/organisations/cdd-west-africa.md
+++ b/docs/organisations/cdd-west-africa.md
@@ -19,7 +19,7 @@ activity:
     date: 2026-06-05
     note: "Server still up (sitemap detected)"
     checked: 2026-06-07
-  manual:
+  dod:
     date: 2026-06-29
     note: "Website and blog confirmed active, with current election-analysis publications (Ekiti State 2026 Pre-Election Environment Analysis; Anambra 2025 Governorship Election report)."
     url: https://www.cddwestafrica.org/blog/

--- a/docs/organisations/cddgg.md
+++ b/docs/organisations/cddgg.md
@@ -16,7 +16,7 @@ activity:
   rss:
     note: "No feed found"
     checked: 2026-06-07
-  manual:
+  dod:
     date: 2026-06-29
     note: "Website confirmed active. Hans Asenbaum remains director; weekly seminar series running, Summer School and Journal of Deliberative Democracy ongoing."
     checked: 2026-06-29

--- a/docs/organisations/china-democratic-league.md
+++ b/docs/organisations/china-democratic-league.md
@@ -16,7 +16,7 @@ activity:
   rss:
     note: "No feed found"
     checked: 2026-06-07
-  manual:
+  dod:
     date: 2026-06-29
     note: "Direct fetch blocked (503) this run; web search confirms ongoing activity — Central Committee research on urban/rural land system reform and the continuing 'Serving the Public, Practicing for the People' education campaign."
     url: https://www.mmzy.org.cn/mmyw/default.aspx

--- a/docs/organisations/cideci-unitierra.md
+++ b/docs/organisations/cideci-unitierra.md
@@ -16,7 +16,7 @@ activity:
     date: 2024-05-21
     note: "Page last modified (from sitemap)"
     checked: 2026-06-07
-  manual:
+  dod:
     date: 2026-06-28
     note: "Web search confirms active programming: 'Seedbed Seminar — War Against Humanity' convened at CIDECI-UniTierra 20-24 July 2026 by the Zapatista Sixth Commission."
     checked: 2026-06-28

--- a/docs/organisations/conaie.md
+++ b/docs/organisations/conaie.md
@@ -16,7 +16,7 @@ activity:
     date: 2026-03-25
     note: "Page last modified (from sitemap)"
     checked: 2026-06-07
-  manual:
+  dod:
     date: 2026-06-28
     note: "Web search confirms continued activity: leadership change (Marlon Vargas elected president, July 2025) and ongoing protest/advocacy on extractivism and state repression through mid-2026."
     checked: 2026-06-28

--- a/docs/organisations/cppcc.md
+++ b/docs/organisations/cppcc.md
@@ -16,7 +16,7 @@ activity:
   rss:
     note: "No feed found"
     checked: 2026-06-07
-  manual:
+  dod:
     date: 2026-06-29
     note: "Direct fetch blocked (503) this run; web search confirms the 14th National Committee's annual session ran 4–11 March 2026 (2,078 of 2,125 members attended), consistent with continued operation."
     checked: 2026-06-29

--- a/docs/organisations/democracy-deutschland.md
+++ b/docs/organisations/democracy-deutschland.md
@@ -13,7 +13,7 @@ location:
   longitude: 13.4050
   name: Germany
 activity:
-  manual:
+  dod:
     date: 2026-03-15
     note: "Latest commit: update GitHub Actions to Node.js 24-compatible versions"
     url: https://github.com/demokratie-live/democracy-client/commits/main

--- a/docs/organisations/opora.md
+++ b/docs/organisations/opora.md
@@ -18,7 +18,7 @@ activity:
   rss:
     note: "No feed found"
     checked: 2026-06-07
-  manual:
+  dod:
     date: 2026-06-29
     note: "Website confirmed active, with recent reports on voter registration amid wartime migration and a January 2026 analysis of the challenges of holding a referendum on territorial changes."
     url: https://oporaua.org/en/announce

--- a/hooks/activity_selector.py
+++ b/hooks/activity_selector.py
@@ -42,7 +42,7 @@ SITE_SOURCES = ["sitemap"]
 # a lower-priority but fresher source.
 STALENESS_DAYS = {
     "manual":  730,   # human visit — strong, but visits are infrequent
-    "dod":     730,   # same confidence as manual
+    "dod":     365,   # AI/bot-driven check — less durable than a human visit
     "social":  365,   # social presence decays as a signal within a year
     "rss":     365,   # actual content publication
     "ical":    365,   # calendar events — reliable structured feed like rss

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -139,12 +139,13 @@ python util/scrape_news.py --update-rss      # also write discovered rss_feed:
 ### `review_orgs.py` — Interactive human review CLI
 
 Opens each org's website in a browser and prompts for a status
-confirmation, writing `activity.manual` (the highest-priority evidence
-source) and optionally updating `status:`. This is a **human-in-the-loop**
-tool — it expects an interactive terminal and a browser, so an AI agent
-without that can't drive it directly. For AI-assisted heartbeat runs, fetch
-the site directly (or web-search as a fallback) and write the
-`activity.manual` entry by hand instead; this script exists for a human
+confirmation, writing `activity.manual` (highest-priority, 730-day staleness)
+and optionally updating `status:`. This is a **human-in-the-loop** tool —
+it expects an interactive terminal and a browser, so an AI agent without
+that can't drive it directly. For AI-assisted heartbeat runs, fetch the site
+directly (or web-search as a fallback) and write an `activity.dod` entry
+instead — `dod` is reserved for bot/automated checks (365-day staleness,
+distinct from the human-visit `manual`). This script exists for a human
 doing the same kind of pass.
 
 ```bash

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -191,6 +191,28 @@ Slugs resolve against `docs/organisations/` first, then `docs/concepts/`. Runnin
 
 ---
 
+### `record_dod.py` — Record an activity.dod entry from the CLI
+
+Writes (or updates) `activity.dod` in org frontmatter and stamps
+`last_checked: today`. Use this during heartbeat AI runs instead of
+hand-editing YAML — keeps bot evidence under `dod` (365-day staleness)
+separate from human `review_orgs.py` entries under `manual` (730-day
+staleness). Handles all three cases: no existing activity block, activity
+block without `dod:`, and updating an existing `dod:` entry.
+
+```bash
+python util/record_dod.py cddgg --note "Website confirmed active, seminar series running"
+python util/record_dod.py cddgg darkenu --note "Confirmed active" --date 2026-06-29
+python util/record_dod.py cddgg --note "..." --url https://example.org/news
+python util/record_dod.py cddgg --note "..." --no-stamp   # skip last_checked update
+```
+
+`--date` is the date of the evidence found (e.g. a publication date);
+defaults to today. The `checked:` field always records today as the probe date.
+Multiple slugs take the same `--note` — run separately for different notes.
+
+---
+
 ### `stats.py` — Landscape snapshot
 
 Situational overview: org counts by status, geographic spread, type breakdown, `last_checked` freshness, and concept coverage. Run at the start of a session.
@@ -241,9 +263,12 @@ Who to re-verify next. Orders active orgs by: no `last_checked` date first, then
 python util/check_orgs.py              # active + inactive, 365-day threshold
 python util/check_orgs.py --days 180   # flag pages not checked in 6 months
 python util/check_orgs.py --active     # active orgs only
+python util/check_orgs.py --since 2026-06-29  # orgs checked on/after this date
 ```
 
-Run this to plan a maintenance pass — gives you a prioritised queue.
+Run without `--since` at the start of a maintenance pass to get a prioritised
+queue. Run with `--since today's date` after stamping orgs to get the title
+list for the heartbeat sync post's "Landscape update" paragraph.
 
 ---
 
@@ -366,7 +391,7 @@ python util/check_links.py --all       # all links
 
 ## Requirements
 
-`add_org.py`, `find.py`, and `stamp.py` use stdlib only. Most other scripts use `python-frontmatter`, `python-dateutil`, and `requests` — all in `util/requirements.txt`. `stats.py` and `heartbeat_post.py` need `python-frontmatter` only; `review_orgs.py` additionally needs `pyyaml`.
+`add_org.py`, `find.py`, and `stamp.py` use stdlib only. Most other scripts use `python-frontmatter`, `python-dateutil`, and `requests` — all in `util/requirements.txt`. `stats.py`, `heartbeat_post.py`, and `record_dod.py` need `python-frontmatter` only; `review_orgs.py` additionally needs `pyyaml`.
 
 ```bash
 pip install -r util/requirements.txt

--- a/util/check_orgs.py
+++ b/util/check_orgs.py
@@ -11,6 +11,10 @@ Usage:
     python util/check_orgs.py              # show all
     python util/check_orgs.py --days 180   # flag pages not checked in 180+ days
     python util/check_orgs.py --active     # active orgs only
+    python util/check_orgs.py --since 2026-06-29  # orgs checked on/after this date
+
+--since is useful for compiling the "verified this run" list for a heartbeat
+sync post: run it with today's date after stamping orgs to get the title list.
 
 Requirements: python-frontmatter (already in util/requirements.txt)
 """
@@ -90,10 +94,31 @@ def main():
                         help="Flag pages not checked within this many days (default: 365)")
     parser.add_argument("--active", action="store_true",
                         help="Show active orgs only")
+    parser.add_argument("--since", metavar="DATE",
+                        help="List orgs checked on/after DATE (YYYY-MM-DD); useful for "
+                             "compiling the heartbeat 'verified this run' list")
     args = parser.parse_args()
 
     orgs = load_orgs()
     today = date.today()
+
+    if args.since:
+        try:
+            since_date = date.fromisoformat(args.since)
+        except ValueError:
+            print(f"--since must be YYYY-MM-DD, got: {args.since}")
+            sys.exit(1)
+        recent = [
+            o for o in orgs
+            if o["last_checked"] is not None and o["last_checked"] >= since_date
+        ]
+        recent.sort(key=lambda o: (o["last_checked"], o["title"]), reverse=True)
+        print(f"\nOrgs checked since {args.since}  ({len(recent)} total)\n")
+        for o in recent:
+            lc = o["last_checked"]
+            print(f"  {o['title']:<45}  {lc}  {o['status']}")
+        print()
+        return
 
     active = [o for o in orgs if o["status"] == "active"]
     inactive = [o for o in orgs if o["status"] != "active"]

--- a/util/record_dod.py
+++ b/util/record_dod.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+record_dod.py — Record an activity.dod entry on one or more org pages
+
+Use during heartbeat AI runs to record that the bot verified an org.
+Writes (or updates) the activity.dod block in org frontmatter and stamps
+last_checked: today, using raw text substitution (same approach as stamp.py
+and review_orgs.py).
+
+This keeps bot evidence under the dod key (365-day staleness) separate from
+human review_orgs.py entries under the manual key (730-day staleness).
+See CLAUDE.md's activity: section for the full distinction.
+
+Usage:
+    python util/record_dod.py cddgg --note "Website confirmed active, seminar series running"
+    python util/record_dod.py cddgg darkenu --note "Confirmed active" --date 2026-06-29
+    python util/record_dod.py cddgg --note "..." --url https://example.org/news
+    python util/record_dod.py cddgg --note "..." --no-stamp   # skip last_checked update
+
+--date is the date of the evidence you found (e.g. a publication date); it
+defaults to today. The checked: field always records today as the probe date.
+
+Requirements: python-frontmatter (util/requirements.txt)
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import date
+
+try:
+    import frontmatter
+except ImportError:
+    print("Missing dependency: pip install python-frontmatter")
+    sys.exit(1)
+
+DOCS_DIR = os.path.join(os.path.dirname(__file__), "..", "docs")
+ORGS_DIR = os.path.join(DOCS_DIR, "organisations")
+TODAY = date.today().isoformat()
+
+LC_RE = re.compile(r'^(last_checked:\s*).*$', re.MULTILINE)
+
+
+def resolve_slug(slug):
+    p = os.path.join(ORGS_DIR, f"{slug}.md")
+    return p if os.path.isfile(p) else None
+
+
+def write_dod_activity(path, date_str, note, url=None, checked_str=None):
+    """Write or update activity.dod in org frontmatter using raw text edit."""
+    if checked_str is None:
+        checked_str = TODAY
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    parts = content.split("---", 2)
+    if len(parts) < 3 or parts[0] != "":
+        return False, "no frontmatter"
+    yaml_block, rest = parts[1], parts[2]
+
+    source_lines = [
+        "  dod:",
+        f"    date: {date_str}",
+        f"    note: {json.dumps(note, ensure_ascii=False)}",
+    ]
+    if url:
+        source_lines.append(f"    url: {url}")
+    source_lines.append(f"    checked: {checked_str}")
+
+    post = frontmatter.loads("---" + yaml_block + "---")
+    if post.metadata.get("activity"):
+        lines = yaml_block.split("\n")
+        new_lines = []
+        in_activity = False
+        in_this_source = False
+        inserted = False
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if re.match(r"^activity\s*:", line):
+                in_activity = True
+                new_lines.append(line)
+                i += 1
+                continue
+            if in_activity:
+                # Top-level key ends the activity block
+                if line and not line.startswith(" "):
+                    if not inserted:
+                        # dod: wasn't in the activity block — append before exit
+                        while new_lines and new_lines[-1] == "":
+                            new_lines.pop()
+                        new_lines.extend(source_lines)
+                        inserted = True
+                    in_activity = False
+                    in_this_source = False
+                    new_lines.append(line)
+                    i += 1
+                    continue
+                # Found the dod sub-block — replace it
+                if re.match(r"^  dod\s*:", line):
+                    in_this_source = True
+                    i += 1
+                    while i < len(lines) and lines[i].startswith("    "):
+                        i += 1
+                    new_lines.extend(source_lines)
+                    inserted = True
+                    continue
+                if in_this_source and re.match(r"^  \w", line):
+                    in_this_source = False
+            new_lines.append(line)
+            i += 1
+        # activity block ran to end of YAML without a closing top-level key
+        if in_activity and not inserted:
+            while new_lines and new_lines[-1] == "":
+                new_lines.pop()
+            new_lines.extend(source_lines)
+        yaml_block = "\n".join(new_lines)
+        if not yaml_block.endswith("\n"):
+            yaml_block += "\n"
+    else:
+        new_block = ["activity:"] + source_lines
+        yaml_block = yaml_block.rstrip("\n") + "\n" + "\n".join(new_block) + "\n"
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---" + yaml_block + "---" + rest)
+    return True, "ok"
+
+
+def stamp_last_checked(path, date_str):
+    """Update last_checked in-place (same logic as stamp.py)."""
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    match = LC_RE.search(content)
+    new_val = f'last_checked: "{date_str}"'
+    if match:
+        if date_str in match.group(0):
+            return False
+        new_content = content[:match.start()] + new_val + content[match.end():]
+    else:
+        lines = content.splitlines(keepends=True)
+        insert_at = None
+        for i, line in enumerate(lines[1:], 1):
+            if line.strip() == "---":
+                insert_at = i
+                break
+        if insert_at is None:
+            return False
+        lines.insert(insert_at, f"{new_val}\n")
+        new_content = "".join(lines)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Record an activity.dod entry on org pages")
+    parser.add_argument("slugs", nargs="+", help="Org slugs or file paths")
+    parser.add_argument("--note", required=True,
+                        help="Evidence note: what you found confirming the org is active")
+    parser.add_argument("--url", help="URL of the evidence page")
+    parser.add_argument("--date", dest="activity_date", default=TODAY,
+                        help=f"Date of the observed activity (default: today, {TODAY})")
+    parser.add_argument("--no-stamp", action="store_true",
+                        help="Skip updating last_checked")
+    args = parser.parse_args()
+
+    errors = 0
+    for slug in args.slugs:
+        if os.path.isfile(slug):
+            path = os.path.abspath(slug)
+        else:
+            path = resolve_slug(slug)
+        if path is None:
+            print(f"  ✗ Not found: {slug}")
+            errors += 1
+            continue
+        rel = os.path.relpath(path)
+        ok, msg = write_dod_activity(path, args.activity_date, args.note, url=args.url)
+        if not ok:
+            print(f"  ✗ {rel}: {msg}")
+            errors += 1
+            continue
+        print(f"  ✓ {rel}: activity.dod → date={args.activity_date}")
+        if not args.no_stamp:
+            stamp_last_checked(path, TODAY)
+
+    if errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/util/review_orgs.py
+++ b/util/review_orgs.py
@@ -44,7 +44,7 @@ WAYBACK_PREFIX = "https://web.archive.org"
 TODAY = date.today().isoformat()
 
 PRIORITY_ORDER = ["manual", "dod", "social", "rss", "ical", "scrape", "sitemap"]
-STALENESS_DAYS = {"manual": 730, "dod": 730, "social": 365, "rss": 365, "ical": 365, "scrape": 365, "sitemap": 180}
+STALENESS_DAYS = {"manual": 730, "dod": 365, "social": 365, "rss": 365, "ical": 365, "scrape": 365, "sitemap": 180}
 MANUAL_STALE_DAYS = 730
 
 
@@ -224,7 +224,7 @@ SOURCE_FILTERS = [
     ("scrape",  "Scrape stale or missing (>1 year)",    365),
     ("sitemap", "Sitemap stale or missing (>6 months)", 180),
     ("social",  "Social stale or missing (>1 year)",    365),
-    ("dod",     "DOD entry stale or missing (>2 years)",730),
+    ("dod",     "DOD/AI entry stale or missing (>1 year)", 365),
 ]
 
 


### PR DESCRIPTION
## Summary

Three improvements to the heartbeat maintenance workflow, surfaced by the last run.

### 1. Separate `manual` (human) from `dod` (AI/bot) activity evidence

Activates the `dod` activity method that was always wired into the schema and hooks but never actually used — its 8 definitively AI-written entries across 65 org `manual:` entries get reclassified, the staleness threshold is corrected, and the docs now clearly direct AI heartbeat runs to write `dod` instead of `manual`.

- **8 org files reclassified** (`cdd-west-africa`, `cddgg`, `china-democratic-league`, `cideci-unitierra`, `conaie`, `cppcc`, `opora`, `democracy-deutschland`): `manual:` → `dod:` for entries that were definitively bot-authored. Entries with "website loaded..." notes are left as `manual` — they read as human `review_orgs.py` sessions.
- **`hooks/activity_selector.py`**: `dod` staleness drops 730 → 365 days. An AI fetching a site (especially with web-search fallback) is less durable evidence than a human clicking through it.
- **`util/review_orgs.py`**: `dod` staleness in the source-filter list updated to match.
- **`CLAUDE.md`**: method-key docs now distinguish `manual` (human, 730 d) from `dod` (AI/bot check, 365 d).
- **`util/SOUL.md`**: `review_orgs.py` entry now says "write `activity.dod`" for AI heartbeat checks.

### 2. `util/record_dod.py` (new)

Writing `activity.dod` entries required hand-crafting YAML for each org verified — exactly the kind of friction that caused the manual/dod conflation in the first place. `record_dod.py` automates it: takes one or more slugs plus `--note`/`--url`/`--date`, writes `activity.dod` in-place via raw text substitution (same approach as `stamp.py` and `review_orgs.py`), and stamps `last_checked` in the same pass. Handles all three cases: no activity block, activity block without `dod:`, and updating an existing `dod:` entry.

### 3. `check_orgs.py --since DATE` (new flag)

Compiling the "verified this run" title list for the sync post's Landscape update paragraph required mentally tracking which slugs were stamped. `--since YYYY-MM-DD` lists orgs with `last_checked >= DATE` in reverse-chron order — run with today's date after a pass to get the title list ready to paste.

## Test plan

- [x] 8 reclassified entries verified to round-trip correctly via `python-frontmatter` parser
- [x] `hooks/activity_selector.py` and `util/review_orgs.py` staleness values consistent at 365
- [x] `record_dod.py` tested on 3 cases in isolated scratch copies: (a) no activity block → creates; (b) activity block without `dod:` → inserts, leaves other entries intact; (c) existing `dod:` → updates in place
- [x] `check_orgs.py --since 2026-06-29` correctly returns the 14 orgs verified in the last run
- [ ] CI (`mkdocs build --strict`) — mkdocs not installed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
