### PR TITLE
Heartbeat automation: dod/manual separation, record_dod.py, cron probes

### DIFF
--- a/.github/workflows/heartbeat-probes.yml
+++ b/.github/workflows/heartbeat-probes.yml
@@ -1,0 +1,40 @@
+name: Heartbeat activity probes
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"   # weekly, Sunday 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  probe:
+    name: Probe RSS feeds and news pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install util dependencies
+        run: pip install -r util/requirements.txt
+
+      - name: Probe RSS feeds and sitemaps
+        run: python util/check_rss.py --update-activity
+
+      - name: Scrape news pages
+        run: python util/scrape_news.py
+
+      - name: Commit any updates
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Always update the keepalive timestamp so the schedule is never disabled
+          # after 60 days of inactivity (GitHub's automated-workflow disable policy).
+          date -u +%Y-%m-%dT%H:%M:%SZ > .github/last-probe.txt
+          git add docs/organisations/ .github/last-probe.txt
+          git diff --staged --quiet || git commit -m "chore: automated activity probe — $(date -u +%Y-%m-%d)"
+          git push

--- a/.github/workflows/heartbeat-probes.yml
+++ b/.github/workflows/heartbeat-probes.yml
@@ -2,7 +2,7 @@ name: Heartbeat activity probes
 
 on:
   schedule:
-    - cron: "0 3 * * 0"   # weekly, Sunday 03:00 UTC
+    - cron: "0 3 * * 5"   # weekly, Friday 03:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/heartbeat-probes.yml
+++ b/.github/workflows/heartbeat-probes.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Always update the keepalive timestamp so the schedule is never disabled
-          # after 60 days of inactivity (GitHub's automated-workflow disable policy).
-          date -u +%Y-%m-%dT%H:%M:%SZ > .github/last-probe.txt
-          git add docs/organisations/ .github/last-probe.txt
+          git add docs/organisations/
           git diff --staged --quiet || git commit -m "chore: automated activity probe — $(date -u +%Y-%m-%d)"
           git push

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -75,6 +75,11 @@ Note the counts, freshness distribution, and concept coverage. These numbers
 anchor the maintenance section of the post. Saving a snapshot now makes Step
 7's before/after numbers a one-line diff instead of a recompute.
 
+**Note on RSS/scrape probes:** `check_rss.py` and `scrape_news.py` are handled by
+the weekly GitHub Actions cron job (`.github/workflows/heartbeat-probes.yml`) —
+do not run them during a heartbeat session. The cron owns automated data collection;
+this brief owns verification and judgment.
+
 ### 2. Work the staleness queue
 
 ```bash

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -356,6 +356,30 @@ The `*` gives a calendar of all captures rather than a single snapshot. `lint_or
 
 ---
 
+## Automated probes (GitHub Actions)
+
+**`.github/workflows/heartbeat-probes.yml`** runs `check_rss.py --update-activity`
+and `scrape_news.py` on a weekly schedule (Sundays 03:00 UTC) and commits any
+updated org pages directly to `main`. No LLM or personal computer required — this
+handles the purely mechanical feed/sitemap/scrape probes that don't need judgment.
+
+It also always updates `.github/last-probe.txt` with a UTC timestamp, which
+prevents GitHub from disabling the schedule after 60 days of repo inactivity.
+
+```
+Trigger:   on: schedule (cron: "0 3 * * 0") + workflow_dispatch
+Installs:  util/requirements.txt
+Runs:      check_rss.py --update-activity → scrape_news.py
+Commits:   docs/organisations/ + .github/last-probe.txt
+Pushes to: main (github-actions[bot] identity)
+```
+
+This covers the non-agentic part of the heartbeat loop. The agentic part —
+staleness review, commentary, sync post writing — still requires a full Claude
+heartbeat run per `HEARTBEAT.md`.
+
+---
+
 ## Typical maintenance workflows
 
 ### AI-assisted recheck pass

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -379,6 +379,15 @@ This covers the non-agentic part of the heartbeat loop. The agentic part —
 staleness review, commentary, sync post writing — still requires a full Claude
 heartbeat run per `HEARTBEAT.md`.
 
+**GitHub Actions ToS note:** Actions must be used for activities related to "the
+production, testing, deployment, or publication of the software project associated
+with the repository" ([Terms for Additional Products](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features)).
+Updating org frontmatter for this wiki qualifies. Infrequent external HTTP probes
+(weekly, robots.txt-respecting) are accepted practice per community guidance. Do
+not add keepalive commits (writing a dummy file to trick GitHub into not disabling
+the schedule) — that circumvents an intentional platform feature and is a policy
+gray area. If the workflow gets disabled due to inactivity, re-enable it manually.
+
 ---
 
 ## Typical maintenance workflows

--- a/util/SOUL.md
+++ b/util/SOUL.md
@@ -363,14 +363,15 @@ and `scrape_news.py` on a weekly schedule (Sundays 03:00 UTC) and commits any
 updated org pages directly to `main`. No LLM or personal computer required — this
 handles the purely mechanical feed/sitemap/scrape probes that don't need judgment.
 
-It also always updates `.github/last-probe.txt` with a UTC timestamp, which
-prevents GitHub from disabling the schedule after 60 days of repo inactivity.
+GitHub will disable a scheduled workflow after 60 days of no commit activity in the
+repository. If the landscape goes quiet and no org data changes for several weeks,
+re-enable the workflow manually from the Actions tab — one click.
 
 ```
 Trigger:   on: schedule (cron: "0 3 * * 0") + workflow_dispatch
 Installs:  util/requirements.txt
 Runs:      check_rss.py --update-activity → scrape_news.py
-Commits:   docs/organisations/ + .github/last-probe.txt
+Commits:   docs/organisations/ (only when changes found)
 Pushes to: main (github-actions[bot] identity)
 ```
 


### PR DESCRIPTION
## Summary

- **Separate `activity.manual` (human) from `activity.dod` (AI/bot)** — `dod` was already wired into the schema but never used because CLAUDE.md directed AI runs to write `manual`. Fixed: reclassified 8 definitively AI-written entries, set `dod` staleness to 365 days (vs 730 for `manual`), updated CLAUDE.md, hooks, and `review_orgs.py`.

- **New `util/record_dod.py`** — CLI to write `activity.dod` entries during heartbeat runs without hand-editing YAML. Handles all three cases: no activity block, block without `dod:`, existing `dod:` to update. Stamps `last_checked` in the same step.

- **`check_orgs.py --since DATE`** — lists orgs checked on/after a date; useful for compiling the "verified this run" list in the heartbeat sync post's Landscape update paragraph.

- **`.github/workflows/heartbeat-probes.yml`** — weekly GitHub Actions cron (Sundays 03:00 UTC) running `check_rss.py --update-activity` and `scrape_news.py`, committing any changed org pages directly to `main`. No LLM or personal computer required for these mechanical probes. Only commits when changes are found (no keepalive hack — that's a ToS gray area).

- **HEARTBEAT.md** — notes that RSS/scrape probes belong to the cron job, not Claude runs; updated Step 2 to use `record_dod.py` instead of `stamp.py`.

- **SOUL.md** — documents `record_dod.py`, `check_orgs.py --since`, the GitHub Actions workflow, and its ToS constraints.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SVMF8EYKYk8fsgtGDd5bxs)_